### PR TITLE
Should fix problem with negative edges

### DIFF
--- a/src/main/java/com/conveyal/r5/api/util/StreetSegment.java
+++ b/src/main/java/com/conveyal/r5/api/util/StreetSegment.java
@@ -73,7 +73,7 @@ public class StreetSegment {
         double lastAngle = 0;
         for (StreetRouter.State state: path.getStates()) {
             int edgeIdx = state.backEdge;
-            if (edgeIdx != -1) {
+            if (edgeIdx >= 0) {
                 EdgeStore.Edge edge = path.getEdge(edgeIdx);
                 StreetEdgeInfo streetEdgeInfo = new StreetEdgeInfo();
                 streetEdgeInfo.edgeId = edgeIdx;

--- a/src/main/java/com/conveyal/r5/point_to_point/builder/PointToPointQuery.java
+++ b/src/main/java/com/conveyal/r5/point_to_point/builder/PointToPointQuery.java
@@ -58,18 +58,18 @@ public class PointToPointQuery {
 
     private static final EnumSet<LegMode> currentlyUnsupportedModes = EnumSet.of(LegMode.CAR_PARK);
 
-    /** Time to rent a bike */
-    private static final int BIKE_RENTAL_PICKUP_TIMEMS = 60*1000;
+    /** Time to rent a bike in seconds */
+    private static final int BIKE_RENTAL_PICKUP_TIME_S = 60;
     /**
      * Cost of renting a bike. The cost is a bit more than actual time to model the associated cost and trouble.
      */
     private static final int BIKE_RENTAL_PICKUP_COST = 120;
-    /** Time to drop-off a rented bike */
-    private static final int BIKE_RENTAL_DROPOFF_TIMEMS = 30*1000;
+    /** Time to drop-off a rented bike in seconds */
+    private static final int BIKE_RENTAL_DROPOFF_TIME_S = 30;
     /** Cost of dropping-off a rented bike */
     private static final int BIKE_RENTAL_DROPOFF_COST = 30;
-    /** Time to park car in P+R **/
-    private static final int CAR_PARK_DROPOFF_TIMEMS = 120*1000;
+    /** Time to park car in P+R in seconds **/
+    private static final int CAR_PARK_DROPOFF_TIME_S = 120;
 
     private static final int CAR_PARK_DROPOFF_COST = 120;
 
@@ -376,7 +376,7 @@ public class PointToPointQuery {
             walking.streetMode = StreetMode.WALK;
             walking.profileRequest = request;
             walking.distanceLimitMeters = 2_000 + streetRouter.distanceLimitMeters;
-            walking.setOrigin(carParks, CAR_PARK_DROPOFF_TIMEMS, CAR_PARK_DROPOFF_COST, LegMode.CAR_PARK);
+            walking.setOrigin(carParks, CAR_PARK_DROPOFF_TIME_S, CAR_PARK_DROPOFF_COST, LegMode.CAR_PARK);
             walking.route();
             walking.previous = streetRouter;
             return walking;
@@ -419,7 +419,7 @@ public class PointToPointQuery {
             bicycle.streetMode = StreetMode.BICYCLE;
             bicycle.profileRequest = request;
             bicycle.distanceLimitMeters = 15_000 + streetRouter.distanceLimitMeters;
-            bicycle.setOrigin(bikeStations, BIKE_RENTAL_PICKUP_TIMEMS, BIKE_RENTAL_PICKUP_COST, LegMode.BICYCLE_RENT);
+            bicycle.setOrigin(bikeStations, BIKE_RENTAL_PICKUP_TIME_S, BIKE_RENTAL_PICKUP_COST, LegMode.BICYCLE_RENT);
             bicycle.route();
             TIntObjectMap<StreetRouter.State> cycledStations = bicycle.getReachedVertices(VertexStore.VertexFlag.BIKE_SHARING);
             LOG.info("BIKE RENT: Found {} cycled stations in {}km cycled distance", cycledStations.size(), bicycle.distanceLimitMeters/1000);
@@ -439,7 +439,7 @@ public class PointToPointQuery {
             end.streetMode = StreetMode.WALK;
             end.profileRequest = request;
             end.distanceLimitMeters = 2_000 + bicycle.distanceLimitMeters;
-            end.setOrigin(cycledStations, BIKE_RENTAL_DROPOFF_TIMEMS, BIKE_RENTAL_DROPOFF_COST, LegMode.BICYCLE_RENT);
+            end.setOrigin(cycledStations, BIKE_RENTAL_DROPOFF_TIME_S, BIKE_RENTAL_DROPOFF_COST, LegMode.BICYCLE_RENT);
             end.route();
             end.previous = bicycle;
             return end;

--- a/src/main/java/com/conveyal/r5/profile/StreetPath.java
+++ b/src/main/java/com/conveyal/r5/profile/StreetPath.java
@@ -65,12 +65,14 @@ public class StreetPath {
             StreetRouter bicycle = streetRouter.previous;
             lastState = bicycle.getStateAtVertex(endCycling.vertex);
             if (lastState != null) {
+                lastState.isBikeShare = endCycling.isBikeShare;
                 //Here part from first bikeshare to the last bikeshare on rented bike is created
                 add(lastState);
                 StreetRouter first = bicycle.previous;
                 StreetRouter.State startCycling = getStates().getFirst();
                 lastState = first.getStateAtVertex(startCycling.vertex);
                 if (lastState != null) {
+                    lastState.isBikeShare = startCycling.isBikeShare;
                     add(lastState);
                 } else {
                     LOG.warn("Start to cycle path missing");

--- a/src/main/java/com/conveyal/r5/streets/EdgeStore.java
+++ b/src/main/java/com/conveyal/r5/streets/EdgeStore.java
@@ -532,7 +532,7 @@ public class EdgeStore implements Serializable {
                 });
             }
 
-            if (s0.backEdge != -1 && getFlag(EdgeFlag.LINK) && getCursor(s0.backEdge).getFlag(EdgeFlag.LINK))
+            if ((s0.backEdge >=0 ) && getFlag(EdgeFlag.LINK) && getCursor(s0.backEdge).getFlag(EdgeFlag.LINK))
                 // two link edges in a row, in other words a shortcut. Disallow this.
                 return null;
 

--- a/src/main/java/com/conveyal/r5/streets/StreetRouter.java
+++ b/src/main/java/com/conveyal/r5/streets/StreetRouter.java
@@ -586,11 +586,10 @@ public class StreetRouter {
         public State(int atVertex, int viaEdge, State backState) {
             this.vertex = atVertex;
             this.backEdge = viaEdge;
-            //This makes sure that new states don't have non-geographic states as backStates
-            //non geographic states are states with negative edges since they aren't made from vertices on graph
-            if (backState.backEdge >= 0) {
-                this.backState = backState;
-            }
+            //Note here it can happen that back state has edge with negative index
+            //This means that this state was created from vertex and can be skipped in display
+            //but it is necessary in bike sharing and P+R to combine WALK and BIKE/CAR parts+
+            this.backState = backState;
             this.distance = backState.distance;
             this.durationSeconds = backState.durationSeconds;
             this.weight = backState.weight;

--- a/src/main/java/com/conveyal/r5/streets/StreetRouter.java
+++ b/src/main/java/com/conveyal/r5/streets/StreetRouter.java
@@ -249,7 +249,7 @@ public class StreetRouter {
      * If legMode is LegMode.BICYCLE_RENT state.isBikeShare is set to true
      *
      * @param previousStates map of bikeshares/P+Rs vertexIndexes and states Return of {@link #getReachedVertices(VertexStore.VertexFlag)}}
-     * @param switchTime How many ms is added to state time (this is used when switching modes, renting bike, parking a car etc.)
+     * @param switchTime How many s is added to state time (this is used when switching modes, renting bike, parking a car etc.)
      * @param switchCost This is added to the weight and is a cost of switching modes
      * @param legMode What origin search is this bike share or P+R
      */

--- a/src/main/java/com/conveyal/r5/streets/StreetRouter.java
+++ b/src/main/java/com/conveyal/r5/streets/StreetRouter.java
@@ -582,7 +582,11 @@ public class StreetRouter {
         public State(int atVertex, int viaEdge, State backState) {
             this.vertex = atVertex;
             this.backEdge = viaEdge;
-            this.backState = backState;
+            //This makes sure that new states don't have non-geographic states as backStates
+            //non geographic states are states with negative edges since they aren't made from vertices on graph
+            if (backState.backEdge >= 0) {
+                this.backState = backState;
+            }
             this.distance = backState.distance;
             this.durationSeconds = backState.durationSeconds;
             this.weight = backState.weight;


### PR DESCRIPTION
Which appeared in 70fc77c. P+R and bike sharing is working again.

Main source of troubles was in state creation from old state. Since first state had negative backEdges  (from setOrigins etc.) next state had those state as backState and there were troubles during path construction in response. Now state creation has backState only if those backState has positive backEdge.

And inside traverse a check needed to be changed from backEdge != -1 to backEdge >= 0 because otherwise we would get exception since first state can have negative edges.

With this changes there is no more negative edges in results.

There are lines [400](https://github.com/conveyal/r5/blob/master/src/main/java/com/conveyal/r5/streets/StreetRouter.java#L400) and [411](https://github.com/conveyal/r5/blob/master/src/main/java/com/conveyal/r5/streets/StreetRouter.java#L411) in StreetRouter where states with negative edges are still saved inside bestStatesAtEdge but since they are never read from it I didn't add conditional before insertion.

@mattwigway: I think this should be the correct fix.