### PR TITLE
Joda removal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -386,11 +386,6 @@
       <version>1.10.28</version>
     </dependency>
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.8.2</version>
-    </dependency>
-    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>1.1.3</version>

--- a/src/main/java/com/conveyal/r5/analyst/broker/Broker.java
+++ b/src/main/java/com/conveyal/r5/analyst/broker/Broker.java
@@ -85,7 +85,7 @@ public class Broker implements Runnable {
     /*static {
         mapper.registerModule(AgencyAndIdSerializer.makeModule());
         mapper.registerModule(QualifiedModeSetSerializer.makeModule());
-        mapper.registerModule(JodaLocalDateSerializer.makeModule());
+        mapper.registerModule(JavaLocalDateSerializer.makeModule());
         mapper.registerModule(TraverseModeSetSerializer.makeModule());
     }*/
 

--- a/src/main/java/com/conveyal/r5/analyst/cluster/JobSimulator.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/JobSimulator.java
@@ -51,7 +51,7 @@ public class JobSimulator {
         mapper.enable(SerializationFeature.INDENT_OUTPUT);
         /*mapper.registerModule(AgencyAndIdSerializer.makeModule());
         mapper.registerModule(QualifiedModeSetSerializer.makeModule());
-        mapper.registerModule(JodaLocalDateSerializer.makeModule());
+        mapper.registerModule(JavaLocalDateSerializer.makeModule());
         mapper.registerModule(TraverseModeSetSerializer.makeModule());*/
 
         List<AnalystClusterRequest> requests = new ArrayList<>();

--- a/src/main/java/com/conveyal/r5/common/JsonUtilities.java
+++ b/src/main/java/com/conveyal/r5/common/JsonUtilities.java
@@ -1,8 +1,7 @@
 package com.conveyal.r5.common;
 
 import com.conveyal.geojson.GeoJsonModule;
-import com.conveyal.r5.model.json_serialization.BitSetSerializer;
-import com.conveyal.r5.model.json_serialization.JodaLocalDateSerializer;
+import com.conveyal.r5.model.json_serialization.JavaLocalDateSerializer;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -13,7 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class JsonUtilities {
     public static final ObjectMapper objectMapper = new ObjectMapper();
     static {
-        objectMapper.registerModule(JodaLocalDateSerializer.makeModule());
+        objectMapper.registerModule(JavaLocalDateSerializer.makeModule());
         objectMapper.registerModule(new GeoJsonModule());
         objectMapper.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
         objectMapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);

--- a/src/main/java/com/conveyal/r5/model/json_serialization/JavaLocalDateSerializer.java
+++ b/src/main/java/com/conveyal/r5/model/json_serialization/JavaLocalDateSerializer.java
@@ -20,7 +20,7 @@ public class JavaLocalDateSerializer extends JsonSerializer<LocalDate> {
         Version moduleVersion = new Version(1, 0, 0, null, null, null);
         SimpleModule module = new SimpleModule("LocalDate", moduleVersion);
         module.addSerializer(LocalDate.class, new JavaLocalDateSerializer());
-        module.addDeserializer(LocalDate.class, new JodaLocalDateDeserializer());
+        module.addDeserializer(LocalDate.class, new JavaLocalDateDeserializer());
         return module;
     }
 

--- a/src/main/java/com/conveyal/r5/model/json_serialization/JodaLocalDateDeserializer.java
+++ b/src/main/java/com/conveyal/r5/model/json_serialization/JodaLocalDateDeserializer.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
-import org.joda.time.LocalDate;
-import org.joda.time.format.ISODateTimeFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 import java.io.IOException;
 
@@ -15,6 +15,6 @@ public class JodaLocalDateDeserializer extends JsonDeserializer<LocalDate> {
     @Override public LocalDate deserialize(JsonParser jsonParser,
                                            DeserializationContext deserializationContext)
             throws IOException, JsonProcessingException {
-        return ISODateTimeFormat.date().parseLocalDate(jsonParser.getValueAsString());
+        return LocalDate.parse(jsonParser.getValueAsString(), DateTimeFormatter.ISO_LOCAL_DATE);
     }
 }

--- a/src/main/java/com/conveyal/r5/model/json_serialization/JodaLocalDateSerializer.java
+++ b/src/main/java/com/conveyal/r5/model/json_serialization/JodaLocalDateSerializer.java
@@ -6,8 +6,8 @@ import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import org.joda.time.LocalDate;
-import org.joda.time.format.ISODateTimeFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 import java.io.IOException;
 
@@ -26,6 +26,6 @@ public class JodaLocalDateSerializer extends JsonSerializer<LocalDate> {
 
     @Override public void serialize(LocalDate localDate, JsonGenerator jsonGenerator,
                                     SerializerProvider serializerProvider) throws IOException, JsonProcessingException {
-        jsonGenerator.writeString(localDate.toString(ISODateTimeFormat.date()));
+        jsonGenerator.writeString(localDate.format(DateTimeFormatter.ISO_LOCAL_DATE));
     }
 }

--- a/src/main/java/com/conveyal/r5/profile/ProfileRequest.java
+++ b/src/main/java/com/conveyal/r5/profile/ProfileRequest.java
@@ -1,7 +1,7 @@
 package com.conveyal.r5.profile;
 
 import com.conveyal.r5.analyst.scenario.Scenario;
-import org.joda.time.LocalDate;
+import java.time.LocalDate;
 
 import java.io.Serializable;
 

--- a/src/main/java/com/conveyal/r5/transit/TransitLayer.java
+++ b/src/main/java/com/conveyal/r5/transit/TransitLayer.java
@@ -20,7 +20,7 @@ import gnu.trove.map.hash.TIntIntHashMap;
 import gnu.trove.map.hash.TObjectIntHashMap;
 import com.conveyal.r5.streets.StreetLayer;
 import com.conveyal.r5.streets.StreetRouter;
-import org.joda.time.LocalDate;
+import java.time.LocalDate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -288,7 +288,7 @@ public class TransitLayer implements Serializable, Cloneable {
         BitSet activeServices = new BitSet();
         int s = 0;
         for (Service service : services) {
-            if (service.activeOn(date)) {
+            if (service.activeOn(new org.joda.time.LocalDate(date.getYear(), date.getMonthValue(), date.getDayOfMonth()))) {
                 activeServices.set(s);
             }
             s++;

--- a/src/main/java/com/conveyal/r5/transit/TransitRouter.java
+++ b/src/main/java/com/conveyal/r5/transit/TransitRouter.java
@@ -6,7 +6,8 @@ import gnu.trove.map.TIntIntMap;
 import gnu.trove.map.hash.TIntIntHashMap;
 import gnu.trove.set.TIntSet;
 import gnu.trove.set.hash.TIntHashSet;
-import org.joda.time.LocalDate;
+import java.time.LocalDate;
+import java.time.Month;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,7 +110,7 @@ public class TransitRouter {
         LOG.debug("Begin raptor routing. Initial state: {}", currentRound);
 
         // Determine which services are active to avoid exploring those that are not running on this day.
-        LocalDate searchDate = new LocalDate(2015, 8, 6);
+        LocalDate searchDate = LocalDate.of(2015, Month.AUGUST, 6);
         servicesActive = transitLayer.getActiveServicesForDate(searchDate);
         final int latestAcceptableTime = departureTime + maxTravelTimeSeconds;
 

--- a/src/test/java/com/conveyal/r5/analyst/core/LocalDateSerialization.java
+++ b/src/test/java/com/conveyal/r5/analyst/core/LocalDateSerialization.java
@@ -1,7 +1,7 @@
 package com.conveyal.r5.analyst.core;
 
 import com.conveyal.r5.common.JsonUtilities;
-import org.joda.time.LocalDate;
+import java.time.LocalDate;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/conveyal/r5/analyst/core/LocalDateSerialization.java
+++ b/src/test/java/com/conveyal/r5/analyst/core/LocalDateSerialization.java
@@ -1,0 +1,25 @@
+package com.conveyal.r5.analyst.core;
+
+import com.conveyal.r5.common.JsonUtilities;
+import org.joda.time.LocalDate;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests correct LocalDate Serialization
+ */
+public class LocalDateSerialization {
+
+    @Test
+    public void testSerializationDeserialization() throws Exception {
+        LocalDate date = LocalDate.now();
+
+        String jsonDate = JsonUtilities.objectMapper.writeValueAsString(date);
+
+        LocalDate deserializedDate = JsonUtilities.objectMapper.readValue(jsonDate, LocalDate.class);
+        assertEquals(date, deserializedDate);
+
+
+    }
+}


### PR DESCRIPTION
Removes all usage of Joda library from R5.

The only usage is in services in transitLayer to communicate with gtfs-lib more in #10.