### PR TITLE
Fix car linking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install: true
 # Decrypt and import the artifact signing certificate before running the build
 before_install: |
   # only install signing keys under the same circumstances we do a mvn deploy later
-  if [[ "$TRAVIS_PULL_REQUEST" = false ]] && [[ "$TRAVIS_BRANCH" = master || ! -z "$TRAVIS_TAG" ]]; then
+  if [[ "$TRAVIS_PULL_REQUEST" = false ]] && [[ "$TRAVIS_BRANCH" = master || "$TRAVIS_BRANCH" = dev || ! -z "$TRAVIS_TAG" ]]; then
     openssl aes-256-cbc -K $encrypted_e5d28768eb0e_key -iv $encrypted_e5d28768eb0e_iv -in maven-artifact-signing-key.asc.enc -out maven-artifact-signing-key.asc -d
     gpg --import --batch maven-artifact-signing-key.asc
   fi
@@ -20,7 +20,7 @@ before_install: |
 # Run all Maven phases at once up through verify, install, and deploy.
 script: |
   # only (attempt to) deploy non-pull request commits to the master branch or to tags
-  if [[ "$TRAVIS_PULL_REQUEST" = false ]] && [[ "$TRAVIS_BRANCH" = master || ! -z "$TRAVIS_TAG" ]]; then
+  if [[ "$TRAVIS_PULL_REQUEST" = false ]] && [[ "$TRAVIS_BRANCH" = master || "$TRAVIS_BRANCH" = dev || ! -z "$TRAVIS_TAG" ]]; then
     mvn clean deploy --settings maven-settings.xml
   else
     # Otherwise, just run all the way up to verify, the last phase before installing and deploying.

--- a/src/main/java/com/conveyal/r5/analyst/TravelTimeComputer.java
+++ b/src/main/java/com/conveyal/r5/analyst/TravelTimeComputer.java
@@ -76,8 +76,8 @@ public class TravelTimeComputer {
         sr.streetMode = accessMode;
         boolean foundOriginPoint = sr.setOrigin(request.fromLat, request.fromLon);
         if (!foundOriginPoint) {
-            // Short circuit around routing and propagation.
-            // Calling finish() before streaming in any travel times to destinations is designed to produce the right result here.
+            // Short circuit around routing and propagation. Calling finish() before streaming in any travel times to
+            // destinations is designed to produce the right result here.
             LOG.info("Origin point was outside the transport network. Skipping routing and propagation, and returning default result.");
             travelTimeReducer.finish();
             return;

--- a/src/main/java/com/conveyal/r5/analyst/broker/Broker.java
+++ b/src/main/java/com/conveyal/r5/analyst/broker/Broker.java
@@ -153,9 +153,7 @@ public class Broker implements Runnable {
 
         this.brokerConfig = brokerConfig;
 
-        Boolean workOffline = Boolean.parseBoolean(brokerConfig.getProperty("work-offline"));
-        if (workOffline == null) workOffline = true;
-        this.workOffline = workOffline;
+        this.workOffline = Boolean.parseBoolean(brokerConfig.getProperty("work-offline", "true"));
 
         if (!workOffline) {
             // create a config for the AWS workers

--- a/src/main/java/com/conveyal/r5/analyst/broker/Broker.java
+++ b/src/main/java/com/conveyal/r5/analyst/broker/Broker.java
@@ -204,9 +204,10 @@ public class Broker implements Runnable {
 
     /**
      * Enqueue a task for execution ASAP, planning to return the response over the same HTTP connection.
-     * Low-reliability, no re-delivery.
-     *
-     * Returns true if the task was delivered and the caller should suspend the response.
+     * For now this is used exclusively for single-point travel time requests.
+     * Low-reliability, no re-delivery in case of failure (unlike regional batch jobs).
+     * @return true if the task was delivered for processing and the caller should hold the connection open waiting
+     * for a response, false if the task cannot be processed at the moment because workers are not yet available.
      */
     public synchronized boolean enqueuePriorityTask (AnalysisTask task, Response response) {
         boolean workersAvailable = workersAvailable(task.getWorkerCategory());
@@ -224,8 +225,7 @@ public class Broker implements Runnable {
                 LOG.error("Could not finish high-priority task, 202 response", e);
             }
         }
-
-        // if we're in offline mode, enqueue anyhow to kick the cluster to build the graph
+        // If we're in offline mode, enqueue anyhow to kick the cluster to build the graph
         // note that this will mean that requests get delivered multiple times in offline mode,
         // so some unnecessary computation takes place
         if (workersAvailable || workOffline) {
@@ -243,10 +243,8 @@ public class Broker implements Runnable {
                 }
             }, 100);
         }
-
-        // do not notify task delivery thread just yet as we haven't put anything in the task delivery queue yet.
-
-        // if workers were available, the caller should wait. Otherwise just return the 202
+        // Do not notify task delivery thread just yet as we haven't put anything in the task delivery queue yet.
+        // If workers were available, the caller should wait. Otherwise just return the 202.
         return workersAvailable;
     }
 

--- a/src/main/java/com/conveyal/r5/analyst/broker/Broker.java
+++ b/src/main/java/com/conveyal/r5/analyst/broker/Broker.java
@@ -143,9 +143,12 @@ public class Broker implements Runnable {
      */
     private TObjectLongMap<WorkerCategory> recentlyRequestedWorkers = new TObjectLongHashMap<>();
 
-    // Queue of tasks to complete Delete, Enqueue etc. to avoid synchronizing all the functions ?
+    // Queue of tasks to complete Delete, Enqueue etc. to avoid synchronizing all the functions?
+    // The synchronization doesn't seem to currently be causing any problematic contention.
     public Broker (Properties brokerConfig, String addr, int port) {
+
         // print out date on startup so that CloudWatch logs has a unique fingerprint
+        // TODO clarify how printing out a date creates a "unique fingerprint"
         LOG.info("Analyst broker starting at {}", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
 
         this.brokerConfig = brokerConfig;

--- a/src/main/java/com/conveyal/r5/analyst/broker/Job.java
+++ b/src/main/java/com/conveyal/r5/analyst/broker/Job.java
@@ -64,6 +64,9 @@ public class Job {
     /**
      * Check if there are any tasks that were delivered to workers but never marked as completed.
      * This could happen if the workers are spot instances and they are terminated by AWS while processing some tasks.
+     * @return the number of tasks that have not been marked complete and will be redelivered.
+     * FIXME we don't actually materialize a list of things to deliver so this method is no longer necessary except for logging purposes
+     * FIXME this is getting called constantly, really we could just do it once in a while on a timer and wake up the broker.
      */
     public int redeliver () {
 

--- a/src/main/java/com/conveyal/r5/analyst/cluster/JobSimulator.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/JobSimulator.java
@@ -54,6 +54,8 @@ public class JobSimulator {
         mapper.registerModule(JavaLocalDateSerializer.makeModule());
         mapper.registerModule(TraverseModeSetSerializer.makeModule());*/
 
+        // FIXME API now expects one single request defining a grid, rather than a list of requests
+
         List<AnalysisTask> requests = new ArrayList<>();
 
         IntStream.range(0, nOrigins).forEach(i -> {

--- a/src/main/java/com/conveyal/r5/labeling/SpeedLabeler.java
+++ b/src/main/java/com/conveyal/r5/labeling/SpeedLabeler.java
@@ -61,7 +61,6 @@ public class SpeedLabeler {
     public float getSpeedMS(Way way, boolean back) {
         // first, check for maxspeed tags
         Float speed = null;
-        Float currentSpeed;
 
         if (way.hasTag("maxspeed:motorcar"))
             speed = getMetersSecondFromSpeed(way.getTag("maxspeed:motorcar"));
@@ -74,7 +73,7 @@ public class SpeedLabeler {
 
         if (speed == null && way.hasTag("maxspeed:lanes")) {
             for (String lane : way.getTag("maxspeed:lanes").split("\\|")) {
-                currentSpeed = getMetersSecondFromSpeed(lane);
+                Float currentSpeed = getMetersSecondFromSpeed(lane);
                 // Pick the largest speed from the tag
                 // currentSpeed might be null if it was invalid, for instance 10|fast|20
                 if (currentSpeed != null && (speed == null || currentSpeed > speed))
@@ -87,9 +86,10 @@ public class SpeedLabeler {
 
         // this would be bad, as the segment could never be traversed by an automobile
         // The small epsilon is to account for possible rounding errors
-        if (speed != null && speed < 0.0001)
-            LOG.warn("Zero or negative automobile speed detected at {} based on OSM " +
-                "maxspeed tags; ignoring these tags", this);
+        if (speed != null && speed < 0.0001) {
+            LOG.warn("Automobile speed of {} based on OSM maxspeed tags. Ignoring these tags.", speed);
+            speed = null;
+        }
 
         // if there was a defined speed and it's not 0, we're done
         if (speed != null)

--- a/src/main/java/com/conveyal/r5/labeling/TypeOfEdgeLabeler.java
+++ b/src/main/java/com/conveyal/r5/labeling/TypeOfEdgeLabeler.java
@@ -102,7 +102,7 @@ public class TypeOfEdgeLabeler {
             forwardFlags.add(EdgeStore.EdgeFlag.STAIRS);
             backFlags.add(EdgeStore.EdgeFlag.STAIRS);
         }
-        // If the road doesn't have those tags it's LINKABLE AKA it will be used for linking P+R (only currently)
+        // Tunnels, covered roads and motorways are unlikely places for origins, destinations, or park and rides.
         if (!(way.hasTag("tunnel", "yes") || way.hasTag("covered", "yes") || way.hasTag("highway", "motorway"))) {
             forwardFlags.add(EdgeStore.EdgeFlag.LINKABLE);
             backFlags.add(EdgeStore.EdgeFlag.LINKABLE);

--- a/src/main/java/com/conveyal/r5/streets/EdgeStore.java
+++ b/src/main/java/com/conveyal/r5/streets/EdgeStore.java
@@ -994,6 +994,19 @@ public class EdgeStore implements Serializable {
             setFlag(EdgeFlag.ALLOWS_WHEELCHAIR);
         }
 
+        public boolean allowsStreetMode(StreetMode mode) {
+            if (mode == StreetMode.WALK) {
+                return getFlag(EdgeStore.EdgeFlag.ALLOWS_PEDESTRIAN);
+            }
+            if (mode == StreetMode.BICYCLE) {
+                return getFlag(EdgeStore.EdgeFlag.ALLOWS_BIKE);
+            }
+            if (mode == StreetMode.CAR) {
+                return getFlag(EdgeStore.EdgeFlag.ALLOWS_CAR);
+            }
+            throw new RuntimeException("Supplied mode not recognized.");
+        }
+
         public long getOSMID() {
             return osmids.get(pairIndex);
         }

--- a/src/main/java/com/conveyal/r5/streets/EdgeStore.java
+++ b/src/main/java/com/conveyal/r5/streets/EdgeStore.java
@@ -224,7 +224,7 @@ public class EdgeStore implements Serializable {
         //Set when OSM tags are wheelchair==limited currently unroutable
         LIMITED_WHEELCHAIR(19),
 
-        // If this edge is good idea to use for linking. Skips tunnels, covered and motorways for now
+        // If this flag is present, the edge is good idea to use for linking. Excludes runnels, motorways, and covered roads.
         LINKABLE(20),
 
         // Bicycle level of traffic stress for this street.

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -102,14 +102,16 @@ public class LinkedPointSet implements Serializable {
         // Null means relink and rebuild everything, but this will be constrained below if a base linkage was supplied.
         Geometry treeRebuildZone = null;
 
-        if (baseLinkage != null && (
-                baseLinkage.pointSet != pointSet ||
-                baseLinkage.streetLayer != streetLayer.baseStreetLayer ||
-                baseLinkage.streetMode != streetMode)) {
-            LOG.error("Cannot reuse linkage with mismatched characteristics. THIS IS A BUG.");
-            // Relink everything as if no base linkage was supplied.
-            baseLinkage = null;
-        }
+// This has been commented out because this was evaluating to true frequently on car searches
+// Perhaps the effect of identity equality comparisons and the fact that both base layer and new linkage are coming from a cache?
+//        if (baseLinkage != null && (
+//                baseLinkage.pointSet != pointSet ||
+//                baseLinkage.streetLayer != streetLayer.baseStreetLayer ||
+//                baseLinkage.streetMode != streetMode)) {
+//            LOG.error("Cannot reuse linkage with mismatched characteristics. THIS IS A BUG.");
+//            // Relink everything as if no base linkage was supplied.
+//            baseLinkage = null;
+//        }
 
         if (baseLinkage == null) {
             edges = new int[nPoints];
@@ -119,7 +121,8 @@ public class LinkedPointSet implements Serializable {
         } else {
             // The caller has supplied an existing linkage for a scenario StreetLayer's base StreetLayer.
             // We want to re-use most of that that existing linkage to reduce linking time.
-            LOG.info("Linking a subset of points and copying other linkages from base layer");
+            LOG.info("Linking a subset of points and copying other linkages from an existing base linkage.");
+            LOG.info("The base linkage is for street mode {}", baseLinkage.streetMode);
 
             // Copy the supplied base linkage into this new LinkedPointSet.
             // The new linkage has the same PointSet as the base linkage, so the linkage arrays remain the same length

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -102,6 +102,15 @@ public class LinkedPointSet implements Serializable {
         // Null means relink and rebuild everything, but this will be constrained below if a base linkage was supplied.
         Geometry treeRebuildZone = null;
 
+        if (baseLinkage != null && (
+                baseLinkage.pointSet != pointSet ||
+                baseLinkage.streetLayer != streetLayer.baseStreetLayer ||
+                baseLinkage.streetMode != streetMode)) {
+            LOG.error("Cannot reuse linkage with mismatched characteristics. THIS IS A BUG.");
+            // Relink everything as if no base linkage was supplied.
+            baseLinkage = null;
+        }
+
         if (baseLinkage == null) {
             edges = new int[nPoints];
             distances0_mm = new int[nPoints];
@@ -110,11 +119,6 @@ public class LinkedPointSet implements Serializable {
         } else {
             // The caller has supplied an existing linkage for a scenario StreetLayer's base StreetLayer.
             // We want to re-use most of that that existing linkage to reduce linking time.
-            // TODO switch on assertions, they are off by default
-            assert baseLinkage.pointSet == pointSet;
-            assert baseLinkage.streetLayer == streetLayer.baseStreetLayer;
-            assert baseLinkage.streetMode == streetMode;
-
             LOG.info("Linking a subset of points and copying other linkages from base layer");
 
             // Copy the supplied base linkage into this new LinkedPointSet.
@@ -142,10 +146,11 @@ public class LinkedPointSet implements Serializable {
         // If dealing with a base network linkage, fill the stop trees list entirely with nulls.
         while (stopToPointDistanceTables.size() < nStops) stopToPointDistanceTables.add(null);
 
-        /* First, link the points in this PointSet to specific street vertices. If there is no base linkage, link all streets. */
+        // First, link the points in this PointSet to specific street vertices.
+        // If there is no base linkage, link all streets.
         this.linkPointsToStreets(baseLinkage == null);
 
-        /* Second, make a table of distances from each transit stop to the points in this PointSet. */
+        // Second, make a table of distances from each transit stop to the points in this PointSet.
         this.makeStopToPointDistanceTables(treeRebuildZone);
 
     }

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -34,13 +34,6 @@ public class LinkedPointSet implements Serializable {
     private static final Logger LOG = LoggerFactory.getLogger(LinkedPointSet.class);
 
     /**
-     * The distance we search around each PointSet point for a road to link it to.
-     * FIXME 1km is really far to walk off a street. But some places have offices in the middle of big parking lots.
-     * FIXME and 4km is even more extreme! This needs to be greatly shortened.
-     */
-    public static final int MAX_OFFSTREET_WALK_METERS = 1600;
-
-    /**
      * LinkedPointSets are long-lived and not extremely numerous, so we keep references to the objects it was built from.
      * Besides these fields are useful for later processing of LinkedPointSets.
      */
@@ -259,7 +252,9 @@ public class LinkedPointSet implements Serializable {
             // hit edges on all sides or reach some predefined maximum.
             if (all || (streetLayer.edgeStore.temporarilyDeletedEdges != null &&
                         streetLayer.edgeStore.temporarilyDeletedEdges.contains(edges[p]))) {
-                Split split = streetLayer.findSplit(pointSet.getLat(p), pointSet.getLon(p), MAX_OFFSTREET_WALK_METERS, streetMode);
+                // Use radius from StreetLayer such that maximum origin and destination walk distances are symmetric.
+                Split split = streetLayer.findSplit(pointSet.getLat(p), pointSet.getLon(p),
+                        StreetLayer.LINK_RADIUS_METERS, streetMode);
                 if (split == null) {
                     edges[p] = -1;
                 } else {

--- a/src/main/java/com/conveyal/r5/streets/StreetLayer.java
+++ b/src/main/java/com/conveyal/r5/streets/StreetLayer.java
@@ -91,8 +91,9 @@ public class StreetLayer implements Serializable, Cloneable {
      * This should not necessarily be a constant, but even if it's made settable it should be stored in a field on this
      * class to avoid cluttering method signatures. Generally you'd set this once at startup and always use the same
      * value afterward.
+     * 1.6km is really far to walk off a street. But some places have offices in the middle of big parking lots.
      */
-    public static final double LINK_RADIUS_METERS = 300;
+    public static final double LINK_RADIUS_METERS = 1600;
 
     /**
      * Searching for streets takes a fair amount of computation, and the number of streets examined grows roughly as

--- a/src/main/java/com/conveyal/r5/streets/StreetLayer.java
+++ b/src/main/java/com/conveyal/r5/streets/StreetLayer.java
@@ -94,6 +94,8 @@ public class StreetLayer implements Serializable, Cloneable {
      */
     public static final double LINK_RADIUS_METERS = 300;
 
+    public static final int MAX_LINK_RADIUS_METERS = 300;
+
     // Edge lists should be constructed after the fact from edges. This minimizes serialized size too.
     public transient List<TIntList> outgoingEdges;
     public transient List<TIntList> incomingEdges;
@@ -1308,8 +1310,8 @@ public class StreetLayer implements Serializable, Cloneable {
      */
     public Split findSplit(double lat, double lon, double radiusMeters, StreetMode streetMode) {
         Split split = null;
-        if (radiusMeters > 300) {
-            split = Split.find(lat, lon, 150, this, streetMode);
+        if (radiusMeters > MAX_LINK_RADIUS_METERS) {
+            split = Split.find(lat, lon, MAX_LINK_RADIUS_METERS, this, streetMode);
         }
         if (split == null) {
             split = Split.find(lat, lon, radiusMeters, this, streetMode);

--- a/src/main/java/com/conveyal/r5/streets/StreetLayer.java
+++ b/src/main/java/com/conveyal/r5/streets/StreetLayer.java
@@ -42,7 +42,6 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
@@ -89,12 +88,19 @@ public class StreetLayer implements Serializable, Cloneable {
 
     /**
      * The radius of a circle in meters within which to search for nearby streets.
-     * This should not necessarily be a constant, but even if it's made settable it should be a field to avoid
-     * cluttering method signatures. Generally you'd set this once at startup and always use the same value afterward.
+     * This should not necessarily be a constant, but even if it's made settable it should be stored in a field on this
+     * class to avoid cluttering method signatures. Generally you'd set this once at startup and always use the same
+     * value afterward.
      */
     public static final double LINK_RADIUS_METERS = 300;
 
-    public static final int MAX_LINK_RADIUS_METERS = 300;
+    /**
+     * Searching for streets takes a fair amount of computation, and the number of streets examined grows roughly as
+     * the square of the radius. In most cases, the closest street is close to the search center point. If the specified
+     * search radius exceeds this value, a mini-search will first be conducted to check for close-by streets before
+     * examining every street within the full specified search radius.
+     */
+    public static final int INITIAL_LINK_RADIUS_METERS = 300;
 
     // Edge lists should be constructed after the fact from edges. This minimizes serialized size too.
     public transient List<TIntList> outgoingEdges;
@@ -1298,21 +1304,24 @@ public class StreetLayer implements Serializable, Cloneable {
 
     /**
      * Find a location on an existing street near the given point, without actually creating any vertices or edges.
-     * The search radius can be specified freely here because we use this function to link transit stops to streets but
-     * also to link pointsets to streets, and currently we use different distances for these two things.
      * This is a nondestructive operation: it simply finds a candidate split point without modifying anything.
      * This function starts with a small search envelope and expands it as needed under the assumption that most
-     * search envelopes will be close to a road.
-     * TODO favor platforms and pedestrian paths when requested
+     * search points will be close to a road.
+     * TODO favor transit station platforms and pedestrian paths when requested
      * @param lat latitude in floating point geographic coordinates (not fixed point int coordinates)
      * @param lon longitude in floating point geographic coordinates (not fixed point int coordinates)
-     * @return a Split object representing a point along a sub-segment of a specific edge, or null if there are no streets nearby.
+*      @param streetMode a mode of travel that the street must allow
+     * @return a Split object representing a point along a sub-segment of a specific edge, or null if there are no
+     *         streets nearby allowing the specified mode of travel.
      */
     public Split findSplit(double lat, double lon, double radiusMeters, StreetMode streetMode) {
         Split split = null;
-        if (radiusMeters > MAX_LINK_RADIUS_METERS) {
-            split = Split.find(lat, lon, MAX_LINK_RADIUS_METERS, this, streetMode);
+        // If the specified radius is large, first try a mini-search on the assumption
+        // that most linking points are close to roads.
+        if (radiusMeters > INITIAL_LINK_RADIUS_METERS) {
+            split = Split.find(lat, lon, INITIAL_LINK_RADIUS_METERS, this, streetMode);
         }
+        // If no split point was found by the first search (or no search was yet conducted) search with the full radius.
         if (split == null) {
             split = Split.find(lat, lon, radiusMeters, this, streetMode);
         }

--- a/src/main/java/com/conveyal/r5/streets/StreetRouter.java
+++ b/src/main/java/com/conveyal/r5/streets/StreetRouter.java
@@ -293,6 +293,9 @@ public class StreetRouter {
      * If the given point is not close to an existing vertex, we will create two states, one at each vertex at the
      * ends of the edge that is found.
      *
+     * Note that the mode of travel should be set before calling this, otherwise you may link to a road you can't
+     * travel on!
+     *
      * @param lat Latitude in floating point (not fixed int) degrees.
      * @param lon Longitude in flating point (not fixed int) degrees.
      * @return true if an edge was found near the specified coordinate

--- a/src/test/java/com/conveyal/r5/streets/ReverseRoutingTest.java
+++ b/src/test/java/com/conveyal/r5/streets/ReverseRoutingTest.java
@@ -101,7 +101,7 @@ public class ReverseRoutingTest extends TestCase {
         streetRouter.streetMode = StreetMode.BICYCLE;
         VertexStore.Vertex AVertex = streetLayer.vertexStore.getCursor(A);
         VertexStore.Vertex EVertex = streetLayer.vertexStore.getCursor(E);
-        Split split = streetLayer.findSplit(AVertex.getLat(), AVertex.getLon(),500, null);
+        Split split = streetLayer.findSplit(AVertex.getLat(), AVertex.getLon(),500, StreetMode.WALK);
         //assertTrue(streetRouter.setDestination(AVertex.getLat(), AVertex.getLon()));
         streetRouter.setOrigin(E); // EVertex.getLat(), EVertex.getLon());
         streetRouter.route();

--- a/src/test/java/com/conveyal/r5/streets/TurnCostCalculatorTest.java
+++ b/src/test/java/com/conveyal/r5/streets/TurnCostCalculatorTest.java
@@ -16,13 +16,13 @@ public class TurnCostCalculatorTest extends TurnTest {
     public void testAngle() throws Exception {
         setUp(false);
         TurnCostCalculator calculator = new TurnCostCalculator(streetLayer, true);
-        assertEquals(0.5 * Math.PI, calculator.computeAngle(EE + 1, ES), 1e-6);
-        assertEquals(Math.PI, calculator.computeAngle(EE, EE + 1), 1e-6);
-        assertEquals(0, calculator.computeAngle(EW + 1, EE), 1e-6);
-        double angle = calculator.computeAngle(EW + 1, ENE);
+        assertEquals(0.5 * Math.PI, calculator.computeAngle(ee + 1, es), 1e-6);
+        assertEquals(Math.PI, calculator.computeAngle(ee, ee + 1), 1e-6);
+        assertEquals(0, calculator.computeAngle(ew + 1, ee), 1e-6);
+        double angle = calculator.computeAngle(ew + 1, ene);
         assertTrue(angle < 0.15 * Math.PI);
-        assertEquals(1.5 * Math.PI, calculator.computeAngle(EE + 1, EN), 1e-6);
-        assertEquals(1.5 * Math.PI, calculator.computeAngle(ES + 1, EE), 1e-6);
+        assertEquals(1.5 * Math.PI, calculator.computeAngle(ee + 1, en), 1e-6);
+        assertEquals(1.5 * Math.PI, calculator.computeAngle(es + 1, ee), 1e-6);
     }
 
     /** Make sure angles are right in the southern hemisphere as well. We scale by the cosine of latitude, which is negative in the southern hemisphere. */
@@ -30,20 +30,20 @@ public class TurnCostCalculatorTest extends TurnTest {
     public void testAngleSouthernHemisphere() throws Exception {
         setUp(true);
         TurnCostCalculator calculator = new TurnCostCalculator(streetLayer, true);
-        assertEquals(0.5 * Math.PI, calculator.computeAngle(EE + 1, ES), 1e-6);
-        assertEquals(Math.PI, calculator.computeAngle(EE, EE + 1), 1e-6);
-        assertEquals(0, calculator.computeAngle(EW + 1, EE), 1e-6);
-        double angle = calculator.computeAngle(EW + 1, ENE);
+        assertEquals(0.5 * Math.PI, calculator.computeAngle(ee + 1, es), 1e-6);
+        assertEquals(Math.PI, calculator.computeAngle(ee, ee + 1), 1e-6);
+        assertEquals(0, calculator.computeAngle(ew + 1, ee), 1e-6);
+        double angle = calculator.computeAngle(ew + 1, ene);
         assertTrue(angle < 0.15 * Math.PI);
-        assertEquals(1.5 * Math.PI, calculator.computeAngle(EE + 1, EN), 1e-6);
-        assertEquals(1.5 * Math.PI, calculator.computeAngle(ES + 1, EE), 1e-6);
+        assertEquals(1.5 * Math.PI, calculator.computeAngle(ee + 1, en), 1e-6);
+        assertEquals(1.5 * Math.PI, calculator.computeAngle(es + 1, ee), 1e-6);
     }
 
     @Test
     public void testCost () throws Exception {
         setUp(false);
         TurnCostCalculator calculator = new TurnCostCalculator(streetLayer, true);
-        assertEquals(calculator.LEFT_TURN, calculator.computeTurnCost(EE + 1, ES, StreetMode.CAR));
+        assertEquals(calculator.LEFT_TURN, calculator.computeTurnCost(ee + 1, es, StreetMode.CAR));
     }
 
     /**

--- a/src/test/java/com/conveyal/r5/streets/TurnRestrictionTest.java
+++ b/src/test/java/com/conveyal/r5/streets/TurnRestrictionTest.java
@@ -239,7 +239,7 @@ public class TurnRestrictionTest extends TurnTest {
         r.setOrigin(VS);
         r.route();
 
-        Split split = streetLayer.findSplit(37.363, -122.1235, 100, null);
+        Split split = streetLayer.findSplit(37.363, -122.1235, 100, StreetMode.CAR);
 
         StreetRouter.State state = r.getState(split);
         assertNotNull(state);
@@ -306,10 +306,10 @@ public class TurnRestrictionTest extends TurnTest {
     public void testNoTurnWithSplitReverse2 () {
         setUp(false);
 
-        Split split = streetLayer.findSplit(37.363, -122.1235, 100, null);
+        Split split = streetLayer.findSplit(37.363, -122.1235, 100, StreetMode.CAR);
 
         VertexStore.Vertex vs = streetLayer.vertexStore.getCursor(VS);
-        Split splitVS = streetLayer.findSplit(vs.getLat(), vs.getLon(), 100, null);
+        Split splitVS = streetLayer.findSplit(vs.getLat(), vs.getLon(), 100, StreetMode.CAR);
 
         StreetRouter r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
@@ -352,7 +352,7 @@ public class TurnRestrictionTest extends TurnTest {
         assertTrue(r.setOrigin(37.3625, -122.123));
         r.route();
 
-        Split dest = streetLayer.findSplit(37.363, -122.1235, 100, null);
+        Split dest = streetLayer.findSplit(37.363, -122.1235, 100, StreetMode.CAR);
 
         StreetRouter.State state = r.getState(dest);
 

--- a/src/test/java/com/conveyal/r5/streets/TurnRestrictionTest.java
+++ b/src/test/java/com/conveyal/r5/streets/TurnRestrictionTest.java
@@ -1,7 +1,6 @@
 package com.conveyal.r5.streets;
 
 import com.conveyal.r5.profile.StreetMode;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,21 +21,21 @@ public class TurnRestrictionTest extends TurnTest {
         StreetRouter r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
-        r.setOrigin(VS);
+        r.setOrigin(vs);
         r.route();
 
-        StreetRouter.State state = r.getStateAtVertex(VW);
+        StreetRouter.State state = r.getStateAtVertex(vw);
         assertNotNull(state);
 
         // create a turn restriction
-        restrictTurn(false, ES + 1, EW);
+        restrictTurn(false, es + 1, ew);
 
         r = new StreetRouter(streetLayer);
         r.streetMode = StreetMode.CAR;
-        r.setOrigin(VS);
+        r.setOrigin(vs);
         r.route();
 
-        StreetRouter.State s1 = r.getStateAtVertex(VW);
+        StreetRouter.State s1 = r.getStateAtVertex(vw);
         LOG.debug("turn rest: {} {}", s1.dump(), s1.compactDump(r.profileRequest.reverseSearch));
 
         // weight should be greater because path should now include going past the intersection and making a U-turn back at it.
@@ -52,23 +51,23 @@ public class TurnRestrictionTest extends TurnTest {
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
         r.profileRequest.reverseSearch = true;
-        r.setOrigin(VW);
+        r.setOrigin(vw);
         r.route();
 
-        StreetRouter.State state = r.getStateAtVertex(VS);
+        StreetRouter.State state = r.getStateAtVertex(vs);
         LOG.debug("normal rev:{}", state.dump());
         assertNotNull(state);
 
         // create a turn restriction
-        restrictTurn(false, ES + 1, EW);
+        restrictTurn(false, es + 1, ew);
 
         r = new StreetRouter(streetLayer);
         r.profileRequest.reverseSearch = true;
         r.streetMode = StreetMode.CAR;
-        r.setOrigin(VW);
+        r.setOrigin(vw);
         r.route();
 
-        StreetRouter.State s1 = r.getStateAtVertex(VS);
+        StreetRouter.State s1 = r.getStateAtVertex(vs);
 
         LOG.debug("turn rest rev:{}", s1.dump());
 
@@ -85,10 +84,10 @@ public class TurnRestrictionTest extends TurnTest {
         StreetRouter r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
-        r.setOrigin(VS);
+        r.setOrigin(vs);
         r.route();
 
-        StreetRouter.State state = r.getStateAtVertex(VW);
+        StreetRouter.State state = r.getStateAtVertex(vw);
         assertNotNull(state);
 
 
@@ -99,10 +98,10 @@ public class TurnRestrictionTest extends TurnTest {
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
         r.profileRequest.reverseSearch = true;
-        r.setOrigin(VW);
+        r.setOrigin(vw);
         r.route();
 
-        StreetRouter.State reverseState = r.getStateAtVertex(VS);
+        StreetRouter.State reverseState = r.getStateAtVertex(vs);
         assertNotNull(reverseState);
         assertEquals(state.weight, reverseState.weight);
 
@@ -115,32 +114,32 @@ public class TurnRestrictionTest extends TurnTest {
         StreetRouter r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
-        r.setOrigin(VS);
+        r.setOrigin(vs);
         r.route();
 
-        StreetRouter.State state = r.getStateAtVertex(VW);
+        StreetRouter.State state = r.getStateAtVertex(vw);
         assertNotNull(state);
 
-        // must turn right from ES to EE
-        restrictTurn(true, ES + 1, EE);
+        // must turn right from es to ee
+        restrictTurn(true, es + 1, ee);
 
         r = new StreetRouter(streetLayer);
         r.streetMode = StreetMode.CAR;
-        r.setOrigin(VS);
+        r.setOrigin(vs);
         r.route();
 
-        StreetRouter.State restrictedState = r.getStateAtVertex(VW);
+        StreetRouter.State restrictedState = r.getStateAtVertex(vw);
 
         LOG.debug("Normal only turn:{}", restrictedState.compactDump(false));
 
         // weight should be greater because path should now include going past the intersection and making a U-turn back at it.
         assertTrue(restrictedState.weight > state.weight);
 
-        // The path should go through VE now because of the only turn restriction
+        // The path should go through ve now because of the only turn restriction
         boolean foundVE = false;
 
         while (restrictedState != null) {
-            if (restrictedState.vertex == VE) {
+            if (restrictedState.vertex == ve) {
                 foundVE = true;
                 break;
             }
@@ -155,17 +154,17 @@ public class TurnRestrictionTest extends TurnTest {
     public void testTurnRestrictionRemaping() throws Exception {
         setUp(false);
 
-        //Must turn left from ES to ENW over EW
-        restrictTurn(true, EN + 1, ENW, EW);
+        //Must turn left from es to enw over ew
+        restrictTurn(true, en + 1, enw, ew);
 
         //Expected List of NO turns which are semantically the same as previous ONLY turn
         List<TurnRestriction> expectedTurnRestrictions = new ArrayList<>(5);
-        expectedTurnRestrictions.add(makeTurnRestriction(false, EN+1,EN));
-        expectedTurnRestrictions.add(makeTurnRestriction(false, EN+1,EE));
-        expectedTurnRestrictions.add(makeTurnRestriction(false, EN+1,ES));
-        expectedTurnRestrictions.add(makeTurnRestriction(false, EN+1,ENE));
-        expectedTurnRestrictions.add(makeTurnRestriction(false, EN+1,EW+1,EW));
-        expectedTurnRestrictions.add(makeTurnRestriction(false, EN+1,ESW,EW));
+        expectedTurnRestrictions.add(makeTurnRestriction(false, en +1, en));
+        expectedTurnRestrictions.add(makeTurnRestriction(false, en +1, ee));
+        expectedTurnRestrictions.add(makeTurnRestriction(false, en +1, es));
+        expectedTurnRestrictions.add(makeTurnRestriction(false, en +1, ene));
+        expectedTurnRestrictions.add(makeTurnRestriction(false, en +1, ew +1, ew));
+        expectedTurnRestrictions.add(makeTurnRestriction(false, en +1, esw, ew));
 
         TurnRestriction tr = streetLayer.turnRestrictions.get(0);
 
@@ -191,33 +190,33 @@ public class TurnRestrictionTest extends TurnTest {
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
         r.profileRequest.reverseSearch = true;
-        r.setOrigin(VW);
+        r.setOrigin(vw);
         r.route();
 
-        StreetRouter.State state = r.getStateAtVertex(VS);
+        StreetRouter.State state = r.getStateAtVertex(vs);
         assertNotNull(state);
 
-        // must turn right from ES to EE
-        restrictTurn(true, ES + 1, EE);
+        // must turn right from es to ee
+        restrictTurn(true, es + 1, ee);
 
         r = new StreetRouter(streetLayer);
         r.profileRequest.reverseSearch = true;
         r.streetMode = StreetMode.CAR;
-        r.setOrigin(VW);
+        r.setOrigin(vw);
         r.route();
 
-        StreetRouter.State restrictedState = r.getStateAtVertex(VS);
+        StreetRouter.State restrictedState = r.getStateAtVertex(vs);
 
         LOG.debug("Reverse only turn:{}", restrictedState.compactDump(true));
 
         // weight should be greater because path should now include going past the intersection and making a U-turn back at it.
         assertTrue(restrictedState.weight > state.weight);
 
-        // The path should go through VE now because of the only turn restriction
+        // The path should go through ve now because of the only turn restriction
         boolean foundVE = false;
 
         while (restrictedState != null) {
-            if (restrictedState.vertex == VE) {
+            if (restrictedState.vertex == ve) {
                 foundVE = true;
                 break;
             }
@@ -236,7 +235,7 @@ public class TurnRestrictionTest extends TurnTest {
         StreetRouter r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
-        r.setOrigin(VS);
+        r.setOrigin(vs);
         r.route();
 
         Split split = streetLayer.findSplit(37.363, -122.1235, 100, StreetMode.CAR);
@@ -247,11 +246,11 @@ public class TurnRestrictionTest extends TurnTest {
         LOG.debug("Normat with split:{}", state.compactDump(r.profileRequest.reverseSearch));
 
         // create a turn restriction
-        restrictTurn(false, ES + 1, EW);
+        restrictTurn(false, es + 1, ew);
 
         r = new StreetRouter(streetLayer);
         r.streetMode = StreetMode.CAR;
-        r.setOrigin(VS);
+        r.setOrigin(vs);
         r.route();
 
         StreetRouter.State restrictedState = r.getState(split);
@@ -267,7 +266,7 @@ public class TurnRestrictionTest extends TurnTest {
     public void testNoTurnWithSplitOriginReverse () {
         setUp(false);
 
-        VertexStore.Vertex vs = streetLayer.vertexStore.getCursor(VS);
+        VertexStore.Vertex vs = streetLayer.vertexStore.getCursor(this.vs);
 
         StreetRouter r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
@@ -276,23 +275,23 @@ public class TurnRestrictionTest extends TurnTest {
         r.setOrigin(37.363, -122.1235); //location of split
         r.route();
 
-        StreetRouter.State state = r.getStateAtVertex(VS); // getState(splitVS);
+        StreetRouter.State state = r.getStateAtVertex(this.vs); // getState(splitVS);
         assertNotNull(state);
 
         LOG.debug("Reverse with split:{}", state.compactDump(r.profileRequest.reverseSearch));
 
 
         // create a turn restriction
-        restrictTurn(false, ES + 1, EW);
+        restrictTurn(false, es + 1, ew);
 
         r = new StreetRouter(streetLayer);
         r.streetMode = StreetMode.CAR;
         r.profileRequest.reverseSearch = true;
         r.setOrigin(37.363, -122.1235);
-        //r.setOrigin(VW);
+        //r.setOrigin(vw);
         r.route();
 
-        StreetRouter.State restrictedState =  r.getStateAtVertex(VS); // getState(splitVS);
+        StreetRouter.State restrictedState =  r.getStateAtVertex(this.vs); // getState(splitVS);
 
         LOG.debug("Reverse restricted with split:{}", restrictedState.compactDump(r.profileRequest.reverseSearch));
 
@@ -308,14 +307,14 @@ public class TurnRestrictionTest extends TurnTest {
 
         Split split = streetLayer.findSplit(37.363, -122.1235, 100, StreetMode.CAR);
 
-        VertexStore.Vertex vs = streetLayer.vertexStore.getCursor(VS);
+        VertexStore.Vertex vs = streetLayer.vertexStore.getCursor(this.vs);
         Split splitVS = streetLayer.findSplit(vs.getLat(), vs.getLon(), 100, StreetMode.CAR);
 
         StreetRouter r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
         r.profileRequest.reverseSearch = true;
-        r.setOrigin(VW); //location of split
+        r.setOrigin(vw); //location of split
         r.route();
 
         StreetRouter.State state = r.getState(splitVS);
@@ -325,13 +324,13 @@ public class TurnRestrictionTest extends TurnTest {
 
 
         // create a turn restriction
-        restrictTurn(false, ES + 1, EW);
+        restrictTurn(false, es + 1, ew);
 
         r = new StreetRouter(streetLayer);
         r.streetMode = StreetMode.CAR;
         r.profileRequest.reverseSearch = true;
-        r.setOrigin(VW);
-        //r.setOrigin(VW);
+        r.setOrigin(vw);
+        //r.setOrigin(vw);
         r.route();
 
         StreetRouter.State restrictedState =  r.getState(splitVS);
@@ -360,7 +359,7 @@ public class TurnRestrictionTest extends TurnTest {
         assertNotNull(state);
 
         // create a turn restriction
-        restrictTurn(false, ES + 1, EW);
+        restrictTurn(false, es + 1, ew);
 
         r = new StreetRouter(streetLayer);
         r.streetMode = StreetMode.CAR;
@@ -385,20 +384,20 @@ public class TurnRestrictionTest extends TurnTest {
         assertTrue(r.setOrigin(37.3625, -122.123));
         r.route();
 
-        StreetRouter.State state = r.getStateAtVertex(VW);
+        StreetRouter.State state = r.getStateAtVertex(vw);
 
         LOG.debug("Normal:{}", state.compactDump(r.profileRequest.reverseSearch));
         assertNotNull(state);
 
         // create a turn restriction
-        restrictTurn(false, ES + 1, EW);
+        restrictTurn(false, es + 1, ew);
 
         r = new StreetRouter(streetLayer);
         r.streetMode = StreetMode.CAR;
         r.setOrigin(37.3625, -122.123);
         r.route();
 
-        StreetRouter.State restrictedState = r.getStateAtVertex(VW);
+        StreetRouter.State restrictedState = r.getStateAtVertex(vw);
 
         LOG.debug("Restricted:{}", restrictedState.compactDump(r.profileRequest.reverseSearch));
 
@@ -414,30 +413,30 @@ public class TurnRestrictionTest extends TurnTest {
         StreetRouter r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
-        r.setOrigin(VN);
+        r.setOrigin(vn);
         r.route();
 
-        StreetRouter.State stateFromN = r.getStateAtVertex(VNW);
+        StreetRouter.State stateFromN = r.getStateAtVertex(vnw);
 
         LOG.debug("Normal: {} {}", stateFromN.dump(), stateFromN.compactDump(false));
 
         r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
-        r.setOrigin(VCENTER);
+        r.setOrigin(vcenter);
         r.route();
 
-        StreetRouter.State stateFromCenter = r.getStateAtVertex(VNW);
+        StreetRouter.State stateFromCenter = r.getStateAtVertex(vnw);
 
-        restrictTurn(false, EN + 1, ENW, EW);
+        restrictTurn(false, en + 1, enw, ew);
 
         r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
-        r.setOrigin(VN);
+        r.setOrigin(vn);
         r.route();
 
-        StreetRouter.State restrictedStateFromN = r.getStateAtVertex(VNW);
+        StreetRouter.State restrictedStateFromN = r.getStateAtVertex(vnw);
 
         LOG.debug("Normal restricted: {} {}", restrictedStateFromN.dump(), restrictedStateFromN.compactDump(false));
 
@@ -447,11 +446,11 @@ public class TurnRestrictionTest extends TurnTest {
         r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
-        r.setOrigin(VCENTER);
+        r.setOrigin(vcenter);
         r.route();
 
         // No U turn should not affect the left turn
-        StreetRouter.State restrictedStateFromCenter = r.getStateAtVertex(VNW);
+        StreetRouter.State restrictedStateFromCenter = r.getStateAtVertex(vnw);
         assertEquals(stateFromCenter.weight, restrictedStateFromCenter.weight);
     }
 
@@ -464,10 +463,10 @@ public class TurnRestrictionTest extends TurnTest {
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
         r.profileRequest.reverseSearch = true;
-        r.setOrigin(VNW);
+        r.setOrigin(vnw);
         r.route();
 
-        StreetRouter.State stateFromN = r.getStateAtVertex(VN);
+        StreetRouter.State stateFromN = r.getStateAtVertex(vn);
 
         LOG.debug("StateFromN:{} {}", stateFromN.dump(), stateFromN.compactDump(true));
 
@@ -475,21 +474,21 @@ public class TurnRestrictionTest extends TurnTest {
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
         r.profileRequest.reverseSearch = true;
-        r.setOrigin(VNW);
+        r.setOrigin(vnw);
         r.route();
 
-        StreetRouter.State stateFromCenter = r.getStateAtVertex(VCENTER);
+        StreetRouter.State stateFromCenter = r.getStateAtVertex(vcenter);
 
-        restrictTurn(false, EN + 1, ENW, EW);
+        restrictTurn(false, en + 1, enw, ew);
 
         r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
         r.profileRequest.reverseSearch = true;
-        r.setOrigin(VNW);
+        r.setOrigin(vnw);
         r.route();
 
-        StreetRouter.State restrictedStateFromN = r.getStateAtVertex(VN);
+        StreetRouter.State restrictedStateFromN = r.getStateAtVertex(vn);
 
         LOG.debug("Res StateFromN:{}", restrictedStateFromN.dump());
 
@@ -500,11 +499,11 @@ public class TurnRestrictionTest extends TurnTest {
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
         r.profileRequest.reverseSearch = true;
-        r.setOrigin(VNW);
+        r.setOrigin(vnw);
         r.route();
 
         // No U turn should not affect the left turn
-        StreetRouter.State restrictedStateFromCenter = r.getStateAtVertex(VCENTER);
+        StreetRouter.State restrictedStateFromCenter = r.getStateAtVertex(vcenter);
         assertEquals(stateFromCenter.weight, restrictedStateFromCenter.weight);
     }
 
@@ -516,35 +515,35 @@ public class TurnRestrictionTest extends TurnTest {
         StreetRouter r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
-        r.setOrigin(VN);
+        r.setOrigin(vn);
         r.route();
 
-        StreetRouter.State stateFromN = r.getStateAtVertex(VE);
+        StreetRouter.State stateFromN = r.getStateAtVertex(ve);
 
-        LOG.debug("Only via N: VN to VE {}", stateFromN.compactDump(r.profileRequest.reverseSearch));
-        assertFalse(stateContainsVertex(stateFromN, VNW));
+        LOG.debug("Only via N: vn to ve {}", stateFromN.compactDump(r.profileRequest.reverseSearch));
+        assertFalse(stateContainsVertex(stateFromN, vnw));
 
         r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
-        r.setOrigin(VCENTER);
+        r.setOrigin(vcenter);
         r.route();
 
-        StreetRouter.State stateFromCenter = r.getStateAtVertex(VE);
-        LOG.debug("Only via N: VCENTER to VE {}", stateFromCenter.compactDump(r.profileRequest.reverseSearch));
-        assertFalse(stateContainsVertex(stateFromCenter, VNW));
+        StreetRouter.State stateFromCenter = r.getStateAtVertex(ve);
+        LOG.debug("Only via N: vcenter to ve {}", stateFromCenter.compactDump(r.profileRequest.reverseSearch));
+        assertFalse(stateContainsVertex(stateFromCenter, vnw));
 
 
-        restrictTurn(true, EN + 1, ENW, EW);
+        restrictTurn(true, en + 1, enw, ew);
 
         r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
-        r.setOrigin(VN);
+        r.setOrigin(vn);
         r.route();
 
-        StreetRouter.State restrictedStateFromN = r.getStateAtVertex(VE);
-        LOG.debug("Only via Restricted: VN to VE {}", restrictedStateFromN.compactDump(r.profileRequest.reverseSearch));
+        StreetRouter.State restrictedStateFromN = r.getStateAtVertex(ve);
+        LOG.debug("Only via Restricted: vn to ve {}", restrictedStateFromN.compactDump(r.profileRequest.reverseSearch));
 
         // we should be forced to make a U-turn
         assertTrue(restrictedStateFromN.weight > stateFromN.weight);
@@ -552,16 +551,16 @@ public class TurnRestrictionTest extends TurnTest {
         r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
-        r.setOrigin(VCENTER);
+        r.setOrigin(vcenter);
         r.route();
 
         // Only U turn should not affect a state starting at the center
-        StreetRouter.State restrictedStateFromCenter = r.getStateAtVertex(VE);
-        LOG.debug("Only via Restricted: VCENTER to VE {}", restrictedStateFromCenter.compactDump(r.profileRequest.reverseSearch));
+        StreetRouter.State restrictedStateFromCenter = r.getStateAtVertex(ve);
+        LOG.debug("Only via Restricted: vcenter to ve {}", restrictedStateFromCenter.compactDump(r.profileRequest.reverseSearch));
         assertEquals(stateFromCenter.weight, restrictedStateFromCenter.weight);
 
-        // make sure the state from the north goes through VNW as there's an only U turn restriction.
-        assertTrue(stateContainsVertex(restrictedStateFromN, VNW));
+        // make sure the state from the north goes through vnw as there's an only U turn restriction.
+        assertTrue(stateContainsVertex(restrictedStateFromN, vnw));
 
     }
 
@@ -573,36 +572,36 @@ public class TurnRestrictionTest extends TurnTest {
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
         r.profileRequest.reverseSearch = true;
-        r.setOrigin(VE);
+        r.setOrigin(ve);
         r.route();
 
-        StreetRouter.State stateFromN = r.getStateAtVertex(VN);
-        LOG.debug("Rev: Only via N: VN to VE {}", stateFromN.compactDump(r.profileRequest.reverseSearch));
-        assertFalse(stateContainsVertex(stateFromN, VNW));
+        StreetRouter.State stateFromN = r.getStateAtVertex(vn);
+        LOG.debug("Rev: Only via N: vn to ve {}", stateFromN.compactDump(r.profileRequest.reverseSearch));
+        assertFalse(stateContainsVertex(stateFromN, vnw));
 
         r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
         r.profileRequest.reverseSearch = true;
-        r.setOrigin(VE);
+        r.setOrigin(ve);
         r.route();
 
-        StreetRouter.State stateFromCenter = r.getStateAtVertex(VCENTER);
-        LOG.debug("Rev: Only via N: VCENTER to VE {}", stateFromCenter.compactDump(r.profileRequest.reverseSearch));
-        assertFalse(stateContainsVertex(stateFromCenter, VNW));
+        StreetRouter.State stateFromCenter = r.getStateAtVertex(vcenter);
+        LOG.debug("Rev: Only via N: vcenter to ve {}", stateFromCenter.compactDump(r.profileRequest.reverseSearch));
+        assertFalse(stateContainsVertex(stateFromCenter, vnw));
 
 
-        restrictTurn(true, EN + 1, ENW, EW);
+        restrictTurn(true, en + 1, enw, ew);
 
         r = new StreetRouter(streetLayer);
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
         r.profileRequest.reverseSearch = true;
-        r.setOrigin(VE);
+        r.setOrigin(ve);
         r.route();
 
-        StreetRouter.State restrictedStateFromN = r.getStateAtVertex(VN);
-        LOG.debug("Rev: Only via Restricted: VN to VE {}", restrictedStateFromN.compactDump(r.profileRequest.reverseSearch));
+        StreetRouter.State restrictedStateFromN = r.getStateAtVertex(vn);
+        LOG.debug("Rev: Only via Restricted: vn to ve {}", restrictedStateFromN.compactDump(r.profileRequest.reverseSearch));
 
         // we should be forced to make a U-turn
         assertTrue(restrictedStateFromN.weight > stateFromN.weight);
@@ -611,16 +610,16 @@ public class TurnRestrictionTest extends TurnTest {
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
         r.profileRequest.reverseSearch = true;
-        r.setOrigin(VE);
+        r.setOrigin(ve);
         r.route();
 
         // Only U turn should not affect a state starting at the center
-        StreetRouter.State restrictedStateFromCenter = r.getStateAtVertex(VCENTER);
-        LOG.debug("Rev: Only via Restricted: VCenter to VE {}", restrictedStateFromCenter.compactDump(r.profileRequest.reverseSearch));
+        StreetRouter.State restrictedStateFromCenter = r.getStateAtVertex(vcenter);
+        LOG.debug("Rev: Only via Restricted: VCenter to ve {}", restrictedStateFromCenter.compactDump(r.profileRequest.reverseSearch));
         assertEquals(stateFromCenter.weight, restrictedStateFromCenter.weight);
 
-        // make sure the state from the north goes through VNW as there's an only U turn restriction.
-        assertTrue(stateContainsVertex(restrictedStateFromN, VNW));
+        // make sure the state from the north goes through vnw as there's an only U turn restriction.
+        assertTrue(stateContainsVertex(restrictedStateFromN, vnw));
 
     }
 
@@ -629,8 +628,8 @@ public class TurnRestrictionTest extends TurnTest {
     public void testAdjacentRestrictionInfiniteLoop () {
         setUp(false);
 
-        restrictTurn(false, EW, ENW);
-        restrictTurn(false, EW + 1, ES);
+        restrictTurn(false, ew, enw);
+        restrictTurn(false, ew + 1, es);
 
         RoutingVisitor countingVisitor = new RoutingVisitor() {
             int count;
@@ -644,7 +643,7 @@ public class TurnRestrictionTest extends TurnTest {
         // turn restrictions only apply to cars
         r.streetMode = StreetMode.CAR;
         r.setRoutingVisitor(countingVisitor);
-        r.setOrigin(VCENTER);
+        r.setOrigin(vcenter);
 
         try {
             r.route();
@@ -658,8 +657,8 @@ public class TurnRestrictionTest extends TurnTest {
     public void testAdjacentRestrictionInfiniteLoopReverse () {
         setUp(false);
 
-        restrictTurn(false, EW, ENW);
-        restrictTurn(false, EW + 1, ES);
+        restrictTurn(false, ew, enw);
+        restrictTurn(false, ew + 1, es);
 
         RoutingVisitor countingVisitor = new RoutingVisitor() {
             int count;
@@ -674,7 +673,7 @@ public class TurnRestrictionTest extends TurnTest {
         r.streetMode = StreetMode.CAR;
         r.profileRequest.reverseSearch = true;
         r.setRoutingVisitor(countingVisitor);
-        r.setOrigin(VCENTER);
+        r.setOrigin(vcenter);
 
         try {
             r.route();

--- a/src/test/java/com/conveyal/r5/streets/TurnTest.java
+++ b/src/test/java/com/conveyal/r5/streets/TurnTest.java
@@ -14,6 +14,7 @@ public abstract class TurnTest {
     private static final Logger LOG = LoggerFactory.getLogger(TurnTest.class);
 
     // center vertex index, n/s/e/w vertex indices, n/s/e/w edge indices (always starting from center).
+    // FIXME capital letters should only be used for constants
     public int VCENTER, VN, VS, VE, VW, VNE, VNW, VSW, EN, ES, EE, EW, ENE, ENW, ESW;
 
     public void setUp (boolean southernHemisphere) {
@@ -52,6 +53,7 @@ public abstract class TurnTest {
         do {
             e.setFlag(EdgeStore.EdgeFlag.ALLOWS_PEDESTRIAN);
             e.setFlag(EdgeStore.EdgeFlag.ALLOWS_CAR);
+            e.setFlag(EdgeStore.EdgeFlag.LINKABLE);
         } while (e.advance());
 
         streetLayer.indexStreets();

--- a/src/test/java/com/conveyal/r5/streets/TurnTest.java
+++ b/src/test/java/com/conveyal/r5/streets/TurnTest.java
@@ -1,7 +1,6 @@
 package com.conveyal.r5.streets;
 
 import com.conveyal.r5.point_to_point.builder.TNBuilderConfig;
-import junit.framework.TestCase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,39 +13,38 @@ public abstract class TurnTest {
     private static final Logger LOG = LoggerFactory.getLogger(TurnTest.class);
 
     // center vertex index, n/s/e/w vertex indices, n/s/e/w edge indices (always starting from center).
-    // FIXME capital letters should only be used for constants
-    public int VCENTER, VN, VS, VE, VW, VNE, VNW, VSW, EN, ES, EE, EW, ENE, ENW, ESW;
+    public int vcenter, vn, vs, ve, vw, vne, vnw, vsw, en, es, ee, ew, ene, enw, esw;
 
     public void setUp (boolean southernHemisphere) {
         // generate a street layer that looks like this
-        // VNW VN
+        // vnw vn
         // |   |
-        // |   |/--VNE
-        // VW--*-- VE
+        // |   |/--vne
+        // vw--*-- ve
         // |   |
-        // VSW VS
-        // Edges have the same names (EW, EE, etc), and all start from the central vertex (except ENW/VSW which starts at VW)
+        // vsw vs
+        // Edges have the same names (ew, ee, etc), and all start from the central vertex (except enw/vsw which starts at vw)
 
         double latOffset = southernHemisphere ? -60 : 0;
 
         streetLayer = new StreetLayer(new TNBuilderConfig());
-        VCENTER = streetLayer.vertexStore.addVertex(37.363 + latOffset, -122.123);
-        VN = streetLayer.vertexStore.addVertex(37.364 + latOffset, -122.123);
-        VS = streetLayer.vertexStore.addVertex(37.362 + latOffset, -122.123);
-        VE = streetLayer.vertexStore.addVertex(37.363 + latOffset, -122.122);
-        VNE = streetLayer.vertexStore.addVertex(37.3631 + latOffset, -122.122);
-        VW = streetLayer.vertexStore.addVertex(37.363 + latOffset, -122.124);
-        VNW = streetLayer.vertexStore.addVertex(37.364 + latOffset, -122.124);
+        vcenter = streetLayer.vertexStore.addVertex(37.363 + latOffset, -122.123);
+        vn = streetLayer.vertexStore.addVertex(37.364 + latOffset, -122.123);
+        vs = streetLayer.vertexStore.addVertex(37.362 + latOffset, -122.123);
+        ve = streetLayer.vertexStore.addVertex(37.363 + latOffset, -122.122);
+        vne = streetLayer.vertexStore.addVertex(37.3631 + latOffset, -122.122);
+        vw = streetLayer.vertexStore.addVertex(37.363 + latOffset, -122.124);
+        vnw = streetLayer.vertexStore.addVertex(37.364 + latOffset, -122.124);
 
-        VSW = streetLayer.vertexStore.addVertex(37.362 + latOffset, -122.124);
+        vsw = streetLayer.vertexStore.addVertex(37.362 + latOffset, -122.124);
 
-        EN = streetLayer.edgeStore.addStreetPair(VCENTER, VN, 15000, 4).getEdgeIndex();
-        EE = streetLayer.edgeStore.addStreetPair(VCENTER, VE, 15000, 2).getEdgeIndex();
-        ES = streetLayer.edgeStore.addStreetPair(VCENTER, VS, 15000, 3).getEdgeIndex();
-        EW = streetLayer.edgeStore.addStreetPair(VCENTER, VW, 15000, 1).getEdgeIndex();
-        ENE = streetLayer.edgeStore.addStreetPair(VCENTER, VNE, 15000, 5).getEdgeIndex();
-        ENW = streetLayer.edgeStore.addStreetPair(VW, VNW, 15000, 6).getEdgeIndex();
-        ESW = streetLayer.edgeStore.addStreetPair(VW, VSW, 15000, 7).getEdgeIndex();
+        en = streetLayer.edgeStore.addStreetPair(vcenter, vn, 15000, 4).getEdgeIndex();
+        ee = streetLayer.edgeStore.addStreetPair(vcenter, ve, 15000, 2).getEdgeIndex();
+        es = streetLayer.edgeStore.addStreetPair(vcenter, vs, 15000, 3).getEdgeIndex();
+        ew = streetLayer.edgeStore.addStreetPair(vcenter, vw, 15000, 1).getEdgeIndex();
+        ene = streetLayer.edgeStore.addStreetPair(vcenter, vne, 15000, 5).getEdgeIndex();
+        enw = streetLayer.edgeStore.addStreetPair(vw, vnw, 15000, 6).getEdgeIndex();
+        esw = streetLayer.edgeStore.addStreetPair(vw, vsw, 15000, 7).getEdgeIndex();
 
         EdgeStore.Edge e = streetLayer.edgeStore.getCursor(0);
 


### PR DESCRIPTION
This pull request fixes some problems with car routing in Analysis that were encountered by Alex on the SBB project. The biggest one is that we weren't providing the on-street mode of travel to the linking method at the origin point, so it could link to roads that were not traversable by the chosen mode.

A more subtle problem for which we do not yet have a complete solution is that ways can have different permissions in different directions, the most obvious example being parallel one-way OSM ways making up "dual carriageways" and boulevards.

There are multiple possible approaches, e.g. linking only to ways that are traversable in both directions, or linking to ways that are traversable in at least one direction. The approach in this PR works better but could still use refinement over time.
