### PR TITLE
Saving stopTrees after building

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/StaticSiteTest.java
+++ b/src/main/java/com/conveyal/r5/analyst/StaticSiteTest.java
@@ -24,7 +24,7 @@ import java.util.zip.GZIPOutputStream;
  */
 public class StaticSiteTest {
     public static void main (String... args) throws Exception {
-        TransportNetwork tn = TransportNetwork.fromDirectory(new File("."));
+        TransportNetwork tn = TransportNetwork.fromDirectory(new File("."), true);
         // run a search from each transit stop
         int[] sum = new int[] { 0 };
         int[] count = new int[] { 0 };

--- a/src/main/java/com/conveyal/r5/labeling/LTSRelabeler.java
+++ b/src/main/java/com/conveyal/r5/labeling/LTSRelabeler.java
@@ -92,7 +92,7 @@ public class LTSRelabeler {
         File netFile = new File(args[0]);
         TransportNetwork network;
         if (netFile.isDirectory())
-            network = TransportNetwork.fromDirectory(netFile);
+            network = TransportNetwork.fromDirectory(netFile, true);
         else {
             InputStream is = new BufferedInputStream(new FileInputStream(netFile));
             network = TransportNetwork.read(is);

--- a/src/main/java/com/conveyal/r5/point_to_point/PointToPointRouterServer.java
+++ b/src/main/java/com/conveyal/r5/point_to_point/PointToPointRouterServer.java
@@ -66,7 +66,7 @@ public class PointToPointRouterServer {
                 LOG.error("'{}' is not a readable directory.", dir);
             }
 
-            TransportNetwork transportNetwork = TransportNetwork.fromDirectory(dir);
+            TransportNetwork transportNetwork = TransportNetwork.fromDirectory(dir, false);
             //In memory doesn't save it to disk others do (build, preFlight)
             if (!inMemory) {
                 try {

--- a/src/main/java/com/conveyal/r5/transit/TransitLayer.java
+++ b/src/main/java/com/conveyal/r5/transit/TransitLayer.java
@@ -109,7 +109,7 @@ public class TransitLayer implements Serializable, Cloneable {
      * buildStopTrees in TransportNetwork. That does make serialized networks much bigger (not a big deal when saving
      * to S3) and makes our checks to ensure that scenario application does not damage base graphs very slow.
      */
-    public transient List<TIntIntMap> stopTrees;
+    public List<TIntIntMap> stopTrees;
 
     /**
      * The TransportNetwork containing this TransitLayer. This link up the object tree also allows us to access the

--- a/src/main/java/com/conveyal/r5/transit/TransportNetworkCache.java
+++ b/src/main/java/com/conveyal/r5/transit/TransportNetworkCache.java
@@ -286,7 +286,7 @@ public class TransportNetworkCache {
         // Now we have a local copy of these graph inputs. Make a graph out of them.
         TransportNetwork network;
         try {
-            network = TransportNetwork.fromDirectory(new File(cacheDir, networkId));
+            network = TransportNetwork.fromDirectory(new File(cacheDir, networkId), true);
         } catch (DuplicateFeedException e) {
             LOG.error("Duplicate feeds in transport network {}", networkId, e);
             throw new RuntimeException(e);

--- a/src/test/java/com/conveyal/r5/analyst/scenario/FakeGraph.java
+++ b/src/test/java/com/conveyal/r5/analyst/scenario/FakeGraph.java
@@ -64,7 +64,8 @@ public class FakeGraph {
                 gtfsFiles.add(gtfsFile.getAbsolutePath());
             }
 
-            TransportNetwork net = TransportNetwork.fromFiles(osmFile.getAbsolutePath(), gtfsFiles, new TNBuilderConfig());
+            TransportNetwork net = TransportNetwork.fromFiles(osmFile.getAbsolutePath(), gtfsFiles, new TNBuilderConfig(),
+                true);
 
             // clean up
             filesToDelete.forEach(f -> f.delete());


### PR DESCRIPTION
This change save stopTrees after building so that they aren't rebuild everything graph is opened. Stoptrees also aren't build in point to point routing since they aren't needed there.
