### PR TITLE
Fix modeify time estimates by recomputing statistics using all patter…

### DIFF
--- a/src/main/java/com/conveyal/r5/R5Main.java
+++ b/src/main/java/com/conveyal/r5/R5Main.java
@@ -17,6 +17,13 @@ import java.util.Arrays;
  */
 public class R5Main {
     public static void main (String... args) throws Exception {
+        System.out.println("__________________\n" +
+                "___  __ \\__  ____/\n" +
+                "__  /_/ /_____ \\  \n" +
+                "_  _, _/ ____/ /  \n" +
+                "/_/ |_| /_____/   \n" +
+                "                ");
+
         // Pull argument 0 off as the sub-command,
         // then pass the remaining args (1..n) on to that subcommand.
         String command = args[0];

--- a/src/main/java/com/conveyal/r5/api/ProfileResponse.java
+++ b/src/main/java/com/conveyal/r5/api/ProfileResponse.java
@@ -200,4 +200,9 @@ public class ProfileResponse {
             }
         }
     }
+
+    /** Recompute stats for all options, should be done once all options have been added */
+    public void recomputeStats (ProfileRequest request) {
+        this.options.forEach(o -> o.recomputeStats(request));
+    }
 }

--- a/src/main/java/com/conveyal/r5/api/util/ProfileOption.java
+++ b/src/main/java/com/conveyal/r5/api/util/ProfileOption.java
@@ -306,8 +306,8 @@ public class ProfileOption {
                         req,
                         // TODO is this intended to handle multiple access modes to the same stop?
                         // do these ever have more or less than one value?
-                        accessIndexes.values().stream().findFirst().orElse(null),
-                        egressIndexes.values().stream().findFirst().orElse(null),
+                        access.get(0).duration,
+                        egress.get(0).duration,
                         transit.size(),
                         fullItineraries);
 

--- a/src/main/java/com/conveyal/r5/api/util/ProfileOption.java
+++ b/src/main/java/com/conveyal/r5/api/util/ProfileOption.java
@@ -1,6 +1,9 @@
 package com.conveyal.r5.api.util;
 
+import com.conveyal.r5.profile.Path;
 import com.conveyal.r5.profile.PathWithTimes;
+import com.conveyal.r5.profile.ProfileRequest;
+import com.conveyal.r5.profile.StatsCalculator;
 import com.conveyal.r5.transit.TransitLayer;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
@@ -8,6 +11,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.*;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalField;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -33,6 +38,18 @@ public class ProfileOption {
 
     private transient Map<ModeStopIndex, Integer> accessIndexes = new HashMap<>();
     private transient Map<ModeStopIndex, Integer> egressIndexes = new HashMap<>();
+
+    /**
+     * contains full itineraries needed to compute statistics. We don't present these to the client though.
+     *
+     * There is no way to compute the statistics by combining the statistics of constituent paths. Suppose there
+     * are two patterns each running every 15 minutes; we don't know if they are coming in and out of phase.
+     * Ergo, we save all itineraries so we can compute fresh stats when we're done.
+     *
+     * Since all transit paths here will have the same start and end stops, we can save all itineraries individually,
+     * we don't need to save their start and end stops as well.
+     */
+    private transient List<PathWithTimes.Itinerary> fullItineraries = new ArrayList<>();
 
     @Override public String toString() {
         return "ProfileOption{" +
@@ -154,6 +171,7 @@ public class ProfileOption {
             }
         }
 
+        fullItineraries.addAll(currentTransitPath.itineraries);
     }
 
     /**
@@ -278,6 +296,27 @@ public class ProfileOption {
             // which is easier if everything is at one place
             currentItinerary.addWalkTime(streetSegment.duration);
             currentItinerary.distance += streetSegment.distance;
+        }
+    }
+
+    /** recompute wait and ride stats for all transit itineraries, should be done once all transit paths are added */
+    public void recomputeStats (ProfileRequest req) {
+        StatsCalculator.StatsCollection collection =
+                StatsCalculator.computeStatistics(
+                        req,
+                        // TODO is this intended to handle multiple access modes to the same stop?
+                        // do these ever have more or less than one value?
+                        accessIndexes.values().stream().findFirst().orElse(null),
+                        egressIndexes.values().stream().findFirst().orElse(null),
+                        transit.size(),
+                        fullItineraries);
+
+        this.stats = collection.stats;
+
+        for (int leg = 0; leg < transit.size(); leg++) {
+            TransitSegment segment = transit.get(leg);
+            segment.rideStats = collection.rideStats[leg];
+            segment.waitStats = collection.waitStats[leg];
         }
     }
 

--- a/src/main/java/com/conveyal/r5/api/util/ProfileOption.java
+++ b/src/main/java/com/conveyal/r5/api/util/ProfileOption.java
@@ -301,22 +301,24 @@ public class ProfileOption {
 
     /** recompute wait and ride stats for all transit itineraries, should be done once all transit paths are added */
     public void recomputeStats (ProfileRequest req) {
-        StatsCalculator.StatsCollection collection =
-                StatsCalculator.computeStatistics(
-                        req,
-                        // TODO is this intended to handle multiple access modes to the same stop?
-                        // do these ever have more or less than one value?
-                        access.get(0).duration,
-                        egress.get(0).duration,
-                        transit.size(),
-                        fullItineraries);
+        if (!fullItineraries.isEmpty()) {
+            StatsCalculator.StatsCollection collection =
+                    StatsCalculator.computeStatistics(
+                            req,
+                            // TODO is this intended to handle multiple access modes to the same stop?
+                            // do these ever have more or less than one value?
+                            access.get(itinerary.get(0).connection.access).duration,
+                            egress.get(itinerary.get(0).connection.egress).duration,
+                            transit.size(),
+                            fullItineraries);
 
-        this.stats = collection.stats;
+            this.stats = collection.stats;
 
-        for (int leg = 0; leg < transit.size(); leg++) {
-            TransitSegment segment = transit.get(leg);
-            segment.rideStats = collection.rideStats[leg];
-            segment.waitStats = collection.waitStats[leg];
+            for (int leg = 0; leg < transit.size(); leg++) {
+                TransitSegment segment = transit.get(leg);
+                segment.rideStats = collection.rideStats[leg];
+                segment.waitStats = collection.waitStats[leg];
+            }
         }
     }
 

--- a/src/main/java/com/conveyal/r5/point_to_point/builder/PointToPointQuery.java
+++ b/src/main/java/com/conveyal/r5/point_to_point/builder/PointToPointQuery.java
@@ -185,6 +185,8 @@ public class PointToPointQuery {
             profileResponse.generateStreetTransfers(transportNetwork, request);
         }
 
+        profileResponse.recomputeStats(request);
+
         LOG.info("Returned {} options", profileResponse.getOptions().size());
         LOG.info("Took {} ms", System.currentTimeMillis() - startRouting);
 

--- a/src/main/java/com/conveyal/r5/profile/StatsCalculator.java
+++ b/src/main/java/com/conveyal/r5/profile/StatsCalculator.java
@@ -1,0 +1,97 @@
+package com.conveyal.r5.profile;
+
+import com.conveyal.r5.api.util.Itinerary;
+import com.conveyal.r5.api.util.Stats;
+
+import java.util.Collection;
+import java.util.stream.IntStream;
+
+/**
+ * Created by matthewc on 4/4/17.
+ */
+public class StatsCalculator {
+    /**
+     * Compute statistics for this particular path over the time window. This is super simple,
+     * we just compute how long the path takes at every possible departure minute. There's probably an
+     * elegant theoretical way to do this, but I prefer pragmatism over theory.
+     */
+    public static StatsCollection computeStatistics (ProfileRequest req, int accessTime, int egressTime,
+                                          int nSegments, Collection<PathWithTimes.Itinerary> itineraries) {
+        Stats stats = new Stats();
+        Stats[] rideStats = IntStream.range(0, nSegments).mapToObj(i -> new Stats()).toArray(Stats[]::new);
+        Stats[] waitStats = IntStream.range(0, nSegments).mapToObj(i -> new Stats()).toArray(Stats[]::new);
+
+        for (int start = req.fromTime; start < req.toTime; start += 60) {
+            // TODO should board slack be applied at the origin stop? Is this done in RaptorWorker?
+            int timeAtOriginStop = start + accessTime + RaptorWorker.BOARD_SLACK_SECONDS;
+            int bestTimeAtDestinationStop = Integer.MAX_VALUE;
+
+            PathWithTimes.Itinerary bestItinerary = null;
+            for (PathWithTimes.Itinerary itin : itineraries) {
+                // itinerary cannot be used at this time
+                if (itin.boardTimes[0] < timeAtOriginStop) continue;
+
+                if (itin.alightTimes[nSegments - 1] < bestTimeAtDestinationStop) {
+                    bestTimeAtDestinationStop = itin.alightTimes[nSegments - 1];
+                    bestItinerary = itin;
+                }
+            }
+
+            if (bestItinerary == null) continue; // cannot use this trip at this time
+
+            int bestTimeAtDestination = bestTimeAtDestinationStop + egressTime;
+
+            int travelTime = bestTimeAtDestination - start;
+
+            stats.num++;
+            stats.avg += travelTime;
+            stats.min = Math.min(stats.min, travelTime);
+            stats.max = Math.max(stats.max, travelTime);
+
+            // accumulate stats for each leg
+            for (int leg = 0; leg < nSegments; leg++) {
+                Stats ride = rideStats[leg];
+                int rideLen = bestItinerary.alightTimes[leg] - bestItinerary.boardTimes[leg];
+                ride.num++;
+                ride.avg += rideLen;
+                ride.min = Math.min(ride.min, rideLen);
+                ride.max = Math.max(ride.max, rideLen);
+
+                Stats wait = waitStats[leg];
+
+                int arriveAtStopTime = leg == 0 ? timeAtOriginStop : bestItinerary.arriveAtBoardStopTimes[leg];
+
+                int waitTime = bestItinerary.boardTimes[leg] - arriveAtStopTime;
+
+                wait.num++;
+                wait.avg += waitTime;
+                wait.min = Math.min(waitTime, wait.min);
+                wait.max = Math.max(waitTime, wait.max);
+            }
+        }
+
+        if (stats.num == 0) throw new IllegalStateException("No valid itineraries found for path computed in RaptorWorker");
+
+        stats.avg /= stats.num;
+
+        for (Stats[] statSet : new Stats[][] { rideStats, waitStats }) {
+            for (Stats s : statSet) {
+                s.avg /= s.num;
+            }
+        }
+
+        return new StatsCollection(stats, waitStats, rideStats);
+    }
+
+    public static class StatsCollection {
+        public Stats stats;
+        public Stats[] waitStats;
+        public Stats[] rideStats;
+
+        public StatsCollection (Stats stats, Stats[] waitStats, Stats[] rideStats) {
+            this.stats = stats;
+            this.rideStats = rideStats;
+            this.waitStats = waitStats;
+        }
+    }
+}

--- a/src/main/java/com/conveyal/r5/util/P2.java
+++ b/src/main/java/com/conveyal/r5/util/P2.java
@@ -6,18 +6,38 @@ import javafx.util.Pair;
 /**
  * Tuple of two elements with same type
  */
-public class P2<E> extends Pair<E,E> {
+public class P2<E> {
+    public final E a;
+
+    public final E b;
+
     /**
      * Creates a new pair
      *
-     * @param key   The key for this pair
-     * @param value The value to use for this pair
+     * @param b   The key for this pair
+     * @param b The value to use for this pair
      */
     public P2(
-        @NamedArg("key")
-        E key,
-        @NamedArg("value")
-        E value) {
-        super(key, value);
+        E a,
+        E b) {
+        this.a = a;
+        this.b = b;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("P2<%s %s>", a, b);
+    }
+
+    @Override
+    public int hashCode() {
+        return (a != null ? a.hashCode() : 0) +
+                (b != null ? b.hashCode() * 31 : 0);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (a == null || b == null) return a == b;
+        else return a.equals(b);
     }
 }


### PR DESCRIPTION
…ns in an option, fixes #260.

@buma as far as I can tell it was just using the stats from the first transit path encountered which led to some weird results when the first path was infrequent.

My main question is how the access and egress time maps work.