### PR TITLE
Remove the custom AMI requirement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <filtering>true</filtering>
         <includes>
           <include>**/*.properties</include>
+          <include>worker.sh</include>
           <include>debug-plan/**</include>
           <include>fares/**</include>
         </includes>

--- a/src/main/java/com/conveyal/r5/analyst/broker/Broker.java
+++ b/src/main/java/com/conveyal/r5/analyst/broker/Broker.java
@@ -384,7 +384,7 @@ public class Broker implements Runnable {
 
         // Read in the startup script
         try {
-            InputStream scriptIs = this.getClass().getClassLoader().getResourceAsStream("worker.sh");
+            InputStream scriptIs = this.getClass().getClassLoader().getResourceAsStream("/worker.sh");
             ByteArrayOutputStream scriptBaos = new ByteArrayOutputStream();
             ByteStreams.copy(scriptIs, scriptBaos);
             scriptIs.close();

--- a/src/main/java/com/conveyal/r5/analyst/broker/Broker.java
+++ b/src/main/java/com/conveyal/r5/analyst/broker/Broker.java
@@ -384,7 +384,7 @@ public class Broker implements Runnable {
 
         // Read in the startup script
         try {
-            InputStream scriptIs = this.getClass().getClassLoader().getResourceAsStream("/worker.sh");
+            InputStream scriptIs = Broker.class.getClassLoader().getResourceAsStream("worker.sh");
             ByteArrayOutputStream scriptBaos = new ByteArrayOutputStream();
             ByteStreams.copy(scriptIs, scriptBaos);
             scriptIs.close();

--- a/src/main/java/com/conveyal/r5/analyst/broker/Broker.java
+++ b/src/main/java/com/conveyal/r5/analyst/broker/Broker.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
+import com.google.common.io.ByteStreams;
 import gnu.trove.map.TIntObjectMap;
 import gnu.trove.map.TObjectLongMap;
 import gnu.trove.map.hash.TIntObjectHashMap;
@@ -24,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
+import java.text.MessageFormat;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -182,7 +184,7 @@ public class Broker implements Runnable {
             workerConfig.setProperty("auto-shutdown", "true");
         }
 
-        // TODO what are these for?
+        // Tags for the workers
         workerName = brokerConfig.getProperty("worker-name") != null ? brokerConfig.getProperty("worker-name") : "analyst-worker";
         project = brokerConfig.getProperty("project") != null ? brokerConfig.getProperty("project") : "analyst";
 
@@ -349,7 +351,7 @@ public class Broker implements Runnable {
             return;
         }
 
-        // TODO: compute
+        // TODO: should we start multiple workers on large jobs?
         int nWorkers = 1;
 
         // There are no workers on this graph with the right worker commit, start some.
@@ -365,13 +367,10 @@ public class Broker implements Runnable {
 
         // It's fine to just modify the worker config without a protective copy because this method is synchronized.
         workerConfig.setProperty("initial-graph-id", category.graphId);
-        workerConfig.setProperty("worker-version", category.workerVersion);
         // Tell the worker where to get its R5 JAR. This is a Conveyal S3 bucket with HTTP access turned on.
         String workerDownloadUrl = String.format("https://r5-builds.s3.amazonaws.com/%s.jar",
                 category.workerVersion);
-        workerConfig.setProperty("download-url", workerDownloadUrl);
-        // This is the R5 broker, so always start R5 workers (rather than OTP workers).
-        workerConfig.setProperty("main-class", AnalystWorker.class.getName());
+
         ByteArrayOutputStream cfg = new ByteArrayOutputStream();
         try {
             workerConfig.store(cfg, "Worker config");
@@ -380,8 +379,27 @@ public class Broker implements Runnable {
             throw new RuntimeException(e);
         }
 
+        String workerConfigString = cfg.toString();
+        String scriptTemplate;
+
+        // Read in the startup script
+        try {
+            InputStream scriptIs = this.getClass().getClassLoader().getResourceAsStream("worker.sh");
+            ByteArrayOutputStream scriptBaos = new ByteArrayOutputStream();
+            ByteStreams.copy(scriptIs, scriptBaos);
+            scriptIs.close();
+            scriptBaos.close();
+            scriptTemplate = scriptBaos.toString();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        String logGroup = workerConfig.getProperty("log-group");
+
+        String script = MessageFormat.format(scriptTemplate, workerDownloadUrl, logGroup, workerConfigString);
+
         // Send the config to the new workers as EC2 "user data"
-        String userData = new String(Base64.getEncoder().encode(cfg.toByteArray()));
+        String userData = new String(Base64.getEncoder().encode(script.getBytes()));
         req.setUserData(userData);
 
         if (brokerConfig.getProperty("worker-iam-role") != null)
@@ -398,7 +416,7 @@ public class Broker implements Runnable {
         RunInstancesResult res = ec2.runInstances(req);
         res.getReservation().getInstances().forEach(i -> {
             Collection<Tag> tags = Arrays.asList(
-                    new Tag("name", workerName),
+                    new Tag("Name", workerName),
                     new Tag("project", project)
             );
             i.setTags(tags);

--- a/src/main/java/com/conveyal/r5/profile/ProfileRequest.java
+++ b/src/main/java/com/conveyal/r5/profile/ProfileRequest.java
@@ -9,6 +9,7 @@ import com.conveyal.r5.api.util.SearchType;
 import com.conveyal.r5.api.util.TransitModes;
 import com.conveyal.r5.model.json_serialization.*;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import graphql.schema.DataFetchingEnvironment;
@@ -236,6 +237,7 @@ public class ProfileRequest implements Serializable, Cloneable {
 
     //If true current search is reverse search AKA we are looking for a path from destination to origin in reverse
     //It differs from searchType because it is used as egress search
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     public boolean reverseSearch = false;
 
     /** maximum fare. If nonnegative, fares will be used in routing. */

--- a/src/main/resources/worker.sh
+++ b/src/main/resources/worker.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Downloads and runs an analyst worker.
+# This will be run through string.format, and the following items will be available:
+# {0}: the URL to grab the worker JAR from
+# {1}: the AWS log group to use
+# {2}: the worker configuration to use
+
+# prep the system: install log agent, java
+yum -y install awslogs java-1.8.0-openjdk
+
+# first things first: set up logging
+LOGFILE=/var/log/analyst-worker.log
+
+echo Starting analyst worker at `date` > $LOGFILE
+
+# make it so that the worker can write to the logfile
+chown ec2-user:ec2-user $LOGFILE
+chmod 664 $LOGFILE # Log agent needs to read log file
+
+cat > /etc/awslogs.conf <<EOF
+[general]
+state_file = /var/awslogs/state/agent-state
+
+[otp]
+file = ${LOGFILE}
+log_group_name = {1}
+log_stream_name = {instance_id}
+datetime_format = %Y-%m-%dT%H:%M:%S%z
+time_zone = UTC
+EOF
+
+service awslogs start
+
+cat > ~ec2-user/worker.conf <<EOF
+{2}
+EOF
+
+# Download the worker
+sudo -u ec2-user wget -O ~ec2-user/r5.jar {0} 2>&1 >> $LOGFILE
+
+# Figure out how much memory to give the worker
+# figure out how much memory to use
+TOTAL_MEM=`grep MemTotal /proc/meminfo | sed 's/[^0-9]//g'`
+# 2097152 kb is 2GB, leave that much for the OS
+MEM=`echo $TOTAL_MEM - 2097152 | bc`
+
+# Start the worker
+# run in ec2-user's home directory
+cd ~ec2-user
+sudo -u ec2-user java8 -jar r5.jar worker worker.conf 2>&1 >> $LOGFILE
+
+# If the worker exits or doesn't start, wait a few minutes so that the CloudWatch log agent grabs
+# the logs
+sleep 120
+halt -p

--- a/src/main/resources/worker.sh
+++ b/src/main/resources/worker.sh
@@ -20,9 +20,9 @@ chmod 664 $LOGFILE # Log agent needs to read log file
 
 cat > /etc/awslogs/awslogs.conf <<EOF
 [general]
-state_file = /var/awslogs/state/agent-state
+state_file = /var/lib/awslogs/agent-state
 
-[otp]
+[logstream1]
 file = $LOGFILE
 log_group_name = {1}
 log_stream_name = '{instance_id}'

--- a/src/main/resources/worker.sh
+++ b/src/main/resources/worker.sh
@@ -37,7 +37,7 @@ cat > ~ec2-user/worker.conf <<EOF
 EOF
 
 # Download the worker
-sudo -u ec2-user wget -O ~ec2-user/r5.jar {0} 2>&1 >> $LOGFILE
+sudo -u ec2-user wget -O ~ec2-user/r5.jar {0} >> $LOGFILE 2>&1
 
 # Figure out how much memory to give the worker
 # figure out how much memory to use
@@ -46,11 +46,13 @@ TOTAL_MEM=`grep MemTotal /proc/meminfo | sed 's/[^0-9]//g'`
 MEM=`echo $TOTAL_MEM - 2097152 | bc`
 
 # Start the worker
-# run in ec2-user's home directory
-cd ~ec2-user
-sudo -u ec2-user java8 -jar r5.jar worker worker.conf 2>&1 >> $LOGFILE
+# run in ec2-user's home directory, in the subshell
+{
+    cd ~ec2-user
+    sudo -u ec2-user java8 -jar r5.jar worker worker.conf >> $LOGFILE 2>&1
 
-# If the worker exits or doesn't start, wait a few minutes so that the CloudWatch log agent grabs
-# the logs
-sleep 120
-halt -p
+    # If the worker exits or doesn't start, wait a few minutes so that the CloudWatch log agent grabs
+    # the logs
+    sleep 120
+    halt -p
+} &

--- a/src/main/resources/worker.sh
+++ b/src/main/resources/worker.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 # Downloads and runs an analyst worker.
-# This will be run through string.format, and the following items will be available:
-# {0}: the URL to grab the worker JAR from
-# {1}: the AWS log group to use
-# {2}: the worker configuration to use
+# This will be run through Java MessageFormat, and the following items will be available by wrapping
+# the relevant index in curly braces
+# 0: the URL to grab the worker JAR from
+# 1: the AWS log group to use
+# 2: the worker configuration to use
 
 # prep the system: install log agent, java
 yum -y install awslogs java-1.8.0-openjdk

--- a/src/main/resources/worker.sh
+++ b/src/main/resources/worker.sh
@@ -36,6 +36,11 @@ cat > ~ec2-user/worker.conf <<EOF
 {2}
 EOF
 
+REGION=`curl http://169.254.169.254/latest/meta-data/placement/availability-zone | egrep --only-matching '^[a-z-]+-[0-9]'`
+cat > /etc/awslogs/awscli.conf <<EOF
+[default]
+region = $REGION
+
 # dump config and awslogs log to stdout so it ends up in the EC2 console
 sleep 30
 echo AWS Logs Config:

--- a/src/main/resources/worker.sh
+++ b/src/main/resources/worker.sh
@@ -41,7 +41,7 @@ sleep 30
 echo AWS Logs Config:
 cat /etc/awslogs/awslogs.conf
 
-echo AWS Logs Logs (how meta):
+echo AWS Log agent logs:
 cat /var/log/awslogs.log
 
 # Download the worker

--- a/src/main/resources/worker.sh
+++ b/src/main/resources/worker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Downloads and runs an analyst worker.
-# This shell script will undergo variable substitution via Java's MessageFormat class before it is run on newly started
+# This shell script will undergo variable substitution via the Java MessageFormat class before it is run on newly started
 # worker machines. MessageFormat will replace special tokens (consisting of numbers inside curly braces) with
 # configuration information specific to the worker being started. These are:
 # 0: the URL to grab the worker JAR from

--- a/src/main/resources/worker.sh
+++ b/src/main/resources/worker.sh
@@ -24,7 +24,7 @@ state_file = /var/awslogs/state/agent-state
 [otp]
 file = $LOGFILE
 log_group_name = {1}
-log_stream_name = \{instance_id\}
+log_stream_name = '''{instance_id}'''
 datetime_format = %Y-%m-%dT%H:%M:%S%z
 time_zone = UTC
 EOF

--- a/src/main/resources/worker.sh
+++ b/src/main/resources/worker.sh
@@ -30,22 +30,27 @@ datetime_format = %Y-%m-%dT%H:%M:%S%z
 time_zone = UTC
 EOF
 
+REGION=`curl http://169.254.169.254/latest/meta-data/placement/availability-zone | egrep --only-matching '^[a-z-]+-[0-9]'`
+cat > /etc/awslogs/awscli.conf <<EOF
+[plugins]
+cwlogs = cwlogs
+[default]
+region = $REGION
+EOF
+
 service awslogs start
 
 cat > ~ec2-user/worker.conf <<EOF
 {2}
 EOF
 
-REGION=`curl http://169.254.169.254/latest/meta-data/placement/availability-zone | egrep --only-matching '^[a-z-]+-[0-9]'`
-cat > /etc/awslogs/awscli.conf <<EOF
-[default]
-region = $REGION
-EOF
-
 # dump config and awslogs log to stdout so it ends up in the EC2 console
 sleep 30
 echo AWS Logs Config:
 cat /etc/awslogs/awslogs.conf
+
+echo AWS Logs CLI Config:
+cat /etc/aws
 
 echo AWS Log agent logs:
 cat /var/log/awslogs.log

--- a/src/main/resources/worker.sh
+++ b/src/main/resources/worker.sh
@@ -25,7 +25,7 @@ state_file = /var/awslogs/state/agent-state
 [otp]
 file = $LOGFILE
 log_group_name = {1}
-log_stream_name = '''{instance_id}'''
+log_stream_name = ''{instance_id}''
 datetime_format = %Y-%m-%dT%H:%M:%S%z
 time_zone = UTC
 EOF

--- a/src/main/resources/worker.sh
+++ b/src/main/resources/worker.sh
@@ -25,7 +25,7 @@ state_file = /var/awslogs/state/agent-state
 [otp]
 file = $LOGFILE
 log_group_name = {1}
-log_stream_name = ''{instance_id}''
+log_stream_name = '{instance_id}'
 datetime_format = %Y-%m-%dT%H:%M:%S%z
 time_zone = UTC
 EOF

--- a/src/main/resources/worker.sh
+++ b/src/main/resources/worker.sh
@@ -36,6 +36,14 @@ cat > ~ec2-user/worker.conf <<EOF
 {2}
 EOF
 
+# dump config and awslogs log to stdout so it ends up in the EC2 console
+sleep 30
+echo AWS Logs Config:
+cat /etc/awslogs/awslogs.conf
+
+echo AWS Logs Logs (how meta):
+cat /var/log/awslogs.log
+
 # Download the worker
 sudo -u ec2-user wget -O ~ec2-user/r5.jar {0} >> $LOGFILE 2>&1
 

--- a/src/main/resources/worker.sh
+++ b/src/main/resources/worker.sh
@@ -22,9 +22,9 @@ cat > /etc/awslogs.conf <<EOF
 state_file = /var/awslogs/state/agent-state
 
 [otp]
-file = ${LOGFILE}
+file = $LOGFILE
 log_group_name = {1}
-log_stream_name = {instance_id}
+log_stream_name = \{instance_id\}
 datetime_format = %Y-%m-%dT%H:%M:%S%z
 time_zone = UTC
 EOF

--- a/src/main/resources/worker.sh
+++ b/src/main/resources/worker.sh
@@ -40,6 +40,7 @@ REGION=`curl http://169.254.169.254/latest/meta-data/placement/availability-zone
 cat > /etc/awslogs/awscli.conf <<EOF
 [default]
 region = $REGION
+EOF
 
 # dump config and awslogs log to stdout so it ends up in the EC2 console
 sleep 30

--- a/src/main/resources/worker.sh
+++ b/src/main/resources/worker.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Downloads and runs an analyst worker.
-# This will be run through Java MessageFormat, and the following items will be available by wrapping
-# the relevant index in curly braces
+# This shell script will undergo variable substitution via Java's MessageFormat class before it is run on newly started
+# worker machines. MessageFormat will replace special tokens (consisting of numbers inside curly braces) with
+# configuration information specific to the worker being started. These are:
 # 0: the URL to grab the worker JAR from
 # 1: the AWS log group to use
 # 2: the worker configuration to use
@@ -18,6 +19,8 @@ echo Starting analyst worker at `date` > $LOGFILE
 chown ec2-user:ec2-user $LOGFILE
 chmod 664 $LOGFILE # Log agent needs to read log file
 
+# using a shell "herefile" or "heredoc", pipe the data between <<EOF and EOF into the cat process which then writes
+# it to the appropriate location on the file system. Leave EOF unquoted so that variables are substituted.
 cat > /etc/awslogs/awslogs.conf <<EOF
 [general]
 state_file = /var/lib/awslogs/agent-state

--- a/src/main/resources/worker.sh
+++ b/src/main/resources/worker.sh
@@ -18,7 +18,7 @@ echo Starting analyst worker at `date` > $LOGFILE
 chown ec2-user:ec2-user $LOGFILE
 chmod 664 $LOGFILE # Log agent needs to read log file
 
-cat > /etc/awslogs.conf <<EOF
+cat > /etc/awslogs/awslogs.conf <<EOF
 [general]
 state_file = /var/awslogs/state/agent-state
 


### PR DESCRIPTION
This just passes in a user data and can be used with a standard Amazon Linux AMI, e.g. `ami-e5083683` in `eu-west-1`.

H/T @dfconway for helping with the shell scripting.

![XKCD](https://cloud.githubusercontent.com/assets/566958/25060066/69996224-2162-11e7-9a09-9d43754f4229.png)
