### PR TITLE
don't include reverse routing field if it is at its default value, to…

### DIFF
--- a/src/main/java/com/conveyal/r5/profile/ProfileRequest.java
+++ b/src/main/java/com/conveyal/r5/profile/ProfileRequest.java
@@ -9,6 +9,7 @@ import com.conveyal.r5.api.util.SearchType;
 import com.conveyal.r5.api.util.TransitModes;
 import com.conveyal.r5.model.json_serialization.*;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import graphql.schema.DataFetchingEnvironment;
@@ -236,6 +237,7 @@ public class ProfileRequest implements Serializable, Cloneable {
 
     //If true current search is reverse search AKA we are looking for a path from destination to origin in reverse
     //It differs from searchType because it is used as egress search
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     public boolean reverseSearch = false;
 
     /** maximum fare. If nonnegative, fares will be used in routing. */


### PR DESCRIPTION
… avoid confusing older workers.

Due to #264, adding fields to the profile request makes older workers blow up with recent brokers. Until we can fix this issue we need to avoid transmitting new values unless they have been modified.