### PR TITLE
Fix for negative edges for edge graph

### DIFF
--- a/src/main/java/com/conveyal/r5/streets/StreetRouter.java
+++ b/src/main/java/com/conveyal/r5/streets/StreetRouter.java
@@ -228,8 +228,8 @@ public class StreetRouter {
         queue.clear();
         // from vertex is at end of back edge. Set edge correctly so that turn restrictions/costs are applied correctly
         // at the origin.
-        State startState0 = new State(split.vertex0, split.edge + 1, streetMode);
-        State startState1 = new State(split.vertex1, split.edge, streetMode);
+        State startState0 = new State(split.vertex0, -1, streetMode);
+        State startState1 = new State(split.vertex1, -1, streetMode);
         // TODO walk speed, assuming 1 m/sec currently.
         startState0.weight = split.distance0_mm / 1000;
         startState1.weight = split.distance1_mm / 1000;
@@ -261,9 +261,7 @@ public class StreetRouter {
         queue.clear();
 
         bikeStations.forEachEntry((vertexIdx, bikeStationState) -> {
-            // backEdge needs to be unique for each start state or they will wind up dominating each other.
-            // subtract 1 from -vertexIdx because -0 == 0
-            State state = new State(vertexIdx, -vertexIdx - 1, streetMode);
+            State state = new State(vertexIdx, - 1, streetMode);
             state.weight = bikeStationState.weight+switchCost;
             state.durationSeconds = bikeStationState.durationSeconds+switchTime;
             state.isBikeShare = true;


### PR DESCRIPTION
Should fix bug which appeared in
70fc77ccbe1f3136410f43e95bbafbc918555b62 and breaks P+R and bike
sharing since edges have negative ID.

It changes negative edge IDs to -1. P+R works again bike sharing doesn't (It finds very short bike part couple of meters and I have to check if this is the reason since distance was added to state in the meantime and other things)

Andrew and Matt had an idea that this could be solved that way:
>I think @mattwigway and I came to a conclusion on that question: it is algorithmically unnecessary to put these starting vertices “at a place” in the map, so they don’t need unique identifiers at all. We can just use -1 in all of them and not put them into the map.