### PR TITLE
Buffer implied pointsets, and allow sub-pointsets to be uncontained b…

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/WebMercatorGridPointSet.java
+++ b/src/main/java/com/conveyal/r5/analyst/WebMercatorGridPointSet.java
@@ -55,9 +55,9 @@ public class WebMercatorGridPointSet extends PointSet implements Serializable {
 
         this.zoom = DEFAULT_ZOOM;
 
-        double latBuffer = SphericalDistanceLibrary.metersToDegreesLatitude(TransitLayer.DISTANCE_TABLE_SIZE_METERS);
+        double latBuffer = SphericalDistanceLibrary.metersToDegreesLatitude(LinkedPointSet.MAX_OFFSTREET_WALK_METERS);
         double lonBuffer = SphericalDistanceLibrary
-                .metersToDegreesLongitude(TransitLayer.DISTANCE_TABLE_SIZE_METERS, transportNetwork.streetLayer.envelope.centre().y);
+                .metersToDegreesLongitude(LinkedPointSet.MAX_OFFSTREET_WALK_METERS, transportNetwork.streetLayer.envelope.centre().y);
 
         int west = lonToPixel(transportNetwork.streetLayer.envelope.getMinX() - lonBuffer);
         int east = lonToPixel(transportNetwork.streetLayer.envelope.getMaxX() + lonBuffer);

--- a/src/main/java/com/conveyal/r5/analyst/WebMercatorGridPointSet.java
+++ b/src/main/java/com/conveyal/r5/analyst/WebMercatorGridPointSet.java
@@ -1,10 +1,14 @@
 package com.conveyal.r5.analyst;
 
+import com.conveyal.r5.common.SphericalDistanceLibrary;
 import com.conveyal.r5.profile.StreetMode;
 import com.conveyal.r5.streets.LinkedPointSet;
+import com.conveyal.r5.streets.Split;
 import com.conveyal.r5.streets.StreetLayer;
+import com.conveyal.r5.transit.TransitLayer;
 import com.conveyal.r5.transit.TransportNetwork;
 import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Envelope;
 import org.mapdb.Fun;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,10 +54,15 @@ public class WebMercatorGridPointSet extends PointSet implements Serializable {
         LOG.info("Creating web mercator pointset for transport network with extents {}", transportNetwork.streetLayer.envelope);
 
         this.zoom = DEFAULT_ZOOM;
-        int west = lonToPixel(transportNetwork.streetLayer.envelope.getMinX());
-        int east = lonToPixel(transportNetwork.streetLayer.envelope.getMaxX());
-        int north = latToPixel(transportNetwork.streetLayer.envelope.getMaxY());
-        int south = latToPixel(transportNetwork.streetLayer.envelope.getMinY());
+
+        double latBuffer = SphericalDistanceLibrary.metersToDegreesLatitude(TransitLayer.DISTANCE_TABLE_SIZE_METERS);
+        double lonBuffer = SphericalDistanceLibrary
+                .metersToDegreesLongitude(TransitLayer.DISTANCE_TABLE_SIZE_METERS, transportNetwork.streetLayer.envelope.centre().y);
+
+        int west = lonToPixel(transportNetwork.streetLayer.envelope.getMinX() - lonBuffer);
+        int east = lonToPixel(transportNetwork.streetLayer.envelope.getMaxX() + lonBuffer);
+        int north = latToPixel(transportNetwork.streetLayer.envelope.getMaxY() + latBuffer);
+        int south = latToPixel(transportNetwork.streetLayer.envelope.getMinY() - latBuffer);
 
         this.west = west;
         this.north = north;


### PR DESCRIPTION
This does two things:

1) Buffers the implied WebMercatorGridPointset so that it expands beyond the street network extent (#224). I used the max offstreet walk distance rather than the distance table size, because if points are further than that from the extent of the street network they are perforce unusable.
2) Allows sub linked pointsets to not completely overlap the superpointset. Currently generating Browsochrones data near the edge of the graph fails because the sub point set created around the origin to report non-transit times have points outside the implied pointset. This way those points outside the graph pointset are simply left unlinked. The reason this is a problem now and not in the past is that we recently made a change to simply subset the implied linked pointset, rather than generating a new linked pointset, when computing the non-transit times. Thus, we won't see walk paths to areas outside the extent of the implied pointset anymore, but this seems like a small loss - not linking a new, small grid pointset was a performance win.