### PR TITLE
Speedier rasterization

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/Grid.java
+++ b/src/main/java/com/conveyal/r5/analyst/Grid.java
@@ -49,6 +49,7 @@ import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -169,7 +170,7 @@ public class Grid {
      * Version of getPixelWeights which returns the weights as relative to the total area of the input geometry (i.e.
      * the weight at a pixel is the proportion of the input geometry that falls within that pixel.
      */
-    public ArrayList<PixelWeight> getPixelWeights (Geometry geometry) {
+    public List<PixelWeight> getPixelWeights (Geometry geometry) {
         return getPixelWeights(geometry, false, null);
     }
 
@@ -185,13 +186,13 @@ public class Grid {
      * This used to return a map from int arrays containing the coordinates to the weight.
      *
      */
-    private ArrayList<PixelWeight> getPixelWeights (Geometry geometry, boolean relativeToPixels, PixelWeightCallback pixelWeightCallback) {
+    private List<PixelWeight> getPixelWeights (Geometry geometry, boolean relativeToPixels, PixelWeightCallback pixelWeightCallback) {
         // No need to convert to a local coordinate system
         // Both the supplied polygon and the web mercator pixel geometries are left in WGS84 geographic coordinates.
         // Both are distorted equally along the X axis at a given latitude so the proportion of the geometry within
         // each pixel is accurate, even though the surface area in WGS84 coordinates is not a usable value.
 
-        ArrayList<PixelWeight> weights = new ArrayList<>();
+        List<PixelWeight> weights = new ArrayList<>();
 
         double area = geometry.getArea();
         if (area < 1e-12) {
@@ -254,7 +255,7 @@ public class Grid {
     }
 
     /** Using a grid of weights produced by getPixelWeights, burn the value of a polygon into the grid */
-    public void incrementFromPixelWeights (ArrayList weights, double value) {
+    public void incrementFromPixelWeights (List weights, double value) {
         Iterator<PixelWeight> pixelWeightIterator = weights.iterator();
         while(pixelWeightIterator.hasNext()) {
             PixelWeight pix = pixelWeightIterator.next();

--- a/src/main/java/com/conveyal/r5/analyst/Grid.java
+++ b/src/main/java/com/conveyal/r5/analyst/Grid.java
@@ -658,7 +658,7 @@ public class Grid {
 
             if (statusListener != null) statusListener.accept(currentCount, total);
 
-            if (currentCount % 100 == 0) {
+            if (currentCount % 10000 == 0) {
                 LOG.info("{} / {} features read", human(currentCount), human(total));
             }
         });

--- a/src/main/java/com/conveyal/r5/analyst/Grid.java
+++ b/src/main/java/com/conveyal/r5/analyst/Grid.java
@@ -233,7 +233,11 @@ public class Grid {
                 }
             }
         }
-        return weights;
+        if (pixelWeightCallback == null){
+            return weights;
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/com/conveyal/r5/analyst/Grid.java
+++ b/src/main/java/com/conveyal/r5/analyst/Grid.java
@@ -13,7 +13,6 @@ import com.vividsolutions.jts.geom.Point;
 import com.vividsolutions.jts.geom.Polygon;
 import com.vividsolutions.jts.geom.prep.PreparedGeometry;
 import com.vividsolutions.jts.geom.prep.PreparedGeometryFactory;
-import com.vividsolutions.jts.geom.prep.PreparedPolygon;
 import org.apache.commons.math3.util.FastMath;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.grid.GridCoverageFactory;
@@ -196,7 +195,7 @@ public class Grid {
             // Iterate over longitude (x) in the inner loop to avoid repeat calculations of pixel areas, which should be
             // equal at a given latitude (y)
 
-            double pixelAreaAtLat = -1; //Set to -1 to recalculate for each latitude.
+            double pixelAreaAtLat = -1; //Set to -1 to recalculate pixelArea at each latitude.
 
             for (int worldx = lonToPixel(env.getMinX(), zoom); worldx <= lonToPixel(env.getMaxX(), zoom); worldx++) {
 
@@ -209,16 +208,11 @@ public class Grid {
 
                 if (pixelAreaAtLat == -1) pixelAreaAtLat = pixel.getArea(); //Recalculate for a new latitude.
 
-                if (preparedGeom.overlaps(pixel)){ // pixel is partly inside the feature; note JTS definition of overlaps
+                if (preparedGeom.intersects(pixel)){ // pixel is at least partly inside the feature
                     Geometry intersection = pixel.intersection(geometry);
                     double denominator = relativeToPixels ? pixelAreaAtLat : area;
                     double weight = intersection.getArea() / denominator;
                     weights.add(new PixelWeight(x, y, weight));
-                } else if (preparedGeom.contains(pixel)) { // pixel is completely inside the feature
-                    double weight = relativeToPixels ? 1 : pixelAreaAtLat/area;
-                    weights.add(new PixelWeight(x,y,weight));
-                } else { //pixel is outside the feature
-                    weights.add(new PixelWeight(x,y,0));
                 }
             }
         }

--- a/src/main/java/com/conveyal/r5/analyst/Grid.java
+++ b/src/main/java/com/conveyal/r5/analyst/Grid.java
@@ -169,13 +169,19 @@ public class Grid {
     private PreparedGeometryFactory pgFact = new PreparedGeometryFactory();
 
     /**
-     * Get the proportions of an input polygon feature that overlap each grid cell, for use in List(x, y, weight)
-     * These weight lists can then be fed into the incrementFromPixelWeights function to actually burn a polygon into the
+     * Get the proportions of an input polygon feature that overlap each grid cell, for use in lists of PixelWeights.
+     * These lists can then be fed into the incrementFromPixelWeights function to actually burn a polygon into the
      * grid.
      *
      * If relativeToPixels is true, the weights are the proportion of the pixel that is covered. Otherwise they are the
      * portion of this polygon which is within the given pixel. If using incrementPixelWeights, this should be set to
      * false.
+     *
+     * This is an internal private method, called by two different public methods with different signatures,
+     * streamPixelWeights or getPixelWeights above.
+     *
+     * streamPixelWeights includes a callback function, which is called for each pixel.  This function then returns null.
+     * The public getPixelWeights calls this function with a null callback, so this function returns the weights.
      *
      * This used to return a map from int arrays containing the coordinates to the weight.
      *

--- a/src/main/java/com/conveyal/r5/analyst/Grid.java
+++ b/src/main/java/com/conveyal/r5/analyst/Grid.java
@@ -128,24 +128,14 @@ public class Grid {
     }
 
     public static class PixelWeight {
-        int x;
-        int y;
-        double weight;
+        final int x;
+        final int y;
+        final double weight;
 
         private PixelWeight (int x, int y, double weight){
             this.x = x;
             this.y = y;
             this.weight = weight;
-        }
-
-        public int getX() {
-            return x;
-        }
-        public int getY() {
-            return y;
-        }
-        public double getWeight() {
-            return weight;
         }
     }
 

--- a/src/main/java/com/conveyal/r5/analyst/Grid.java
+++ b/src/main/java/com/conveyal/r5/analyst/Grid.java
@@ -159,10 +159,7 @@ public class Grid {
     }
 
     /**
-     *
-     * @param geometry
-     * @param relativeToPixels
-     * @param pixelWeightCallback
+     * Stream pixel weights using a callback, rather than keeping them in memory.
      */
     public void streamPixelWeights (Geometry geometry, boolean relativeToPixels, PixelWeightCallback pixelWeightCallback) {
         getPixelWeights(geometry, relativeToPixels, pixelWeightCallback);
@@ -233,6 +230,8 @@ public class Grid {
                     double weight = intersection.getArea() / denominator;
                     if (pixelWeightCallback == null){
                         weights.add(new PixelWeight(x, y, weight));
+                    } else {
+                        pixelWeightCallback.handlePixelWeight(x,y,weight);
                     }
                 }
             }

--- a/src/main/java/com/conveyal/r5/analyst/Grid.java
+++ b/src/main/java/com/conveyal/r5/analyst/Grid.java
@@ -164,6 +164,10 @@ public class Grid {
         return getPixelWeights(geometry, false, null);
     }
 
+    // PreparedGeometry is often faster for small numbers of vertices;
+    // see https://github.com/chrisbennight/intersection-test
+    private PreparedGeometryFactory pgFact = new PreparedGeometryFactory();
+
     /**
      * Get the proportions of an input polygon feature that overlap each grid cell, for use in List(x, y, weight)
      * These weight lists can then be fed into the incrementFromPixelWeights function to actually burn a polygon into the
@@ -189,10 +193,6 @@ public class Grid {
             throw new IllegalArgumentException("Geometry is too small");
         }
 
-        // PreparedGeometry is often faster for small numbers of vertices;
-        // see https://github.com/chrisbennight/intersection-test
-
-        PreparedGeometryFactory pgFact = new PreparedGeometryFactory();
         PreparedGeometry preparedGeom = pgFact.create(geometry);
 
         Envelope env = geometry.getEnvelopeInternal();


### PR DESCRIPTION
I've tried to follow some suggestions in the code related to #315, but it doesn't seem that this initial work actually speeds things up -- the geotools implementation of intersection may already do what I've tried to here.

Using Lists will require changes to AggregationAreaController and SeamlessCensusGridExtractor in analysis-backend (on the speedier-rasterization branch).