### PR TITLE
ReverseSearch field is now on StreetRouter

### DIFF
--- a/src/main/java/com/conveyal/r5/api/ProfileResponse.java
+++ b/src/main/java/com/conveyal/r5/api/ProfileResponse.java
@@ -93,8 +93,6 @@ public class ProfileResponse {
             if (accessPathIndex < 0) {
                 //Here accessRouter needs to have this access mode since stopModeAccessMap is filled from accessRouter
                 StreetRouter streetRouter = accessRouter.get(accessMode);
-                //FIXME: Must we really update this on every streetrouter?
-                streetRouter.profileRequest.reverseSearch = false;
                 StreetRouter.State state = streetRouter.getStateAtVertex(startVertexStopIndex);
                 if (state != null) {
                     StreetPath streetPath;
@@ -102,7 +100,7 @@ public class ProfileResponse {
                         streetPath = new StreetPath(state, streetRouter, accessMode,
                             transportNetwork);
                     } else {
-                        streetPath = new StreetPath(state, transportNetwork, false);
+                        streetPath = new StreetPath(state, transportNetwork, streetRouter.reverseSearch); //reverse search is false
                     }
                     StreetSegment streetSegment = new StreetSegment(streetPath, accessMode, transportNetwork.streetLayer);
                     profileOption.addAccess(streetSegment, accessMode, startVertexStopIndex);
@@ -122,11 +120,9 @@ public class ProfileResponse {
             if (egressPathIndex < 0) {
                 //Here egressRouter needs to have this egress mode since stopModeEgressMap is filled from egressRouter
                 StreetRouter streetRouter = egressRouter.get(egressMode);
-                //FIXME: Must we really update this on every streetrouter?
-                streetRouter.profileRequest.reverseSearch = true;
                 StreetRouter.State state = streetRouter.getStateAtVertex(endVertexStopIndex);
                 if (state != null) {
-                    StreetPath streetPath = new StreetPath(state, transportNetwork, true);
+                    StreetPath streetPath = new StreetPath(state, transportNetwork, streetRouter.reverseSearch); // reverse search is true
                     StreetSegment streetSegment = new StreetSegment(streetPath, egressMode, transportNetwork.streetLayer);
                     profileOption.addEgress(streetSegment, egressMode, endVertexStopIndex);
                     //This should never happen since stopModeEgressMap is filled from reached stops in egressRouter
@@ -180,10 +176,9 @@ public class ProfileResponse {
         Map<Integer, List<Transfer>> transfersWithSameStart = transferToOption.keySet().stream()
             .collect(Collectors.groupingBy(Transfer::getAlightStop));
         //LOG.info("Filling middle paths");
-        boolean prevReverseSearch = request.reverseSearch;
-        request.reverseSearch = false;
         for (Map.Entry<Integer, List<Transfer>> entry: transfersWithSameStart.entrySet()) {
             StreetRouter streetRouter = new StreetRouter(transportNetwork.streetLayer);
+            //reverse search is false
             streetRouter.streetMode = StreetMode.WALK;
             streetRouter.profileRequest = request;
             //TODO: make configurable distanceLimitMeters in middle
@@ -207,7 +202,6 @@ public class ProfileResponse {
                 }
             }
         }
-        request.reverseSearch = prevReverseSearch;
     }
 
     /** Recompute stats for all options, should be done once all options have been added */

--- a/src/main/java/com/conveyal/r5/point_to_point/PointToPointRouterServer.java
+++ b/src/main/java/com/conveyal/r5/point_to_point/PointToPointRouterServer.java
@@ -359,9 +359,10 @@ public class PointToPointRouterServer {
             }
 
             ProfileRequest profileRequest = new ProfileRequest();
-            Boolean reverseSearch = request.queryMap("reverse").booleanValue();
-            if (reverseSearch != null && reverseSearch) {
-                profileRequest.reverseSearch = true;
+            Boolean reverseSearchB = request.queryMap("reverse").booleanValue();
+            boolean reverseSearch = false;
+            if (reverseSearchB != null && reverseSearchB) {
+                reverseSearch = true;
             }
             profileRequest.zoneId = transportNetwork.getTimeZone();
             profileRequest.fromLat = fromLat;
@@ -410,7 +411,7 @@ public class PointToPointRouterServer {
                 featureCollection.put("type", "FeatureCollection");
                 List<GeoJsonFeature> features = new ArrayList<>();
 
-                fillFeature(transportNetwork, lastState, features, profileRequest.reverseSearch);
+                fillFeature(transportNetwork, lastState, features, reverseSearch);
                 featureCollection.put("features", features);
                 content.put("data", featureCollection);
             } else {

--- a/src/main/java/com/conveyal/r5/point_to_point/builder/PointToPointQuery.java
+++ b/src/main/java/com/conveyal/r5/point_to_point/builder/PointToPointQuery.java
@@ -199,10 +199,9 @@ public class PointToPointQuery {
     private Map<LegMode, StreetRouter> findEgressPaths(ProfileRequest request) {
         Map<LegMode, StreetRouter> egressRouter = new HashMap<>();
         //For egress
-        //TODO: this must be reverse search
-        request.reverseSearch = true;
         for(LegMode mode: request.egressModes) {
             StreetRouter streetRouter = new StreetRouter(transportNetwork.streetLayer);
+            streetRouter.reverseSearch = true;
             streetRouter.transitStopSearch = true;
             streetRouter.quantityToMinimize = StreetRouter.State.RoutingVariable.DURATION_SECONDS;
             if (egressUnsupportedModes.contains(mode)) {
@@ -232,10 +231,10 @@ public class PointToPointQuery {
      * @param option
      */
     private void findDirectPaths(ProfileRequest request, ProfileOption option) {
-        request.reverseSearch = false;
         //For direct modes
         for(LegMode mode: request.directModes) {
             StreetRouter streetRouter = new StreetRouter(transportNetwork.streetLayer);
+            //reverse search is false
             StreetPath streetPath;
             streetRouter.profileRequest = request;
             if (mode == LegMode.BICYCLE_RENT) {
@@ -289,10 +288,10 @@ public class PointToPointQuery {
      * @param request
      */
     private HashMap<LegMode, StreetRouter> findAccessPaths(ProfileRequest request) {
-        request.reverseSearch = false;
         // Routes all access modes
         HashMap<LegMode, StreetRouter> accessRouter = new HashMap<>();
         for(LegMode mode: request.accessModes) {
+            //reverse search is false
             StreetRouter streetRouter = new StreetRouter(transportNetwork.streetLayer);
             streetRouter.profileRequest = request;
             if (mode == LegMode.CAR_PARK) {

--- a/src/main/java/com/conveyal/r5/profile/ProfileRequest.java
+++ b/src/main/java/com/conveyal/r5/profile/ProfileRequest.java
@@ -169,13 +169,6 @@ public class ProfileRequest implements Serializable, Cloneable {
     private SearchType searchType;
 
     /**
-     * If true current search is reverse search AKA we are looking for a path from destination to origin in reverse
-     * It differs from searchType because it is used as egress search
-     */
-    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-    public boolean reverseSearch = false;
-
-    /**
      * Maximum fare for constraining monetary cost of paths during search in Analysis.
      * If nonnegative, fares will be used in routing.
      */

--- a/src/main/java/com/conveyal/r5/streets/EdgeStore.java
+++ b/src/main/java/com/conveyal/r5/streets/EdgeStore.java
@@ -552,12 +552,12 @@ public class EdgeStore implements Serializable {
             return options.getSpeedForMode(traverseStreetMode);
         }
 
-        public StreetRouter.State traverse (StreetRouter.State s0, StreetMode streetMode, ProfileRequest req,
-                                            TurnCostCalculator turnCostCalculator) {
+        public StreetRouter.State traverse(StreetRouter.State s0, StreetMode streetMode,
+            ProfileRequest req, TurnCostCalculator turnCostCalculator, boolean reverseSearch) {
 
             // The vertex we'll be at after the traversal
             int vertex;
-            if (req.reverseSearch) {
+            if (reverseSearch) {
                 vertex = getFromVertex();
             } else {
                 vertex = getToVertex();
@@ -568,14 +568,14 @@ public class EdgeStore implements Serializable {
             float time = (float) (getLengthM() / speedms);
             float weight = 0;
 
-            if (!canTurnFrom(s0, s1, req.reverseSearch)) return null;
+            if (!canTurnFrom(s0, s1, reverseSearch)) return null;
 
             // clear out turn restrictions if they're empty
             if (s1.turnRestrictions != null && s1.turnRestrictions.isEmpty()) s1.turnRestrictions = null;
 
             // figure out which turn res
 
-            startTurnRestriction(s0.streetMode, req.reverseSearch, s1);
+            startTurnRestriction(s0.streetMode, reverseSearch, s1);
 
             //We allow two links in a row if this is a first state (negative back edge or no backState
             //Since at least P+R stations are connected to graph with only LINK edges and otherwise search doesn't work
@@ -644,7 +644,7 @@ public class EdgeStore implements Serializable {
             // Negative backEdge means this state is not the result of traversing an edge (it's the start of a search).
             int turnCost = 0;
             if (s0.backEdge >= 0) {
-                if (req.reverseSearch) {
+                if (reverseSearch) {
                     turnCost = turnCostCalculator.computeTurnCost(getEdgeIndex(), s0.backEdge, streetMode);
                 } else {
                     turnCost = turnCostCalculator.computeTurnCost(s0.backEdge, getEdgeIndex(), streetMode);

--- a/src/test/java/com/conveyal/r5/streets/ReverseRoutingTest.java
+++ b/src/test/java/com/conveyal/r5/streets/ReverseRoutingTest.java
@@ -97,7 +97,7 @@ public class ReverseRoutingTest extends TestCase {
         ProfileRequest profileRequest = new ProfileRequest();
         StreetRouter streetRouter = new StreetRouter(streetLayer);
         streetRouter.profileRequest = profileRequest;
-        profileRequest.reverseSearch = true;
+        streetRouter.reverseSearch = true;
         streetRouter.streetMode = StreetMode.BICYCLE;
         VertexStore.Vertex AVertex = streetLayer.vertexStore.getCursor(A);
         VertexStore.Vertex EVertex = streetLayer.vertexStore.getCursor(E);
@@ -108,7 +108,7 @@ public class ReverseRoutingTest extends TestCase {
 
         StreetRouter.State lastState = streetRouter.getStateAtVertex(A); //streetRouter.getDestinationSplit());
         assertNotNull(lastState);
-        StreetPath streetPath = new StreetPath(lastState, transportNetwork, profileRequest.reverseSearch);
+        StreetPath streetPath = new StreetPath(lastState, transportNetwork, streetRouter.reverseSearch);
 
         List<Integer> correctEdgeIdx = Arrays.asList( 0, 4, 6, 3 );
         List<Integer> correctDuration = Arrays.asList(3,6,9,13);

--- a/src/test/java/com/conveyal/r5/streets/TurnRestrictionTest.java
+++ b/src/test/java/com/conveyal/r5/streets/TurnRestrictionTest.java
@@ -37,7 +37,7 @@ public class TurnRestrictionTest extends TurnTest {
         r.route();
 
         StreetRouter.State s1 = r.getStateAtVertex(VW);
-        LOG.debug("turn rest: {} {}", s1.dump(), s1.compactDump(r.profileRequest.reverseSearch));
+        LOG.debug("turn rest: {} {}", s1.dump(), s1.compactDump(r.reverseSearch));
 
         // weight should be greater because path should now include going past the intersection and making a U-turn back at it.
         assertTrue(s1.weight > state.weight);
@@ -51,7 +51,7 @@ public class TurnRestrictionTest extends TurnTest {
         StreetRouter r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
-        r.profileRequest.reverseSearch = true;
+        r.reverseSearch = true;
         r.setOrigin(VW);
         r.route();
 
@@ -63,7 +63,7 @@ public class TurnRestrictionTest extends TurnTest {
         restrictTurn(false, ES + 1, EW);
 
         r = new StreetRouter(streetLayer);
-        r.profileRequest.reverseSearch = true;
+        r.reverseSearch = true;
         r.streetMode = StreetMode.CAR;
         r.setOrigin(VW);
         r.route();
@@ -98,7 +98,7 @@ public class TurnRestrictionTest extends TurnTest {
         new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
-        r.profileRequest.reverseSearch = true;
+        r.reverseSearch = true;
         r.setOrigin(VW);
         r.route();
 
@@ -190,7 +190,7 @@ public class TurnRestrictionTest extends TurnTest {
         StreetRouter r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
-        r.profileRequest.reverseSearch = true;
+        r.reverseSearch = true;
         r.setOrigin(VW);
         r.route();
 
@@ -201,7 +201,7 @@ public class TurnRestrictionTest extends TurnTest {
         restrictTurn(true, ES + 1, EE);
 
         r = new StreetRouter(streetLayer);
-        r.profileRequest.reverseSearch = true;
+        r.reverseSearch = true;
         r.streetMode = StreetMode.CAR;
         r.setOrigin(VW);
         r.route();
@@ -244,7 +244,7 @@ public class TurnRestrictionTest extends TurnTest {
         StreetRouter.State state = r.getState(split);
         assertNotNull(state);
 
-        LOG.debug("Normat with split:{}", state.compactDump(r.profileRequest.reverseSearch));
+        LOG.debug("Normat with split:{}", state.compactDump(r.reverseSearch));
 
         // create a turn restriction
         restrictTurn(false, ES + 1, EW);
@@ -256,7 +256,7 @@ public class TurnRestrictionTest extends TurnTest {
 
         StreetRouter.State restrictedState = r.getState(split);
 
-        LOG.debug("Normal restricted with split:{}", restrictedState.compactDump(r.profileRequest.reverseSearch));
+        LOG.debug("Normal restricted with split:{}", restrictedState.compactDump(r.reverseSearch));
 
         // weight should be greater because path should now include going past the intersection and making a U-turn back at it.
         assertTrue(restrictedState.weight > state.weight);
@@ -272,14 +272,14 @@ public class TurnRestrictionTest extends TurnTest {
         StreetRouter r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
-        r.profileRequest.reverseSearch = true;
+        r.reverseSearch = true;
         r.setOrigin(37.363, -122.1235); //location of split
         r.route();
 
         StreetRouter.State state = r.getStateAtVertex(VS); // getState(splitVS);
         assertNotNull(state);
 
-        LOG.debug("Reverse with split:{}", state.compactDump(r.profileRequest.reverseSearch));
+        LOG.debug("Reverse with split:{}", state.compactDump(r.reverseSearch));
 
 
         // create a turn restriction
@@ -287,14 +287,14 @@ public class TurnRestrictionTest extends TurnTest {
 
         r = new StreetRouter(streetLayer);
         r.streetMode = StreetMode.CAR;
-        r.profileRequest.reverseSearch = true;
+        r.reverseSearch = true;
         r.setOrigin(37.363, -122.1235);
         //r.setOrigin(VW);
         r.route();
 
         StreetRouter.State restrictedState =  r.getStateAtVertex(VS); // getState(splitVS);
 
-        LOG.debug("Reverse restricted with split:{}", restrictedState.compactDump(r.profileRequest.reverseSearch));
+        LOG.debug("Reverse restricted with split:{}", restrictedState.compactDump(r.reverseSearch));
 
         // weight should be greater because path should now include going past the intersection and making a U-turn back at it.
         assertTrue(restrictedState.weight > state.weight);
@@ -314,14 +314,14 @@ public class TurnRestrictionTest extends TurnTest {
         StreetRouter r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
-        r.profileRequest.reverseSearch = true;
+        r.reverseSearch = true;
         r.setOrigin(VW); //location of split
         r.route();
 
         StreetRouter.State state = r.getState(splitVS);
         assertNotNull(state);
 
-        LOG.debug("Reverse with split:{}", state.compactDump(r.profileRequest.reverseSearch));
+        LOG.debug("Reverse with split:{}", state.compactDump(r.reverseSearch));
 
 
         // create a turn restriction
@@ -329,14 +329,14 @@ public class TurnRestrictionTest extends TurnTest {
 
         r = new StreetRouter(streetLayer);
         r.streetMode = StreetMode.CAR;
-        r.profileRequest.reverseSearch = true;
+        r.reverseSearch = true;
         r.setOrigin(VW);
         //r.setOrigin(VW);
         r.route();
 
         StreetRouter.State restrictedState =  r.getState(splitVS);
 
-        LOG.debug("Reverse restricted with split:{}", restrictedState.compactDump(r.profileRequest.reverseSearch));
+        LOG.debug("Reverse restricted with split:{}", restrictedState.compactDump(r.reverseSearch));
 
         // weight should be greater because path should now include going past the intersection and making a U-turn back at it.
         assertTrue(restrictedState.weight > state.weight);
@@ -356,7 +356,7 @@ public class TurnRestrictionTest extends TurnTest {
 
         StreetRouter.State state = r.getState(dest);
 
-        LOG.debug("Normal:{}", state.compactDump(r.profileRequest.reverseSearch));
+        LOG.debug("Normal:{}", state.compactDump(r.reverseSearch));
         assertNotNull(state);
 
         // create a turn restriction
@@ -369,7 +369,7 @@ public class TurnRestrictionTest extends TurnTest {
 
         StreetRouter.State restrictedState = r.getState(dest);
 
-        LOG.debug("Restricted:{}", restrictedState.compactDump(r.profileRequest.reverseSearch));
+        LOG.debug("Restricted:{}", restrictedState.compactDump(r.reverseSearch));
 
         // weight should be greater because path should now include going past the intersection and making a U-turn back at it.
         assertTrue(restrictedState.weight > state.weight);
@@ -387,7 +387,7 @@ public class TurnRestrictionTest extends TurnTest {
 
         StreetRouter.State state = r.getStateAtVertex(VW);
 
-        LOG.debug("Normal:{}", state.compactDump(r.profileRequest.reverseSearch));
+        LOG.debug("Normal:{}", state.compactDump(r.reverseSearch));
         assertNotNull(state);
 
         // create a turn restriction
@@ -400,7 +400,7 @@ public class TurnRestrictionTest extends TurnTest {
 
         StreetRouter.State restrictedState = r.getStateAtVertex(VW);
 
-        LOG.debug("Restricted:{}", restrictedState.compactDump(r.profileRequest.reverseSearch));
+        LOG.debug("Restricted:{}", restrictedState.compactDump(r.reverseSearch));
 
         // weight should be greater because path should now include going past the intersection and making a U-turn back at it.
         assertTrue(restrictedState.weight > state.weight);
@@ -463,7 +463,7 @@ public class TurnRestrictionTest extends TurnTest {
         StreetRouter r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
-        r.profileRequest.reverseSearch = true;
+        r.reverseSearch = true;
         r.setOrigin(VNW);
         r.route();
 
@@ -474,7 +474,7 @@ public class TurnRestrictionTest extends TurnTest {
         r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
-        r.profileRequest.reverseSearch = true;
+        r.reverseSearch = true;
         r.setOrigin(VNW);
         r.route();
 
@@ -485,7 +485,7 @@ public class TurnRestrictionTest extends TurnTest {
         r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
-        r.profileRequest.reverseSearch = true;
+        r.reverseSearch = true;
         r.setOrigin(VNW);
         r.route();
 
@@ -499,7 +499,7 @@ public class TurnRestrictionTest extends TurnTest {
         r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
-        r.profileRequest.reverseSearch = true;
+        r.reverseSearch = true;
         r.setOrigin(VNW);
         r.route();
 
@@ -521,7 +521,7 @@ public class TurnRestrictionTest extends TurnTest {
 
         StreetRouter.State stateFromN = r.getStateAtVertex(VE);
 
-        LOG.debug("Only via N: VN to VE {}", stateFromN.compactDump(r.profileRequest.reverseSearch));
+        LOG.debug("Only via N: VN to VE {}", stateFromN.compactDump(r.reverseSearch));
         assertFalse(stateContainsVertex(stateFromN, VNW));
 
         r = new StreetRouter(streetLayer);
@@ -531,7 +531,7 @@ public class TurnRestrictionTest extends TurnTest {
         r.route();
 
         StreetRouter.State stateFromCenter = r.getStateAtVertex(VE);
-        LOG.debug("Only via N: VCENTER to VE {}", stateFromCenter.compactDump(r.profileRequest.reverseSearch));
+        LOG.debug("Only via N: VCENTER to VE {}", stateFromCenter.compactDump(r.reverseSearch));
         assertFalse(stateContainsVertex(stateFromCenter, VNW));
 
 
@@ -544,7 +544,7 @@ public class TurnRestrictionTest extends TurnTest {
         r.route();
 
         StreetRouter.State restrictedStateFromN = r.getStateAtVertex(VE);
-        LOG.debug("Only via Restricted: VN to VE {}", restrictedStateFromN.compactDump(r.profileRequest.reverseSearch));
+        LOG.debug("Only via Restricted: VN to VE {}", restrictedStateFromN.compactDump(r.reverseSearch));
 
         // we should be forced to make a U-turn
         assertTrue(restrictedStateFromN.weight > stateFromN.weight);
@@ -557,7 +557,7 @@ public class TurnRestrictionTest extends TurnTest {
 
         // Only U turn should not affect a state starting at the center
         StreetRouter.State restrictedStateFromCenter = r.getStateAtVertex(VE);
-        LOG.debug("Only via Restricted: VCENTER to VE {}", restrictedStateFromCenter.compactDump(r.profileRequest.reverseSearch));
+        LOG.debug("Only via Restricted: VCENTER to VE {}", restrictedStateFromCenter.compactDump(r.reverseSearch));
         assertEquals(stateFromCenter.weight, restrictedStateFromCenter.weight);
 
         // make sure the state from the north goes through VNW as there's an only U turn restriction.
@@ -572,23 +572,23 @@ public class TurnRestrictionTest extends TurnTest {
         StreetRouter r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
-        r.profileRequest.reverseSearch = true;
+        r.reverseSearch = true;
         r.setOrigin(VE);
         r.route();
 
         StreetRouter.State stateFromN = r.getStateAtVertex(VN);
-        LOG.debug("Rev: Only via N: VN to VE {}", stateFromN.compactDump(r.profileRequest.reverseSearch));
+        LOG.debug("Rev: Only via N: VN to VE {}", stateFromN.compactDump(r.reverseSearch));
         assertFalse(stateContainsVertex(stateFromN, VNW));
 
         r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
-        r.profileRequest.reverseSearch = true;
+        r.reverseSearch = true;
         r.setOrigin(VE);
         r.route();
 
         StreetRouter.State stateFromCenter = r.getStateAtVertex(VCENTER);
-        LOG.debug("Rev: Only via N: VCENTER to VE {}", stateFromCenter.compactDump(r.profileRequest.reverseSearch));
+        LOG.debug("Rev: Only via N: VCENTER to VE {}", stateFromCenter.compactDump(r.reverseSearch));
         assertFalse(stateContainsVertex(stateFromCenter, VNW));
 
 
@@ -597,12 +597,12 @@ public class TurnRestrictionTest extends TurnTest {
         r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
-        r.profileRequest.reverseSearch = true;
+        r.reverseSearch = true;
         r.setOrigin(VE);
         r.route();
 
         StreetRouter.State restrictedStateFromN = r.getStateAtVertex(VN);
-        LOG.debug("Rev: Only via Restricted: VN to VE {}", restrictedStateFromN.compactDump(r.profileRequest.reverseSearch));
+        LOG.debug("Rev: Only via Restricted: VN to VE {}", restrictedStateFromN.compactDump(r.reverseSearch));
 
         // we should be forced to make a U-turn
         assertTrue(restrictedStateFromN.weight > stateFromN.weight);
@@ -610,13 +610,13 @@ public class TurnRestrictionTest extends TurnTest {
         r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
-        r.profileRequest.reverseSearch = true;
+        r.reverseSearch = true;
         r.setOrigin(VE);
         r.route();
 
         // Only U turn should not affect a state starting at the center
         StreetRouter.State restrictedStateFromCenter = r.getStateAtVertex(VCENTER);
-        LOG.debug("Rev: Only via Restricted: VCenter to VE {}", restrictedStateFromCenter.compactDump(r.profileRequest.reverseSearch));
+        LOG.debug("Rev: Only via Restricted: VCenter to VE {}", restrictedStateFromCenter.compactDump(r.reverseSearch));
         assertEquals(stateFromCenter.weight, restrictedStateFromCenter.weight);
 
         // make sure the state from the north goes through VNW as there's an only U turn restriction.
@@ -672,7 +672,7 @@ public class TurnRestrictionTest extends TurnTest {
         StreetRouter r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
-        r.profileRequest.reverseSearch = true;
+        r.reverseSearch = true;
         r.setRoutingVisitor(countingVisitor);
         r.setOrigin(VCENTER);
 


### PR DESCRIPTION
Instead of ProfileRequest

Since I wasn't able to make tests for change. I tested with comparing two saved requests.
Times, distances and paths are the same also for Bike rental and P+R.