### PR TITLE
fix(add-trips): properly set transitLayer.hasFrequencies

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/scenario/AddTrips.java
+++ b/src/main/java/com/conveyal/r5/analyst/scenario/AddTrips.java
@@ -126,7 +126,7 @@ public class AddTrips extends Modification {
         LOG.info("Created {}.", pattern);
         for (PatternTimetable timetable : frequencies) {
             createSchedules(timetable, directionId, transitLayer.services).forEach(pattern::addTrip);
-            if (timetable.firstDepartures != null) transitLayer.hasFrequencies = true;
+            if (timetable.firstDepartures == null) transitLayer.hasFrequencies = true;
             else transitLayer.hasSchedules = true;
         }
 


### PR DESCRIPTION
This PR fixes a boolean check that was improperly inverted.

`firstDepartures` is null for a `PatternTimetable` if it is frequency based. So if `firstDepartures` is null, `transitLayers.hasFrequencies` should be set to true.