### PR TITLE
fix(pointsets) allow points outside base pointset

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/WebMercatorGridPointSet.java
+++ b/src/main/java/com/conveyal/r5/analyst/WebMercatorGridPointSet.java
@@ -60,10 +60,6 @@ public class WebMercatorGridPointSet extends PointSet implements Serializable {
         // TODO don't copy, just have a cache that lazy loads and crops from base pointset
         if (base != null) {
             base.linkageCache.asMap().forEach((key, baseLinkage) -> {
-                // TODO handle the case where the new grid is not completely contained by the base grid.
-                // Since this generally will happen when there are points beyond the transit network, just leaving the points
-                // that are not contained by the base linkage unlinked (and logging a warning, or perhaps even returning a
-                // warning to the UI) should be completely sufficient as you will not be able to reach these locations anyhow.
                 LinkedPointSet croppedLinkage = new LinkedPointSet(baseLinkage, this);
                 this.linkageCache.put(key, croppedLinkage);
             });


### PR DESCRIPTION
Addresses a small todo from https://github.com/conveyal/r5/pull/298/commits/9083021e19aeeb10fe8e16e7c38b41d51dacd701, by allowing sub-grids (based on user-defined project bounds) to extend beyond base super-grids (based on TransportNetwork extents).

Not sure if the distance arrays should be filled with `MAX_OFFSTREET_WALK_METERS` or something else.

It might be good to eventually send warnings like at LOC 171 to the front-end, as is currently done for some modification warnings.