### PR TITLE
fix(pointsets) allow points outside base pointset

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/WebMercatorGridPointSet.java
+++ b/src/main/java/com/conveyal/r5/analyst/WebMercatorGridPointSet.java
@@ -60,6 +60,10 @@ public class WebMercatorGridPointSet extends PointSet implements Serializable {
         // TODO don't copy, just have a cache that lazy loads and crops from base pointset
         if (base != null) {
             base.linkageCache.asMap().forEach((key, baseLinkage) -> {
+                // LinkedPointSet now handles the case where the new grid is not completely contained by the base grid.
+                // Since this generally happens when there are points beyond the transit network's extents, marking the points
+                // that are not contained by the base linkage as unlinked (and logging a warning if all points are beyond
+                // the network) is sufficient as you will not be able to reach these locations anyhow.
                 LinkedPointSet croppedLinkage = new LinkedPointSet(baseLinkage, this);
                 this.linkageCache.put(key, croppedLinkage);
             });

--- a/src/main/java/com/conveyal/r5/analyst/WebMercatorGridPointSet.java
+++ b/src/main/java/com/conveyal/r5/analyst/WebMercatorGridPointSet.java
@@ -60,10 +60,6 @@ public class WebMercatorGridPointSet extends PointSet implements Serializable {
         // TODO don't copy, just have a cache that lazy loads and crops from base pointset
         if (base != null) {
             base.linkageCache.asMap().forEach((key, baseLinkage) -> {
-                // TODO handle the case where the new grid is not completely contained by the base grid.
-                // Since this generally will happen when there are points beyond the transit network, just leaving the points
-                // that are not contained by the base linkage unlinked (and logging a warning, or perhaps even returning a
-                // warning to the UI) should be completely sufficient as you will not be able to reach these locations anyhow.
                 LinkedPointSet croppedLinkage = new LinkedPointSet(baseLinkage, this);
                 this.linkageCache.put(key, croppedLinkage);
             });

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -188,9 +188,9 @@ public class LinkedPointSet implements Serializable {
                 int sourceColumn = subGrid.west + x - superGrid.west;
                 int sourceRow = subGrid.north + y - superGrid.north;
                 if (sourceColumn < 0 || sourceColumn >= superGrid.width || sourceRow < 0 || sourceRow >= superGrid.height) { //point is outside super-grid
-                    edges[pixel] = -1; //set the edge value to -1 to indicate no linkage.
-                    distances0_mm[pixel] = MAX_OFFSTREET_WALK_METERS;
-                    distances1_mm[pixel] = MAX_OFFSTREET_WALK_METERS;
+                    //Set the edge value to -1 to indicate no linkage.
+                    //Distances should never be read downstream, so they don't need to be set here.
+                    edges[pixel] = -1;
                 } else { //point is inside super-grid
                     int sourcePixel = sourceRow * superGrid.width + sourceColumn;
                     edges[pixel] = sourceLinkage.edges[sourcePixel];

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -193,7 +193,6 @@ public class LinkedPointSet implements Serializable {
                     distances1_mm[pixel] = MAX_OFFSTREET_WALK_METERS;
                 } else { //point is inside super-grid
                     int sourcePixel = sourceRow * superGrid.width + sourceColumn;
-                    LOG.info(Integer.toString(sourcePixel));
                     edges[pixel] = sourceLinkage.edges[sourcePixel];
                     distances0_mm[pixel] = sourceLinkage.distances0_mm[sourcePixel];
                     distances1_mm[pixel] = sourceLinkage.distances1_mm[sourcePixel];

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -164,9 +164,11 @@ public class LinkedPointSet implements Serializable {
         if (superGrid.zoom != subGrid.zoom) {
             throw new IllegalArgumentException("Source and sub-grid zoom level do not match.");
         }
-        if (superGrid.west > subGrid.west || superGrid.west + superGrid.width < subGrid.west + subGrid.width ||
-            superGrid.north > subGrid.north || superGrid.north + superGrid.height < subGrid.north + subGrid.height) {
-            throw new IllegalArgumentException("Sub-grid must lie fully inside the super-grid.");
+        if (subGrid.west + subGrid.width < superGrid.west //sub-grid is entirely west of super-grid
+                || superGrid.west + superGrid.width < subGrid.west // super-grid is entirely west of sub-grid
+                || subGrid.north + subGrid.height < superGrid.north //sub-grid is entirely north of super-grid (note Web Mercator conventions)
+                || superGrid.north + superGrid.height < subGrid.north ) { //super-grid is entirely north of sub-grid
+            LOG.warn("Sub-grid is entirely outside the super-grid.  Points will not be linked to any street edges.");
         }
 
         // Initialize the fields of the new LinkedPointSet instance
@@ -185,10 +187,17 @@ public class LinkedPointSet implements Serializable {
             for (int x = 0; x < subGrid.width; x++, pixel++) {
                 int sourceColumn = subGrid.west + x - superGrid.west;
                 int sourceRow = subGrid.north + y - superGrid.north;
-                int sourcePixel = sourceRow * superGrid.width + sourceColumn;
-                edges[pixel] = sourceLinkage.edges[sourcePixel];
-                distances0_mm[pixel] = sourceLinkage.distances0_mm[sourcePixel];
-                distances1_mm[pixel] = sourceLinkage.distances1_mm[sourcePixel];
+                if (sourceColumn < 0 || sourceColumn >= superGrid.width || sourceRow < 0 || sourceRow >= superGrid.height) { //point is outside super-grid
+                    edges[pixel] = -1; //set the edge value to -1 to indicate no linkage.
+                    distances0_mm[pixel] = MAX_OFFSTREET_WALK_METERS;
+                    distances1_mm[pixel] = MAX_OFFSTREET_WALK_METERS;
+                } else { //point is inside super-grid
+                    int sourcePixel = sourceRow * superGrid.width + sourceColumn;
+                    LOG.info(Integer.toString(sourcePixel));
+                    edges[pixel] = sourceLinkage.edges[sourcePixel];
+                    distances0_mm[pixel] = sourceLinkage.distances0_mm[sourcePixel];
+                    distances1_mm[pixel] = sourceLinkage.distances1_mm[sourcePixel];
+                }
             }
         }
 


### PR DESCRIPTION
Addresses a small todo from 9083021, by allowing sub-grids (based on user-defined project bounds) to extend beyond base super-grids (based on TransportNetwork extents).

Not sure if the distance arrays should be filled with MAX_OFFSTREET_WALK_METERS or something else.

It might be good to eventually send warnings like at LOC 171 to the front-end, as is currently done for some modification warnings.