### PR TITLE
Support multiple networks in TransportNetworkCache

### DIFF
--- a/src/main/java/com/conveyal/r5/transit/TransportNetwork.java
+++ b/src/main/java/com/conveyal/r5/transit/TransportNetwork.java
@@ -41,6 +41,12 @@ public class TransportNetwork implements Serializable {
     public TransitLayer transitLayer;
 
     /**
+     * This stores any number of lightweight scenario networks built upon the current base network.
+     * FIXME that sounds like a memory leak, should be a WeighingCache or at least size-limited.
+     */
+    public Map<String, TransportNetwork> scenarios = new HashMap<>();
+
+    /**
      * A grid point set that covers the full extent of this transport network. The PointSet itself then caches linkages
      * to street networks (the baseline street network, or ones with various scenarios applied). If they have been
      * created, this point set and its linkage to the street network are serialized along with the network, which makes

--- a/src/main/java/com/conveyal/r5/transit/TransportNetwork.java
+++ b/src/main/java/com/conveyal/r5/transit/TransportNetwork.java
@@ -44,7 +44,7 @@ public class TransportNetwork implements Serializable {
      * This stores any number of lightweight scenario networks built upon the current base network.
      * FIXME that sounds like a memory leak, should be a WeighingCache or at least size-limited.
      */
-    public Map<String, TransportNetwork> scenarios = new HashMap<>();
+    public transient Map<String, TransportNetwork> scenarios = new HashMap<>();
 
     /**
      * A grid point set that covers the full extent of this transport network. The PointSet itself then caches linkages

--- a/src/main/java/com/conveyal/r5/transit/TransportNetworkCache.java
+++ b/src/main/java/com/conveyal/r5/transit/TransportNetworkCache.java
@@ -6,7 +6,6 @@ import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 import com.conveyal.gtfs.GTFSCache;
 import com.conveyal.osmlib.OSMCache;
-import com.conveyal.r5.analyst.WebMercatorGridPointSet;
 import com.conveyal.r5.analyst.cluster.BundleManifest;
 import com.conveyal.r5.analyst.scenario.Scenario;
 import com.conveyal.r5.common.JsonUtilities;
@@ -14,17 +13,20 @@ import com.conveyal.r5.common.R5Version;
 import com.conveyal.r5.point_to_point.builder.TNBuilderConfig;
 import com.conveyal.r5.profile.ProfileRequest;
 import com.conveyal.r5.streets.StreetLayer;
-import com.google.common.collect.Sets;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.cache.RemovalListener;
 import com.google.common.io.ByteStreams;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -44,11 +46,13 @@ public class TransportNetworkCache {
     private final File cacheDir;
 
     private final String sourceBucket;
+    private final String bucketFolder;
 
-    String currentNetworkId = null;
+//    String currentNetworkId = null;
 
-    TransportNetwork currentNetwork = null;
+    private static final int DEFAULT_CACHE_SIZE = 1;
 
+    private final LoadingCache<String, TransportNetwork> cachedNetworks;
     private final GTFSCache gtfsCache;
     private final OSMCache osmCache;
 
@@ -59,24 +63,41 @@ public class TransportNetworkCache {
 
     /** Create a transport network cache. If source bucket is null, will work offline. */
     public TransportNetworkCache(String sourceBucket, File cacheDir) {
+        this(sourceBucket, cacheDir, DEFAULT_CACHE_SIZE, null);
+    }
+
+    public TransportNetworkCache(String sourceBucket, File cacheDir, String bucketFolder) {
+        this(sourceBucket, cacheDir, DEFAULT_CACHE_SIZE, bucketFolder);
+    }
+
+    /** Create a transport network cache. If source bucket is null, will work offline. */
+    public TransportNetworkCache(String sourceBucket, File cacheDir, int cacheSize, String bucketFolder) {
         this.cacheDir = cacheDir;
         this.sourceBucket = sourceBucket;
+        this.bucketFolder = bucketFolder != null ? bucketFolder.replaceAll("\\/","") : null;
+        this.cachedNetworks = createCache(cacheSize);
         this.gtfsCache = new GTFSCache(sourceBucket, cacheDir);
         this.osmCache = new OSMCache(sourceBucket, cacheDir);
     }
 
     public TransportNetworkCache(GTFSCache gtfsCache, OSMCache osmCache) {
-        this.gtfsCache = gtfsCache;
-        this.osmCache = osmCache;
-        this.cacheDir = gtfsCache.cacheDir;
-        this.sourceBucket = gtfsCache.bucket;
+        this(gtfsCache, osmCache, DEFAULT_CACHE_SIZE);
     }
 
-    /**
-     * This stores any number of lightweight scenario networks built upon the current base network.
-     * FIXME that sounds like a memory leak, should be a WeighingCache or at least size-limited.
-     */
-    private Map<String, TransportNetwork> scenarioNetworkCache = new HashMap<>();
+    public TransportNetworkCache(GTFSCache gtfsCache, OSMCache osmCache, int cacheSize) {
+        this(gtfsCache, osmCache, cacheSize, null);
+    }
+
+    public TransportNetworkCache(GTFSCache gtfsCache, OSMCache osmCache, int cacheSize, String bucketFolder) {
+        this.gtfsCache = gtfsCache;
+        this.osmCache = osmCache;
+        this.cachedNetworks = createCache(cacheSize);
+        this.cacheDir = gtfsCache.cacheDir;
+        this.sourceBucket = gtfsCache.bucket;
+        // we don't necessarily want to put r5 networks in the gtfsCache bucketFolder
+        // (e.g., "s3://bucket/gtfs"), but we'll go ahead and use the same bucket
+        this.bucketFolder = bucketFolder;
+    }
 
     /**
      * Return the graph for the given unique identifier for graph builder inputs on S3.
@@ -87,11 +108,6 @@ public class TransportNetworkCache {
 
         LOG.info("Finding or building a TransportNetwork for ID {} and R5 version {}", networkId, R5Version.version);
 
-        if (networkId.equals(currentNetworkId)) {
-            LOG.info("Network ID has not changed. Reusing the last one that was built.");
-            return currentNetwork;
-        }
-
         TransportNetwork network = checkCached(networkId);
         if (network == null) {
             LOG.info("Cached transport network for id {} and R5 version {} was not found. Building the network from scratch.",
@@ -99,10 +115,7 @@ public class TransportNetworkCache {
             network = buildNetwork(networkId);
         }
 
-        currentNetwork = network;
-        currentNetworkId = networkId;
-        scenarioNetworkCache.clear(); // We cache only scenario graphs built upon the currently active base graph.
-
+        cachedNetworks.put(networkId, network);
         return network;
     }
 
@@ -122,7 +135,7 @@ public class TransportNetworkCache {
 
         // The following call clears the scenarioNetworkCache if the current base graph changes.
         TransportNetwork baseNetwork = this.getNetwork(networkId);
-        TransportNetwork scenarioNetwork = scenarioNetworkCache.get(scenarioId);
+        TransportNetwork scenarioNetwork = baseNetwork.scenarios.get(scenarioId);
 
         // DEBUG force scenario re-application
         // scenarioNetwork = null;
@@ -135,12 +148,11 @@ public class TransportNetworkCache {
                 // resolve scenario
                 LOG.info("Retrieving scenario stored separately on S3 rather than in the ProfileRequest");
 
-                String scenarioKey = String.format("%s_%s.json", networkId, scenarioId);
-                File scenarioFile = new File(cacheDir, scenarioKey);
+                File scenarioFile = new File(cacheDir, getScenarioFilename(networkId, scenarioId));
 
                 if (!scenarioFile.exists()) {
                     try {
-                        S3Object obj = s3.getObject(sourceBucket, scenarioKey);
+                        S3Object obj = s3.getObject(sourceBucket, getScenarioKey(networkId, scenarioId));
                         InputStream is = obj.getObjectContent();
                         OutputStream os = new BufferedOutputStream(new FileOutputStream(scenarioFile));
                         ByteStreams.copy(is, os);
@@ -172,18 +184,26 @@ public class TransportNetworkCache {
             // scenario.modifications.add(0, new InactiveTripsFilter(baseNetwork, clusterRequest.profileRequest));
             scenarioNetwork = scenario.applyToTransportNetwork(baseNetwork);
             LOG.info("Done applying scenario. Caching the resulting network.");
-            scenarioNetworkCache.put(scenario.id, scenarioNetwork);
+            baseNetwork.scenarios.put(scenario.id, scenarioNetwork);
         } else {
             LOG.info("Reusing cached TransportNetwork for scenario {}.", scenarioId);
         }
         return scenarioNetwork;
     }
 
+    private String getScenarioFilename(String networkId, String scenarioId) {
+        return String.format("%s_%s.json", networkId, scenarioId);
+    }
+
+    private String getScenarioKey(String networkId, String scenarioId) {
+        String filename = getScenarioFilename(networkId, scenarioId);
+        return bucketFolder != null ? String.join("/", bucketFolder, filename) : filename;
+    }
+
     /** If this transport network is already built and cached, fetch it quick */
     private TransportNetwork checkCached (String networkId) {
         try {
-            String filename = networkId + "_" + R5Version.version + ".dat";
-            File cacheLocation = new File(cacheDir, networkId + "_" + R5Version.version + ".dat");
+            File cacheLocation = new File(cacheDir, getR5NetworkFilename(networkId));
             if (cacheLocation.exists())
                 LOG.info("Found locally-cached TransportNetwork at {}", cacheLocation);
             else {
@@ -193,7 +213,7 @@ public class TransportNetworkCache {
                     LOG.info("Checking for cached transport network on S3.");
                     S3Object tn;
                     try {
-                        tn = s3.getObject(sourceBucket, filename);
+                        tn = s3.getObject(sourceBucket, getR5NetworkKey(networkId));
                     } catch (AmazonServiceException ex) {
                         LOG.info("No cached transport network was found in S3. It will be built from scratch.");
                         return null;
@@ -222,6 +242,16 @@ public class TransportNetworkCache {
         }
     }
 
+
+    private String getR5NetworkKey(String networkId) {
+        String filename = getR5NetworkFilename(networkId);
+        return bucketFolder != null ? String.join("/", bucketFolder, filename) : filename;
+    }
+
+    private String getR5NetworkFilename(String networkId) {
+        return networkId + "_" + R5Version.version + ".dat";
+    }
+
     /** If we did not find a cached network, build one */
     public TransportNetwork buildNetwork (String networkId) {
 
@@ -247,8 +277,7 @@ public class TransportNetworkCache {
         network.rebuildLinkedGridPointSet();
 
         // Cache the network.
-        String filename = networkId + "_" + R5Version.version + ".dat";
-        File cacheLocation = new File(cacheDir, networkId + "_" + R5Version.version + ".dat");
+        File cacheLocation = new File(cacheDir, getR5NetworkFilename(networkId));
 
         try {
             // Serialize TransportNetwork to local cache on this worker
@@ -256,7 +285,7 @@ public class TransportNetworkCache {
             // Upload the serialized TransportNetwork to S3
             if (sourceBucket != null) {
                 LOG.info("Uploading the serialized TransportNetwork to S3 for use by other workers.");
-                s3.putObject(sourceBucket, filename, cacheLocation);
+                s3.putObject(sourceBucket, getR5NetworkKey(networkId), cacheLocation);
                 LOG.info("Done uploading the serialized TransportNetwork to S3.");
             } else {
                 LOG.info("Network saved to cache directory, not uploading to S3 while working offline.");
@@ -279,7 +308,8 @@ public class TransportNetworkCache {
             if (sourceBucket != null) {
                 LOG.info("Downloading graph input files from S3.");
                 dataDirectory.mkdirs();
-                S3Object graphDataZipObject = s3.getObject(sourceBucket, networkId + ".zip");
+                String networkZipKey = bucketFolder != null ? String.join("/", bucketFolder, networkId + ".zip") : networkId + ".zip";
+                S3Object graphDataZipObject = s3.getObject(sourceBucket, networkZipKey);
                 ZipInputStream zis = new ZipInputStream(graphDataZipObject.getObjectContent());
                 try {
                     ZipEntry entry;
@@ -329,13 +359,14 @@ public class TransportNetworkCache {
      * It contains the unique IDs of the GTFS feeds and OSM extract.
      */
     private TransportNetwork buildNetworkFromManifest (String networkId) {
-        String manifestFileName = GTFSCache.cleanId(networkId) + ".json";
+        String manifestFileName = getManifestFilename(networkId);
         File manifestFile = new File(cacheDir, manifestFileName);
 
         // TODO handle manifest not in S3
         if (!manifestFile.exists() && sourceBucket != null) {
             LOG.info("Manifest file not found locally, downloading from S3");
-            s3.getObject(new GetObjectRequest(sourceBucket, manifestFileName), manifestFile);
+            String manifestKey = getManifestKey(networkId);
+            s3.getObject(new GetObjectRequest(sourceBucket, manifestKey), manifestFile);
         }
 
         BundleManifest manifest;
@@ -374,12 +405,50 @@ public class TransportNetworkCache {
         return network;
     }
 
+    private String getManifestKey(String networkId) {
+        String filename = getManifestFilename(networkId);
+        return bucketFolder != null ? String.join("/", bucketFolder, filename) : filename;
+    }
+
+    private String getManifestFilename(String networkId) {
+        return GTFSCache.cleanId(networkId) + ".json";
+    }
+
+    private LoadingCache<String, TransportNetwork> createCache(int size) {
+        RemovalListener<String, TransportNetwork> removalListener = removalNotification -> {
+            String id = removalNotification.getKey();
+
+            // delete local files ONLY if using s3
+            if (sourceBucket != null) {
+                String[] extensions = {".db", ".db.p", ".zip"};
+                // delete local cache files (including zip) when feed removed from cache
+                for (String type : extensions) {
+                    File file = new File(cacheDir, id + type);
+                    file.delete();
+                }
+            }
+        };
+        return CacheBuilder.newBuilder()
+                .maximumSize(size)
+                .removalListener(removalListener)
+                .build(new CacheLoader() {
+                    public TransportNetwork load(Object s) throws Exception {
+                        // Thanks, java, for making me use a cast here. If I put generic arguments to new CacheLoader
+                        // due to type erasure it can't be sure I'm using types correctly.
+                        return getNetwork((String) s);
+                    }
+                });
+    }
+
     public Set<String> getLoadedNetworkIds() {
-        if (currentNetwork == null) return Collections.emptySet();
-        else return Sets.newHashSet(currentNetwork.scenarioId);
+        if (cachedNetworks == null) return Collections.emptySet();
+        else return cachedNetworks.asMap().keySet();
     }
 
     public Set<String> getAppliedScenarios() {
-        return scenarioNetworkCache.keySet();
+        return cachedNetworks.asMap().values().stream()
+                .map(network -> network.scenarios.keySet())
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet());
     }
 }


### PR DESCRIPTION
Addresses #279.

This moves `TransportNetworkCache.scenarioNetworkCache` -> `TransportNetwork.scenarios` and adds a Guava loading cache with a configurable number of transport networks (defaults to 1).

This also adds support for a bucketFolder, so that r5 networks (+ scenarios and manifest files) can be stored in a "subdirectory" on s3.