### PR TITLE
Allow exact-times to be false

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>com.conveyal</groupId>
   <artifactId>r5</artifactId>
-  <version>3.3.0-SNAPSHOT</version>
+  <version>4.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>

--- a/src/main/java/com/conveyal/r5/profile/FastRaptorWorker.java
+++ b/src/main/java/com/conveyal/r5/profile/FastRaptorWorker.java
@@ -445,6 +445,10 @@ public class FastRaptorWorker {
     /** Do a frequency search. If computeDeterministicUpperBound is true, worst-case frequency boarding time will be used
      * so that the output of this function can be used in a range-RAPTOR search. Otherwise Monte Carlo schedules will be
      * used to improve upon the output of the range-RAPTOR bounds search.
+     *
+     * @param computeDeterministicUpperBound specifies whether to compute a deterministic upper bound, which helps speed up
+     *                                       subsequent frequency searches. If false, a bona fide frequency search is conducted
+     *                                       using randomized offsets.
      */
     private void doFrequencySearchForRound(RaptorState inputState, RaptorState outputState, boolean computeDeterministicUpperBound) {
         BitSet patternsTouched = getPatternsTouchedForStops(inputState, frequencyIndexForOriginalPatternIndex);
@@ -461,9 +465,6 @@ public class FastRaptorWorker {
 
                 for (int frequencyEntryIdx = 0; frequencyEntryIdx < schedule.headwaySeconds.length; frequencyEntryIdx++) {
                     int originalPatternIndex = originalPatternIndexForFrequencyIndex[patternIndex];
-
-                    int offset = computeDeterministicUpperBound ? -1 : offsets.offsets.get(originalPatternIndex)[tripScheduleIndex][frequencyEntryIdx];
-                    // offset is reset below (i.e. when computeDeterministicUpperBound is false). Otherwise it should not be used.
 
                     int boardTime = -1;
                     int boardStopPositionInPattern = -1;
@@ -488,9 +489,15 @@ public class FastRaptorWorker {
                             // if we're computing the upper bound, we want the worst case. This is the only thing that is
                             // valid in a range RAPTOR search; using random schedule draws in range RAPTOR would be problematic
                             // because they need to be independent across minutes.
-                            int newBoardingDepartureTimeAtStop = computeDeterministicUpperBound ?
-                                getWorstCaseFrequencyDepartureTime(schedule, stopPositionInPattern, frequencyEntryIdx, earliestBoardTime) :
-                                getRandomFrequencyDepartureTime(schedule, stopPositionInPattern, offset, frequencyEntryIdx, earliestBoardTime);
+
+                            int newBoardingDepartureTimeAtStop;
+
+                            if (computeDeterministicUpperBound) {
+                                newBoardingDepartureTimeAtStop = getWorstCaseFrequencyDepartureTime(schedule, stopPositionInPattern, frequencyEntryIdx, earliestBoardTime);
+                            } else {
+                                int offset = offsets.offsets.get(originalPatternIndex)[tripScheduleIndex][frequencyEntryIdx];
+                                newBoardingDepartureTimeAtStop = getRandomFrequencyDepartureTime(schedule, stopPositionInPattern, offset, frequencyEntryIdx, earliestBoardTime);
+                            }
 
                             int remainOnBoardDepartureTimeAtStop = Integer.MAX_VALUE;
 

--- a/src/main/java/com/conveyal/r5/profile/FastRaptorWorker.java
+++ b/src/main/java/com/conveyal/r5/profile/FastRaptorWorker.java
@@ -461,7 +461,9 @@ public class FastRaptorWorker {
 
                 for (int frequencyEntryIdx = 0; frequencyEntryIdx < schedule.headwaySeconds.length; frequencyEntryIdx++) {
                     int originalPatternIndex = originalPatternIndexForFrequencyIndex[patternIndex];
-                    int offset = offsets.offsets.get(originalPatternIndex)[tripScheduleIndex][frequencyEntryIdx];
+
+                    int offset = computeDeterministicUpperBound ? -1 : offsets.offsets.get(originalPatternIndex)[tripScheduleIndex][frequencyEntryIdx];
+                    // offset is reset below (i.e. when computeDeterministicUpperBound is false). Otherwise it should not be used.
 
                     int boardTime = -1;
                     int boardStopPositionInPattern = -1;


### PR DESCRIPTION
Small bugfix (for #290).

Also bump version number (unrelated to this bugfix; should have been done on the previously merged speedier-rasterization branch)