### PR TITLE
Island pruning

### DIFF
--- a/src/main/java/com/conveyal/r5/streets/EdgeStore.java
+++ b/src/main/java/com/conveyal/r5/streets/EdgeStore.java
@@ -213,7 +213,7 @@ public class EdgeStore implements Serializable {
         NO_THRU_TRAFFIC_BIKE (11),
         NO_THRU_TRAFFIC_CAR (12),
         SLOPE_OVERRIDE (13),
-        /** Link edge, two should not be traversed one-after-another FIXME comment seems incorrect */
+        /** An edge that links a transit stop to the street network; two such edges should not be traversed consecutively. */
         LINK (14),
 
         // Permissions

--- a/src/main/java/com/conveyal/r5/streets/TarjanIslandPruner.java
+++ b/src/main/java/com/conveyal/r5/streets/TarjanIslandPruner.java
@@ -186,13 +186,13 @@ public class TarjanIslandPruner {
                         // a relatively large (metropolitan Washington, DC) graph.
                         forEachOutgoingEdge(vertex, e -> {
                             int toVertex = e.getToVertex();
-                            if (discoveryIndex[toVertex] > discoveryIndex[vertex]) {
-                                // only update if the to vertex was discovered later than the vertex under consideration
+                            if (discoveryIndex[toVertex] == -1) everySuccessorExplored[0] = false;
+                            if (discoveryIndex[toVertex] > discoveryIndex[vertex] &&
+                                    lowestDiscoveryIndexOfReachableVertexKnownToBePredecessor[vertex] > lowestDiscoveryIndexOfReachableVertexKnownToBePredecessor[toVertex])
+                                // only update if toVertex was discovered later than the vertex under consideration
                                 // i.e. if it was explored downstream of this vertex.
                                 // We don't want to accidentally set lowestDiscoveryIndexOfReachableVertexKnownToBePredecessor to something that is not a predecessor of this vertex
-                                if (discoveryIndex[toVertex] == -1) everySuccessorExplored[0] = false;
-                                else if (lowestDiscoveryIndexOfReachableVertexKnownToBePredecessor[vertex] > lowestDiscoveryIndexOfReachableVertexKnownToBePredecessor[toVertex]) lowestDiscoveryIndexOfReachableVertexKnownToBePredecessor[vertex] = lowestDiscoveryIndexOfReachableVertexKnownToBePredecessor[toVertex];
-                            }
+                                lowestDiscoveryIndexOfReachableVertexKnownToBePredecessor[vertex] = lowestDiscoveryIndexOfReachableVertexKnownToBePredecessor[toVertex];
                         });
 
                         // this is the root of a strong component if every successor has been explored and the lowest reachable


### PR DESCRIPTION
This PR addresses the original problem identified in #335 (though subsequent posts in that thread may be related to other issues).

Strong components ("islands") were being falsely identified for cars, resulting in edges being removed even though they were well connected to the whole network.

When looping through vertices, a boolean `everySuccessorExplored` is initialized as true.  Then, `if (discoveryIndex[toVertex] == -1) everySuccessorExplored[0] = false` resets this boolean to false if there are more successors to explore.  Previously, this was nested inside `if (discoveryIndex[toVertex] > discoveryIndex[vertex])`, which is often false because the `discoveryIndex` for each vertex is initialized as -1.  So a given vertex _v_ could be left with `everySuccessorExplored = true`, even if not every successor had actually been explored.  If an unexplored successor to _v_ was the only link to the sourceVertex (root), then _v_ itself would be considered the root, leading a strongComponent to be identified.

Pulling the `if (discoveryIndex[toVertex] == -1) everySuccessorExplored[0] = false` out of the if clause it had been in leads to the expected network, without edges spuriously removed:

![image](https://user-images.githubusercontent.com/2173529/33092263-a05a91bc-cec7-11e7-8792-a4f7e68b96f0.png)
