### PR TITLE
Refactor transitive network construction

### DIFF
--- a/src/main/java/com/conveyal/r5/publish/StaticMetadata.java
+++ b/src/main/java/com/conveyal/r5/publish/StaticMetadata.java
@@ -69,7 +69,7 @@ public class StaticMetadata implements Runnable {
     }
 
     public void writeTransitiveData(OutputStream os) throws IOException {
-        TransitiveNetwork net = new TransitiveNetwork(network.transitLayer, network.streetLayer);
+        TransitiveNetwork net = new TransitiveNetwork(network.transitLayer);
         JsonUtilities.objectMapper.writeValue(os, net);
     }
 
@@ -83,7 +83,7 @@ public class StaticMetadata implements Runnable {
         metadata.width = ps.width;
         metadata.height = ps.height;
         metadata.transportNetwork = request.transportNetworkId;
-        metadata.transitiveData = new TransitiveNetwork(network.transitLayer, network.streetLayer);
+        metadata.transitiveData = new TransitiveNetwork(network.transitLayer);
         metadata.request = request.request;
 
         JsonUtilities.objectMapper.writeValue(out, metadata);

--- a/src/main/java/com/conveyal/r5/publish/StaticServer.java
+++ b/src/main/java/com/conveyal/r5/publish/StaticServer.java
@@ -48,7 +48,7 @@ public class StaticServer {
         sm.writeStopTrees(sbaos);
         stopTrees = sbaos.toByteArray();
 
-        TransitiveNetwork tn = new TransitiveNetwork(network.transitLayer, network.streetLayer);
+        TransitiveNetwork tn = new TransitiveNetwork(network.transitLayer);
         ByteArrayOutputStream tnbaos = new ByteArrayOutputStream();
         JsonUtilities.objectMapper.writeValue(tnbaos, tn);
         transitive = tnbaos.toByteArray();

--- a/src/main/java/com/conveyal/r5/transit/TripPattern.java
+++ b/src/main/java/com/conveyal/r5/transit/TripPattern.java
@@ -219,6 +219,9 @@ public class TripPattern implements Serializable, Cloneable {
                 previousCoordinate = currentCoordinate;
             }
         }
+        if (geometries.size() != stops.length - 1) {
+            throw new AssertionError("This function should always generate one less geometry than there are stops.");
+        }
         return geometries;
     }
 

--- a/src/main/java/com/conveyal/r5/transit/TripPattern.java
+++ b/src/main/java/com/conveyal/r5/transit/TripPattern.java
@@ -56,7 +56,10 @@ public class TripPattern implements Serializable, Cloneable {
     // This set includes the numeric codes for all services on which at least one trip in this pattern is active.
     public BitSet servicesActive = new BitSet();
 
-    /** index of this route in TransitLayer data. -1 if detailed route information has not been loaded */
+    /**
+     * index of this route in TransitLayer data. -1 if detailed route information has not been loaded
+     * TODO clarify what "this route" means. The route of this tripPattern?
+     */
     public int routeIndex = -1;
 
     /**

--- a/src/main/java/com/conveyal/r5/transit/TripPattern.java
+++ b/src/main/java/com/conveyal/r5/transit/TripPattern.java
@@ -2,8 +2,12 @@ package com.conveyal.r5.transit;
 
 import com.conveyal.gtfs.model.Shape;
 import com.conveyal.gtfs.model.StopTime;
+import com.conveyal.r5.common.GeometryUtils;
+import com.conveyal.r5.streets.VertexStore;
+import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.LineString;
 import com.vividsolutions.jts.linearref.LinearLocation;
+import com.vividsolutions.jts.linearref.LocationIndexedLine;
 import gnu.trove.list.TIntList;
 import gnu.trove.map.TObjectIntMap;
 import org.slf4j.Logger;
@@ -177,6 +181,45 @@ public class TripPattern implements Serializable, Cloneable {
      */
     public boolean containsNoTrips(Set<String> tripIds) {
         return this.tripSchedules.stream().noneMatch(ts -> tripIds.contains(ts.tripId));
+    }
+
+    /**
+     * @param transitLayer to allow lookup of stop locations when the tripPattern has no shape.
+     * @return one geometry for the path the vehicle takes after each stop, except the last one.
+     */
+    public List<LineString> getHopGeometries(TransitLayer transitLayer) {
+        List<LineString> geometries = new ArrayList<>();
+        if (shape != null) {
+            // This pattern has a shape. Using the segment indexes and segment fractions that were recorded for each
+            // stop when the R5 network was built, split that shape up into segments between each pair of stops.
+            LocationIndexedLine unprojectedLine = new LocationIndexedLine(shape);
+            for (int stopPos = 0; stopPos < stops.length - 1; stopPos++) {
+                LinearLocation fromLocation =
+                        new LinearLocation(stopShapeSegment[stopPos], stopShapeFraction[stopPos]);
+                LinearLocation toLocation =
+                        new LinearLocation(stopShapeSegment[stopPos + 1], stopShapeFraction[stopPos + 1]);
+                geometries.add((LineString)unprojectedLine.extractLine(fromLocation, toLocation));
+            }
+        } else {
+            // This pattern does not have a shape, but Transitive expects geometries. Use straight lines between stops.
+            Coordinate previousCoordinate = null;
+            VertexStore.Vertex v = transitLayer.parentNetwork.streetLayer.vertexStore.getCursor();
+            for (int stopIndex : stops) {
+                int vertexIndex = transitLayer.streetVertexForStop.get(stopIndex);
+                // Unlinked stops don't have coordinates. See comment in stop conversion method.
+                // A better stopgap might be to reuse the previous coordinate.
+                // TODO We should really just make sure we have coordinates for all stops, then pass the stops list into getStopRefs.
+                if (vertexIndex < 0) vertexIndex = 0;
+                v.seek(vertexIndex);
+                Coordinate currentCoordinate = new Coordinate(v.getLon(), v.getLat());
+                if (previousCoordinate != null) {
+                    geometries.add(GeometryUtils.geometryFactory.createLineString(
+                            new Coordinate[] { previousCoordinate, currentCoordinate }));
+                }
+                previousCoordinate = currentCoordinate;
+            }
+        }
+        return geometries;
     }
 
 }

--- a/src/main/java/com/conveyal/r5/transitive/TransitiveNetwork.java
+++ b/src/main/java/com/conveyal/r5/transitive/TransitiveNetwork.java
@@ -77,23 +77,16 @@ public class TransitiveNetwork {
 
         // Convert R5 stops to Transitive stops.
         for (int sidx = 0; sidx < layer.getStopCount(); sidx++) {
-            TransitiveStop ts = new TransitiveStop();
             int vidx = layer.streetVertexForStop.get(sidx);
-
+            // Transitive requires coordinates for every stop,
+            // but currently R5 is not saving coordinates for unlinked stops.
+            // see https://github.com/conveyal/r5/issues/33
+            // As a stopgap, for unlinked stops use the location of the 0th stop.
+            v.seek(vidx < 0 ? 0 : vidx);
+            TransitiveStop ts = new TransitiveStop();
+            ts.stop_lat = v.getLat();
+            ts.stop_lon = v.getLon();
             ts.stop_id = sidx + "";
-
-            if (vidx != -1) {
-                v.seek(vidx);
-                ts.stop_lat = v.getLat();
-                ts.stop_lon = v.getLon();
-            } else {
-                // TODO this should actually know where unlinked stop are
-                // see issue 33
-                // at least put the stop in the map somewhere
-                v.seek(0);
-                ts.stop_lat = v.getLat();
-                ts.stop_lon = v.getLon();
-            }
             ts.stop_name = layer.stopNames.get(sidx);
             stops.add(ts);
         }


### PR DESCRIPTION
I suspected the problem with zoomed-in transitive rendering in TAUI was bad geometries where shapes aren't present, as in Marseille. I did a bunch of refactoring to break the TransitiveNetwork down into functional units, and eventually noticed that we were using stop IDs as vertex IDs without the intermediate lookup.

Although the rendering is much better than it was (not jumping around to random street vertices) for some reason the results are still bizarre. The weirdness seems more common and visible on inter-city trains. Things render properly in schematic mode but the destination station seems to be shifted one stop early (while retaining the true destination stop's name) in geo-accurate mode. It seems plausible that I've introduced some off-by-one error when generating the geometries but I don't see it.