### PR TITLE
Update r5 to use the latest gtfs-lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -348,7 +348,7 @@
     <dependency>
       <groupId>com.conveyal</groupId>
       <artifactId>gtfs-lib</artifactId>
-      <version>1.3.1</version>
+      <version>3.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.conveyal</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -348,7 +348,7 @@
     <dependency>
       <groupId>com.conveyal</groupId>
       <artifactId>gtfs-lib</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.conveyal</groupId>


### PR DESCRIPTION
### this will not pass tests/work until `gtfs-lib@v3.0.0` is released

Only changes are to utilize `BaseGTFSCache` instead of `GTFSCache` directly and the new `getFeed` method created in https://github.com/conveyal/gtfs-lib/pull/67.