### PR TITLE
Move wheelchair filtering into raptor algoritm

### DIFF
--- a/src/main/java/com/conveyal/r5/point_to_point/builder/PointToPointQuery.java
+++ b/src/main/java/com/conveyal/r5/point_to_point/builder/PointToPointQuery.java
@@ -281,12 +281,15 @@ public class PointToPointQuery {
                         RouteInfo routeInfo = transportNetwork.transitLayer.routes.get(pattern.routeIndex);
                         TransitModes mode = TransitLayer.getTransitModes(routeInfo.route_type);
                         if (!request.transitModes.contains(mode)) {
+                            LOG.error("Route with unwanted transit mode found!!");
                             return false;
+
                             //If trip with wheelchair is requested filters out trips where boarding/arrival stop or trip doesn't allow a wheelchair
                         } else if(request.wheelchair) {
                             if (!(transportNetwork.transitLayer.stopsWheelchair.get(pathWithTimes.boardStops[i]) &&
                                 transportNetwork.transitLayer.stopsWheelchair.get(pathWithTimes.alightStops[i]) &&
                                 pattern.tripSchedules.get(pathWithTimes.trips[i]).getFlag(TripFlag.WHEELCHAIR))) {
+                                LOG.error("Trip that doesn't allow wheelchairs found!!");
                                 return false;
                             }
                         }


### PR DESCRIPTION
So that filtering is done during the search itself instead at the end.
It skips stops and trips which don't have wheelchair support.
It also skips patterns that don't have transitModes that are requested.

Working on #109.

It seems to be working OK. Some different trips are found then when afterwards filtering is used. But it takes a little more time in raptor.

I added wheelchair checks on the same places that service checks were made. And I added one on stops.
@mattwigway: Could you please check if it is OK?

Then I'll remove afterwards filtering and it can be merged.