### PR TITLE
handle high priority browsochrones requests via side channels.

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalystClusterRequest.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalystClusterRequest.java
@@ -67,4 +67,9 @@ public class AnalystClusterRequest extends GenericClusterRequest implements Seri
         return profileRequest;
     }
 
+    @Override
+    public boolean isHighPriority() {
+        return outputLocation == null; // return results directly to client over HTTP
+    }
+
 }

--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
@@ -300,7 +300,7 @@ public class AnalystWorker implements Runnable {
 
             // Enqueue high-priority (interactive) tasks first to ensure they are enqueued
             // even if the low-priority batch queue blocks.
-            tasks.stream().filter(t -> t instanceof AnalystClusterRequest && ((AnalystClusterRequest) t).outputLocation == null)
+            tasks.stream().filter(AnalystWorker::isHighPriorityTask)
                     .forEach(t -> highPriorityExecutor.execute(() -> {
                         LOG.warn("Handling single point request via normal channel, side channel should open shortly.");
                         this.handleOneRequest(t);
@@ -308,7 +308,7 @@ public class AnalystWorker implements Runnable {
 
             // Enqueue low-priority (batch) tasks; note that this may block anywhere in the process
             logQueueStatus();
-            tasks.stream().filter(t -> !(t instanceof AnalystClusterRequest) || ((AnalystClusterRequest) t).outputLocation != null)
+            tasks.stream().filter(t -> !isHighPriorityTask(t))
                 .forEach(t -> {
                     // attempt to enqueue, waiting if the queue is full
                     while (true) {
@@ -335,6 +335,12 @@ public class AnalystWorker implements Runnable {
      * It may be called several times simultaneously on different executor threads.
      */
     private void handleOneRequest(GenericClusterRequest clusterRequest) {
+        if (isHighPriorityTask(clusterRequest)) {
+            lastHighPriorityRequestProcessed = System.currentTimeMillis();
+            if (!sideChannelOpen) {
+                openSideChannel();
+            }
+        }
 
         if (dryRunFailureRate >= 0) {
             // This worker is running in test mode.
@@ -425,7 +431,6 @@ public class AnalystWorker implements Runnable {
         if (request.request.bucket != null) computer.run();
         else {
             // if bucket is null, return results directly to consumer (high-priority request)
-            lastHighPriorityRequestProcessed = System.currentTimeMillis();
             try {
                 PipedInputStream pis = new PipedInputStream();
                 PipedOutputStream pos = new PipedOutputStream(pis);
@@ -460,7 +465,6 @@ public class AnalystWorker implements Runnable {
             deleteRequest(request);
         } else {
             // if bucket is null, return results directly to consumer (high-priority request)
-            lastHighPriorityRequestProcessed = System.currentTimeMillis();
             try {
                 PipedInputStream pis = new PipedInputStream();
                 PipedOutputStream pos = new PipedOutputStream(pis);
@@ -492,7 +496,6 @@ public class AnalystWorker implements Runnable {
             deleteRequest(request);
         } else {
             // if bucket is null, return results directly to consumer (high-priority request)
-            lastHighPriorityRequestProcessed = System.currentTimeMillis();
             try {
                 PipedInputStream pis = new PipedInputStream();
                 PipedOutputStream pos = new PipedOutputStream(pis);
@@ -530,13 +533,6 @@ public class AnalystWorker implements Runnable {
         // or a job task (where the result is saved to output location on S3).
         boolean isochrone = (clusterRequest.destinationPointsetId == null);
         boolean singlePoint = (clusterRequest.outputLocation == null);
-
-        if (singlePoint) {
-            lastHighPriorityRequestProcessed = startTime;
-            if (!sideChannelOpen) {
-                openSideChannel();
-            }
-        }
 
         ts.lon = clusterRequest.profileRequest.fromLon;
         ts.lat = clusterRequest.profileRequest.fromLat;
@@ -823,6 +819,20 @@ public class AnalystWorker implements Runnable {
     /** log queue status */
     private void logQueueStatus() {
         LOG.debug("Waiting tasks: high priority: {}, batch: {}", highPriorityExecutor.getQueue().size(), batchExecutor.getQueue().size());
+    }
+
+    public static boolean isHighPriorityTask (GenericClusterRequest req) {
+        if (req instanceof StaticMetadata.MetadataRequest) {
+            return ((StaticMetadata.MetadataRequest) req).request.bucket == null;
+        } else if (req instanceof StaticMetadata.StopTreeRequest) {
+            return ((StaticMetadata.StopTreeRequest) req).request.bucket == null;
+        } else if (req instanceof StaticSiteRequest.PointRequest) {
+            return ((StaticSiteRequest.PointRequest) req).request.bucket == null;
+        } else if (req instanceof AnalystClusterRequest){
+            return ((AnalystClusterRequest) req).outputLocation == null;
+        } else {
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/com/conveyal/r5/analyst/cluster/GenericClusterRequest.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/GenericClusterRequest.java
@@ -54,4 +54,10 @@ public abstract class GenericClusterRequest implements Serializable {
      */
     public abstract ProfileRequest extractProfileRequest();
 
+    /**
+     * Should be overridden by subclasses to determine whether they are high priority or not.
+     */
+    @JsonIgnore
+    public abstract boolean isHighPriority();
+
 }

--- a/src/main/java/com/conveyal/r5/analyst/cluster/GridRequest.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/GridRequest.java
@@ -39,4 +39,8 @@ public class GridRequest extends GenericClusterRequest {
         return request;
     }
 
+    @Override
+    public boolean isHighPriority() {
+        return false; // grid requests only used in regional analysis, never high priority
+    }
 }

--- a/src/main/java/com/conveyal/r5/analyst/cluster/GridResultConsumer.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/GridResultConsumer.java
@@ -62,8 +62,8 @@ public class GridResultConsumer implements Runnable {
 
                             if (!assemblers.containsKey(jobId)) {
                                 // TODO is this the right thing to do?
-                                LOG.warn("Received message for invalid job ID {}, returning to queue", jobId);
-                                return null;
+                                LOG.warn("Received message for invalid job ID {}, silently discarding", jobId);
+                                return new DeleteMessageBatchRequestEntry(m.getMessageId(), m.getReceiptHandle());
                             }
 
                             assemblers.get(jobId).handleMessage(m);

--- a/src/main/java/com/conveyal/r5/publish/StaticComputer.java
+++ b/src/main/java/com/conveyal/r5/publish/StaticComputer.java
@@ -152,6 +152,7 @@ public class StaticComputer implements Runnable {
                 out.writeInt(time - prev);
                 prev = time;
 
+
                 if (worker.saveAllStates) {
                     RaptorState state = worker.statesEachIteration.get(stateIteration);
                     int inVehicleTravelTime = state.inVehicleTravelTime[stop] / 60;

--- a/src/main/java/com/conveyal/r5/publish/StaticMetadata.java
+++ b/src/main/java/com/conveyal/r5/publish/StaticMetadata.java
@@ -111,6 +111,7 @@ public class StaticMetadata implements Runnable {
         for (int[] table : lps.stopToPointDistanceTables) {
             // make sure stop always gets incremented
             stop++;
+
             if (table == null) {
                 continue;
             }
@@ -194,6 +195,11 @@ public class StaticMetadata implements Runnable {
         public ProfileRequest extractProfileRequest() {
             return request.request;
         }
+
+        @Override
+        public boolean isHighPriority() {
+            return request.bucket == null; // null bucket, results will be returned over HTTP
+        }
     }
 
     /** A request for the cluster to produce static stop trees */
@@ -203,6 +209,11 @@ public class StaticMetadata implements Runnable {
         @Override
         public ProfileRequest extractProfileRequest() {
             return request.request;
+        }
+
+        @Override
+        public boolean isHighPriority() {
+            return request.bucket == null; // null bucket, results will be returned over HTTP
         }
     }
 }

--- a/src/main/java/com/conveyal/r5/publish/StaticSiteRequest.java
+++ b/src/main/java/com/conveyal/r5/publish/StaticSiteRequest.java
@@ -61,5 +61,10 @@ public class StaticSiteRequest {
             return request.request;
         }
 
+        @Override
+        public boolean isHighPriority() {
+            return request.bucket == null; // null bucket means will be returned directly over HTTP
+        }
+
     }
 }

--- a/src/main/java/com/conveyal/r5/streets/Split.java
+++ b/src/main/java/com/conveyal/r5/streets/Split.java
@@ -118,6 +118,8 @@ public class Split {
             return null;
         }
 
+        LOG.info("Linked point to edge {}", best.edge);
+
         // We found an edge. Iterate over its segments again, accumulating distances along its geometry.
         // The distance calculations involve square roots so are deferred to happen here, only on the selected edge.
         // TODO accumulate before/after geoms. Split point can be passed over since it's not an intermediate.

--- a/src/main/java/com/conveyal/r5/streets/Split.java
+++ b/src/main/java/com/conveyal/r5/streets/Split.java
@@ -118,8 +118,6 @@ public class Split {
             return null;
         }
 
-        LOG.info("Linked point to edge {}", best.edge);
-
         // We found an edge. Iterate over its segments again, accumulating distances along its geometry.
         // The distance calculations involve square roots so are deferred to happen here, only on the selected edge.
         // TODO accumulate before/after geoms. Split point can be passed over since it's not an intermediate.


### PR DESCRIPTION
Previously the side channel would only open for old-style analyst requests, meaning that single point jobs would not complete when a regional job was running on the same graph. This fixes that and also cleans up the auto-shutdown code.