### PR TITLE
Reduce memory consumption in broker

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/BootstrappingTravelTimeReducer.java
+++ b/src/main/java/com/conveyal/r5/analyst/BootstrappingTravelTimeReducer.java
@@ -94,7 +94,7 @@ import java.util.stream.DoubleStream;
  */
 public class BootstrappingTravelTimeReducer implements PerTargetPropagater.TravelTimeReducer {
     /** The number of bootstrap replications used to bootstrap the sampling distribution of the percentiles */
-    public static final int N_BOOTSTRAP_REPLICATIONS = 1000;
+    public static final int N_BOOTSTRAP_REPLICATIONS = 0;
 
     /** SQS client. TODO: async? */
     private static final AmazonSQS sqs = new AmazonSQSClient();

--- a/src/main/java/com/conveyal/r5/analyst/broker/Broker.java
+++ b/src/main/java/com/conveyal/r5/analyst/broker/Broker.java
@@ -675,6 +675,10 @@ public class Broker implements Runnable {
             return false;
         }
         job.completedTasks.add(taskId);
+        // Once the last task is marked as completed, the job is finished. Purge it from the list to free memory.
+        if (job.isComplete()) {
+            jobs.remove(job);
+        }
         return true;
     }
 

--- a/src/main/java/com/conveyal/r5/analyst/broker/Broker.java
+++ b/src/main/java/com/conveyal/r5/analyst/broker/Broker.java
@@ -5,7 +5,9 @@ import com.amazonaws.regions.Region;
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.AmazonEC2Client;
 import com.amazonaws.services.ec2.model.*;
+import com.conveyal.r5.analyst.Grid;
 import com.conveyal.r5.analyst.cluster.AnalysisTask;
+import com.conveyal.r5.analyst.cluster.RegionalTask;
 import com.conveyal.r5.common.JsonUtilities;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ArrayListMultimap;
@@ -291,25 +293,40 @@ public class Broker implements Runnable {
         notify();
     }
 
-    /** Enqueue some tasks for queued execution possibly much later. Results will be saved to S3. */
-    public synchronized void enqueueTasks (List<AnalysisTask> tasks) {
-        Job job = findJob(tasks.get(0)); // creates one if it doesn't exist
+    /**
+     * Enqueue a set of tasks for a regional analysis.
+     * Only a single task is passed in, and the broker expands it into all the individual tasks for a regional job.
+     */
+    public synchronized void enqueueTasksForRegionalJob(RegionalTask templateTask) {
+
+        if (findJob(templateTask.jobId) != null) {
+            LOG.error("Someone tried to enqueue job {} but it already exists.", templateTask.jobId);
+            throw new RuntimeException("Enqueued duplicate job " + templateTask.jobId);
+        }
+        Job job = new Job(templateTask.jobId);
+        job.workerCategory = new WorkerCategory(templateTask.graphId, templateTask.workerVersion);
+        jobs.insertAtTail(job);
 
         if (!workersAvailable(job.getWorkerCategory())) {
             createWorkersInCategory(job.getWorkerCategory());
         }
 
-        for (AnalysisTask task : tasks) {
-            task.taskId = nextTaskId++;
-            job.addTask(task);
-            LOG.debug("Enqueued task id {} in job {}", task.taskId, job.jobId);
-            if (!task.graphId.equals(job.workerCategory.graphId)) {
-                LOG.error("Task graph ID {} does not match job: {}.", task.graphId, job.workerCategory);
-            }
-            if (!task.workerVersion.equals(job.workerCategory.workerVersion)) {
-                LOG.error("Task R5 commit {} does not match job: {}.", task.workerVersion, job.workerCategory);
+        // Now explode this single task into width * height individual tasks for the whole regional origin grid.
+        // All these tasks are accumulated into the new job. Because the tasks are clones, any referenced objects
+        // such as scenarios should be shared, which reduces memory use.
+        // Of course the fact that the tasks are stored as separate objects at all can eventually be optimized away.
+        for (int x = 0; x < templateTask.width; x++) {
+            for (int y = 0; y < templateTask.height; y++) {
+                RegionalTask singleTask = templateTask.clone();
+                singleTask.taskId = nextTaskId++;
+                singleTask.x = x;
+                singleTask.y = y;
+                singleTask.fromLat = Grid.pixelToCenterLat(templateTask.north + y, templateTask.zoom);
+                singleTask.fromLon = Grid.pixelToCenterLon(templateTask.west + x, templateTask.zoom);
+                job.addTask(singleTask);
             }
         }
+        LOG.info("Broker expanded and enqueued {} tasks for job {}.", job.tasksById.size(), job.jobId);
         // Wake up the delivery thread if it's waiting on input.
         // This wakes whatever thread called wait() while holding the monitor for this Broker object.
         notify();
@@ -704,18 +721,6 @@ public class Broker implements Runnable {
                 return;
             }
         }
-    }
-
-    /** Find the job that should contain a given task, creating that job if it does not exist. */
-    public Job findJob (AnalysisTask task) {
-        Job job = findJob(task.jobId);
-        if (job != null) {
-            return job;
-        }
-        job = new Job(task.jobId);
-        job.workerCategory = new WorkerCategory(task.graphId, task.workerVersion);
-        jobs.insertAtTail(job);
-        return job;
     }
 
     /** Find the job for the given jobId, returning null if that job does not exist. */

--- a/src/main/java/com/conveyal/r5/analyst/broker/Job.java
+++ b/src/main/java/com/conveyal/r5/analyst/broker/Job.java
@@ -24,8 +24,6 @@ public class Job {
 
     public static final int REDELIVERY_QUIET_PERIOD_MSEC = 60 * 1000;
 
-    public static final int MAX_REDELIVERIES = 2;
-
     /* A unique identifier for this job, usually a random UUID. */
     public final String jobId;
 

--- a/src/main/java/com/conveyal/r5/common/Util.java
+++ b/src/main/java/com/conveyal/r5/common/Util.java
@@ -1,0 +1,29 @@
+package com.conveyal.r5.common;
+
+/**
+ * Created by abyrd on 2017-11-29
+ */
+public abstract class Util {
+
+    public static String human (double n, String units) {
+        String prefix = "";
+        if (n > 1024) {
+            n /= 1024;
+            prefix = "ki";
+        }
+        if (n > 1024) {
+            n /= 1024;
+            prefix = "Mi";
+        }
+        if (n > 1024) {
+            n /= 1024;
+            prefix = "Gi";
+        }
+        if (n > 1024) {
+            n /= 1024;
+            prefix = "Ti";
+        }
+        return String.format("%1.1f %s%s", n, prefix, units);
+    }
+
+}


### PR DESCRIPTION
This PR addresses conveyal/analysis-backend#79 and a major memory leak #318.
It changes the way the broker works, so that regional analyses are enqueued as a single template task that the broker expands into a set of tasks, one for each gridded origin point. Those all share references to any more complex data structures so they use a lot less memory. We've also gone back to workers fetching their scenarios from S3 instead of passing the full scenario text in the tasks.

We have been running this for about one day, and in that time have run quite a few very large regional analyses using this new code. Memory usage is drastically lower and does not expand over time.

Note that this *changes the HTTP API of the broker* and therefore using this new code as the analysis broker requires corresponding changes in the analysis-backend, which I'm also submitting as a PR.