### PR TITLE
Build transport network without OSM

### DIFF
--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -142,7 +142,7 @@ public class LinkedPointSet implements Serializable {
         while (stopToPointDistanceTables.size() < nStops) stopToPointDistanceTables.add(null);
 
         /* First, link the points in this PointSet to specific street vertices. If there is no base linkage, link all streets. */
-        this.linkPointsToStreets(baseLinkage == null);
+        if (streetLayer.hasOSM) this.linkPointsToStreets(baseLinkage == null);
 
         /* Second, make a table of distances from each transit stop to the points in this PointSet. */
         this.makeStopToPointDistanceTables(treeRebuildZone);

--- a/src/main/java/com/conveyal/r5/streets/RoutingVisitor.java
+++ b/src/main/java/com/conveyal/r5/streets/RoutingVisitor.java
@@ -12,7 +12,7 @@ public interface RoutingVisitor {
     void visitVertex(StreetRouter.State state);
 
     /**
-     * Called right after visitVertex
+     * Called right after {@link #visitVertex}
      *
      * @return true if search should stop
      */

--- a/src/main/java/com/conveyal/r5/transit/TransitLayer.java
+++ b/src/main/java/com/conveyal/r5/transit/TransitLayer.java
@@ -543,14 +543,14 @@ public class TransitLayer implements Serializable, Cloneable {
     /**
      * Perform a single on-street search from the specified transit stop.
      * Return the distance in millimeters to every reached street vertex.
-     * @param stop the internal integer stop ID for which to build a distance table.
+     * @param stopIndex the internal integer stop ID (stop index) for which to build a distance table.
      * @return a map from street vertex numbers to distances in millimeters
      */
-    public TIntIntMap buildOneDistanceTable(int stop) {
-        int originVertex = streetVertexForStop.get(stop);
+    public TIntIntMap buildOneDistanceTable(int stopIndex) {
+        int originVertex = streetVertexForStop.get(stopIndex);
         if (originVertex == -1) {
             // -1 indicates that this stop is not linked to the street network.
-            LOG.warn("Stop {} has not been linked to the street network, cannot build a distance table for it.", stop);
+            LOG.warn("Stop {} has not been linked to the street network, cannot build a distance table for it.", stopIndex);
             return null;
         }
         StreetRouter router = new StreetRouter(parentNetwork.streetLayer);
@@ -594,7 +594,11 @@ public class TransitLayer implements Serializable, Cloneable {
         }
     }
 
-    /** Get a coordinate for a stop in FIXED POINT DEGREES */
+    /**
+     * Get a coordinate for a stop in FIXED POINT DEGREES
+     * @param s stop index
+     * @return Coordinate for stop lat/lon
+     */
     public Coordinate getCoordinateForStopFixed(int s) {
         int v = streetVertexForStop.get(s);
 
@@ -604,7 +608,11 @@ public class TransitLayer implements Serializable, Cloneable {
         return new Coordinate(vertex.getFixedLon(), vertex.getFixedLat());
     }
 
-    /** Get a JTS point for a stop in FIXED POINT DEGREES */
+    /**
+     * Get a JTS point for a stop in FIXED POINT DEGREES
+     * @param s stop index
+     * @return Point for stop coordinate
+     */
     public Point getJTSPointForStopFixed(int s) {
         Coordinate c = getCoordinateForStopFixed(s);
         return c == null ? null : GeometryUtils.geometryFactory.createPoint(c);


### PR DESCRIPTION
We need to be able to build transport networks without OSM for the following use cases:

1. Quick, low resource building of transport networks when r5 is used as a library.
2. Network-based comparison of GTFS feeds without the influence of potential changes in the OSM networks used by each transport network
