### PR TITLE
Enable static sites

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/TravelTimeComputer.java
+++ b/src/main/java/com/conveyal/r5/analyst/TravelTimeComputer.java
@@ -295,19 +295,18 @@ public class TravelTimeComputer {
                                 }
                                 pathIdx = paths.get(path);
                             }
-
                             pathsToStops[iter][stop] = pathIdx;
                         }
                     }
                 }
-
-                perTargetPropagater = new PerTargetPropagater(egressModeLinkedDestinations, request, transitTravelTimesToStops, nonTransitTravelTimesToDestinations, inVehicleTimesToStops, waitTimesToStops, pathsToStops);
+                perTargetPropagater = new PerTargetPropagater(egressModeLinkedDestinations, request,
+                        transitTravelTimesToStops, nonTransitTravelTimesToDestinations, inVehicleTimesToStops,
+                        waitTimesToStops, pathsToStops);
                 perTargetPropagater.reducer = travelTimeReducer;
                 perTargetPropagater.pathWriter = new PathWriter(request, network, pathList);
-
             } else {
-
-                perTargetPropagater = new PerTargetPropagater(egressModeLinkedDestinations, request, transitTravelTimesToStops, nonTransitTravelTimesToDestinations, null, null, null);
+                perTargetPropagater = new PerTargetPropagater(egressModeLinkedDestinations, request,
+                        transitTravelTimesToStops, nonTransitTravelTimesToDestinations, null, null, null);
                 perTargetPropagater.reducer = travelTimeReducer;
             }
             perTargetPropagater.propagate();

--- a/src/main/java/com/conveyal/r5/analyst/TravelTimeComputer.java
+++ b/src/main/java/com/conveyal/r5/analyst/TravelTimeComputer.java
@@ -224,8 +224,10 @@ public class TravelTimeComputer {
             // Create a new Raptor Worker.
             FastRaptorWorker worker = new FastRaptorWorker(network.transitLayer, request, accessTimes);
 
-            if (request.returnPaths || request.returnInVehicleTimes || request.returnWaitTimes) {
-                worker.saveAllStates = true; // By default, this is false and intermediate results (e.g. paths) are discarded.
+            if (request.returnPaths || request.travelTimeBreakdown) {
+                // By default, this is false and intermediate results (e.g. paths) are discarded.
+                // TODO do we really need to save all states just to get the travel time breakdown?
+                worker.saveAllStates = true;
             }
 
             // Run the main RAPTOR algorithm to find paths and travel times to all stops in the network.
@@ -266,25 +268,18 @@ public class TravelTimeComputer {
 
                         RaptorState state = worker.statesEachIteration.get(iter);
 
-                        // Calculate the components of travel time (waiting, in-vehicle)
-                        if (request.returnWaitTimes || request.returnInVehicleTimes) {
-
+                        if (request.travelTimeBreakdown) {
                             int inVehicleTime = state.nonTransferInVehicleTravelTime[stop] / 60;
                             int waitTime = state.nonTransferWaitTime[stop] / 60;
-
                             if (inVehicleTime + waitTime > time && time != -1) {
                                 LOG.info("Wait and in vehicle travel time greater than total time");
                             }
-
                             inVehicleTimesToStops[iter][stop] = inVehicleTime;
                             waitTimesToStops[iter][stop] = waitTime;
-
                         }
-
                         // Record the paths used
                         if (request.returnPaths) {
                             int pathIdx = -1;
-
                             // only compute a path if this stop was reached
                             if (state.bestNonTransferTimes[stop] != FastRaptorWorker.UNREACHED) {
                                 // TODO reuse pathwithtimes?

--- a/src/main/java/com/conveyal/r5/analyst/TravelTimeSurfaceReducer.java
+++ b/src/main/java/com/conveyal/r5/analyst/TravelTimeSurfaceReducer.java
@@ -103,12 +103,19 @@ public class TravelTimeSurfaceReducer implements PerTargetPropagater.TravelTimeR
                 outputStream = MultipointDataStore.getOutputStream(task, task.taskId + "_times.dat", "application/octet-stream");
             }
 
-            TravelTimeSurfaceTask timeSurfaceTask = (TravelTimeSurfaceTask) task;
-
-            if (timeSurfaceTask.getFormat() == TravelTimeSurfaceTask.Format.GRID) {
+            if (task instanceof TravelTimeSurfaceTask) {
+                // This travel time surface is being produced by a single-origin task.
+                // We could be making a grid or a TIFF.
+                TravelTimeSurfaceTask timeSurfaceTask = (TravelTimeSurfaceTask) task;
+                if (timeSurfaceTask.getFormat() == TravelTimeSurfaceTask.Format.GRID) {
+                    timeGrid.writeGrid(outputStream);
+                } else if (timeSurfaceTask.getFormat() == TravelTimeSurfaceTask.Format.GEOTIFF) {
+                    timeGrid.writeGeotiff(outputStream);
+                }
+            } else {
+                // This travel time surface is being produced by a regional task. We must be making a static site.
+                // Write the grid format.
                 timeGrid.writeGrid(outputStream);
-            } else if (timeSurfaceTask.getFormat() == TravelTimeSurfaceTask.Format.GEOTIFF) {
-                timeGrid.writeGeotiff(outputStream);
             }
 
             LOG.info("Travel time surface written, appending metadata with {} warnings",

--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalysisTask.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalysisTask.java
@@ -48,26 +48,18 @@ public abstract class AnalysisTask extends ProfileRequest {
     /** A unique identifier for this task assigned by the queue/broker system. */
     public int taskId;
 
-    /** Save results to a bucket.  If blank, the response to this task will be via the default channel (broker for
-     *  single-point requests, queue for regional requests).  Not yet compatible with UI.
+    /**
+     * Whether to save results on S3. If null or empty, the response to this task will be via the
+     * default channel (broker for single-point requests, queue for regional requests).
+     * The results will actually be stored in a sub-bucket named after the job ID.
+     * FIXME in practice this always implies travelTimeBreakdown and returnPaths, so we've got redundant and potentially incoherent information.
      */
-    @JsonIgnore
-    public String outputBucket = "";
+    public boolean makeStaticSite = false;
 
-    /* Directory in the bucket in which to save results; not yet compatible with UI */
-    @JsonIgnore
-    public String outputDirectory = "";
+    /** Whether to break travel time down into in-vehicle, wait, and access/egress time. */
+    public boolean travelTimeBreakdown = false;
 
-    /** Whether to include the in-vehicle component of overall travel time in results */
-    @JsonIgnore
-    public boolean returnInVehicleTimes = false;
-
-    /** Whether to include the waiting time component of overall travel time in results */
-    @JsonIgnore
-    public boolean returnWaitTimes = false;
-
-    /** Whether to include paths, used to for transitive-style maps, in results */
-    @JsonIgnore
+    /** Whether to include paths in results. This allows rendering transitive-style schematic maps. */
     public boolean returnPaths = false;
 
     /** Which percentiles of travel time to calculate. */
@@ -90,7 +82,7 @@ public abstract class AnalysisTask extends ProfileRequest {
     @JsonIgnore
     public abstract boolean isHighPriority();
 
-    /** Get the destinations that should be used for this task */
+    /** Get the set of points to which we are measuring travel time. */
     @JsonIgnore
     public abstract List<PointSet> getDestinations(TransportNetwork network, GridCache gridCache);
 

--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
@@ -360,12 +360,15 @@ public class AnalystWorker implements Runnable {
                 return;
             }
 
-            // replicate previous static site functionality; if this is the first of a batch of tasks, and if there is
-            // an output bucket specified, write the shared metadata for this batch of requests to the output bucket
-            if(request.taskId == 0 && request.outputBucket != null && !request.outputBucket.isEmpty()){
-                MultipointMetadata mm = new MultipointMetadata(request, transportNetwork);
-                LOG.info("This is the lead-off task for a static site request; writing shared metadata");
-                mm.write();
+            // If we are generating a static site, there must be a single metadata file for an entire batch of results.
+            // Arbitrarily we create this metadata as part of the first task in the job.
+            if (request instanceof RegionalTask) {
+                // TODO with new broker that numbers tasks inside a job, use request.taskId == 0
+                if (request.makeStaticSite && ((RegionalTask)request).x == 0 && ((RegionalTask)request).y == 0) {
+                    MultipointMetadata mm = new MultipointMetadata(request, transportNetwork);
+                    LOG.info("This is the first task in a job that will produce a static site. Writing shared metadata.");
+                    mm.write();
+                }
             }
 
             TravelTimeComputer computer = new TravelTimeComputer(request, transportNetwork, gridCache);

--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
@@ -391,7 +391,8 @@ public class AnalystWorker implements Runnable {
             // Catch any exceptions that were not handled by more specific catch clauses above.
             // This ensures that some form of error message is passed all the way back up to the web UI.
             TaskError taskError = new TaskError(ex);
-            LOG.error("An error occurred while routing", ex);
+            LOG.error("An error occurred while routing: {}", ex.toString());
+            ex.printStackTrace();
             reportTaskErrors(request.taskId, HttpStatus.INTERNAL_SERVER_ERROR_500, Arrays.asList(taskError));
         }
     }

--- a/src/main/java/com/conveyal/r5/analyst/cluster/PathWriter.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/PathWriter.java
@@ -18,7 +18,7 @@ import java.util.List;
  * At the moment, we return all paths (i.e. we don't reduce them); users might be confused if the path that happened to be associated with
  * the median travel time was not a commonly used one, etc.
  *
- * This implementation streams, which might be an example for hwo to reimplement TravelTimeSurfaceReducer.
+ * This implementation streams, which might be an example for how to reimplement TravelTimeSurfaceReducer.
  */
 public class PathWriter implements PerTargetPropagater.PathWriter {
     private static final Logger LOG = LoggerFactory.getLogger(PathWriter.class);
@@ -29,8 +29,6 @@ public class PathWriter implements PerTargetPropagater.PathWriter {
     /** The task used to create travel times being reduced herein */
     public final AnalysisTask task;
 
-    int[] paths;
-
     List<Path> pathList;
 
     OutputStream outputStream;
@@ -39,31 +37,12 @@ public class PathWriter implements PerTargetPropagater.PathWriter {
         this.task = task;
         this.network = network;
         this.pathList = pathList;
-
         try {
             outputStream = MultipointDataStore.getOutputStream(task, task.taskId + "_paths.dat", "application/octet-stream");
             outputStream.write("PATHGRID".getBytes());
-
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public void recordPathsForTarget (int[] paths) {
-        try {
-
-            // write the path indexes used to reach the target at each iteration, delta coded within each target
-
-            int prev = 0;
-            for (int pathIdx : paths) {
-                outputStream.write(pathIdx - prev);
-                prev = pathIdx;
-            }
-
-            // write the number of different paths used
+            // Write the number of different paths used to reach all destination cells
             outputStream.write(pathList.size());
-
-            // write the details for each path used
+            // Write the details for each of those paths
             for (Path path : pathList) {
                 outputStream.write(path.patterns.length);
                 for (int i = 0 ; i < path.patterns.length; i ++){
@@ -71,9 +50,20 @@ public class PathWriter implements PerTargetPropagater.PathWriter {
                     outputStream.write(path.patterns[i]);
                     outputStream.write(path.alightStops[i]);
                 }
-
             }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
+    public void recordPathsForTarget (int[] paths) {
+        try {
+            // Write the path indexes used to reach this target at each iteration, delta coded within each target.
+            int prev = 0;
+            for (int pathIdx : paths) {
+                outputStream.write(pathIdx - prev);
+                prev = pathIdx;
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/conveyal/r5/analyst/cluster/RegionalTask.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/RegionalTask.java
@@ -24,15 +24,20 @@ public class RegionalTask extends AnalysisTask implements Cloneable {
      */
     public int x = -1, y = -1;
 
-    /** The grid key on S3 to compute access to. If this is not blank, the default TravelTimeSurfaceTask will be
+    /**
+     * The grid key on S3 to compute access to. If this is not blank, the default TravelTimeSurfaceTask will be
      * overridden; returnInVehicleTimes, returnWaitTimes, and returnPaths will be set to false; and the returned results
-     * will be an accessibility value per origin, rather than a grid of travel times from that origin.*/
+     * will be an accessibility value per origin, rather than a grid of travel times from that origin.
+     */
     public String grid;
 
-    /** An array of grid keys on S3 to compute access to. If this is not blank, the default TravelTimeSurfaceTask will be
+    /**
+     * An array of grid keys on S3 to compute access to. If this is not blank, the default TravelTimeSurfaceTask will be
      * overridden; returnInVehicleTimes, returnWaitTimes, and returnPaths will be set to false; and the returned results
      * will be an accessibility value per origin for each destination grid, rather than a grid of travel times from
-     * that origin.*/
+     * that origin.
+     * NOT YET IMPLEMENTED AND TESTED
+     */
     public List <String> grids;
 
     /** Where should output of this job be saved */

--- a/src/main/java/com/conveyal/r5/analyst/cluster/RegionalTask.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/RegionalTask.java
@@ -56,24 +56,35 @@ public class RegionalTask extends AnalysisTask implements Cloneable {
         return false; // regional analysis tasks are not high priority
     }
 
-    /** Regional analyses use the extents of the destination opportunity grids as their destination extents.
+    /**
+     * Regional analyses use the extents of the destination opportunity grids as their destination extents.
      * We don't want to enqueue duplicate tasks with the same destination pointset extents, because it is more efficient
-     * to compute travel time for a given destination only once, then accumulate multiple accessibility values for multiple
-     * opportunities at that destination*/
-
+     * to compute travel time for a given destination only once, then accumulate multiple accessibility values
+     * for multiple opportunities at that destination.
+     */
     @Override
     public List<PointSet> getDestinations(TransportNetwork network, GridCache gridCache) {
         List<Grid> gridList = new ArrayList<>();
         List<PointSet> pointSets = new ArrayList<>();
 
-        //TODO check that this actually works and clean it up
-        if (grid != null){ // single grid specified
+        if (makeStaticSite) {
+            // In the special case where we're making a static site, a regional task is producing travel time grids.
+            // This is unlike the usual case where regional tasks produce accessibility indicator values.
+            // Because the time grids are not intended for one particular set of destinations,
+            // they should cover the whole analysis region.
+            // FIXME this limits the destination grid bounds to be exactly those of the origin grid.
+            pointSets.add(gridPointSetCache.get(this.zoom, this.west, this.north, this.width, this.height, network.gridPointSet));
+            return pointSets;
+        }
 
+        if (grid != null){
+            // A single grid is specified.
             gridData = gridCache.get(grid);
             pointSets.add(gridPointSetCache.get(gridData, network.gridPointSet));
-
-        } else { // grids specified; add only the first one, and any with different extents, to pointSets
-
+        } else {
+            // Multiple grids should be specified. Add only the first one, and any with different extents, to pointSets.
+            // TODO more explanation, complete implementation. This block is currently unused.
+            // FIXME we really shouldn't have two different implementations present, one for a list and one for a single grid.
             gridData = gridCache.get(grids.get(0));
             gridList.add(gridData);
             pointSets.add(gridPointSetCache.get(gridData, network.gridPointSet));

--- a/src/main/java/com/conveyal/r5/analyst/cluster/RegionalTask.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/RegionalTask.java
@@ -110,7 +110,8 @@ public class RegionalTask extends AnalysisTask implements Cloneable {
      * Otherwise, use a reducer that returns accessibility values. */
     @Override
     public PerTargetPropagater.TravelTimeReducer getTravelTimeReducer(TransportNetwork network, OutputStream os) {
-        if (gridData == null) {
+        if (gridData == null || makeStaticSite) {
+            // When making a static site, we want to save travel time surfaces for no particular grid.
             return new TravelTimeSurfaceReducer(this, network, os);
         } else {
             return new BootstrappingTravelTimeReducer(this, gridData);

--- a/src/main/java/com/conveyal/r5/analyst/cluster/TravelTimeSurfaceTask.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/TravelTimeSurfaceTask.java
@@ -50,12 +50,18 @@ public class TravelTimeSurfaceTask extends AnalysisTask {
     }
 
     /**
-     * Since this may be applied to many different grids, we use the extents defined in the request.
+     * Travel time results may be combined with many different grids, so we don't want to limit their geographic extent
+     * to that of any one grid. Instead we use the extents supplied in the request.
+     * The UI only sends these if the user has changed them to something other than "full region".
+     * If "full region" is selected, the UI sends nothing and the backend fills in the bounds of the region.
+     *
+     * FIXME: the request bounds indicate either origin bounds or destination bounds depending on the request type.
+     * We need to specify these separately as we merge all the request types.
      */
     @Override
     public List<PointSet> getDestinations(TransportNetwork network, GridCache gridCache) {
         List pointSets = new ArrayList<>();
-        // Use TransportNetwork gridPointSet as base to avoid relinking
+        // Reuse linkages in the base gridPointSet stored in the TransportNetwork as to avoid relinking
         pointSets.add(gridPointSetCache.get(this.zoom, this.west, this.north, this.width, this.height, network.gridPointSet));
         return pointSets;
     }

--- a/src/main/java/com/conveyal/r5/multipoint/MultipointDataStore.java
+++ b/src/main/java/com/conveyal/r5/multipoint/MultipointDataStore.java
@@ -16,6 +16,10 @@ import java.util.zip.GZIPOutputStream;
 public abstract class MultipointDataStore {
     private static AmazonS3 s3 = new AmazonS3Client();
 
+//    static {
+//        s3.setRegion(Region.getRegion(Regions.EU_WEST_1));
+//    }
+
     /**
      * Get an output stream to upload an object to S3 for the given static site request.
      * There is no need to gzip data going into this stream, it will be gzipped on upload in storage and when downloaded
@@ -30,10 +34,7 @@ public abstract class MultipointDataStore {
         PipedOutputStream pipeOut = new PipedOutputStream();
         PipedInputStream pipeIn = new PipedInputStream(pipeOut);
 
-        //TODO use a better key
-        String key = "static-results/" + req.outputDirectory + "/" + filename;
-
-        PutObjectRequest por = new PutObjectRequest(req.outputBucket, key, pipeIn, md);
+        PutObjectRequest por = new PutObjectRequest("analysis-static/" + req.jobId, filename, pipeIn, md);
         // buffer files up to 100MB
         por.getRequestClientOptions().setReadLimit(100 * 1024 * 1024 + 1);
 

--- a/src/main/java/com/conveyal/r5/profile/PerTargetPropagater.java
+++ b/src/main/java/com/conveyal/r5/profile/PerTargetPropagater.java
@@ -217,8 +217,9 @@ public class PerTargetPropagater {
         default void finish () {}
     }
 
-    /** Uses streaming to write paths from a given origin to all targets.
-     *
+    /**
+     * Uses streaming to write paths from a given origin to all targets.
+     * TODO merge interface into its only implementation.
      */
     public interface PathWriter {
 


### PR DESCRIPTION
This PR makes some additional changes so that we can actually signal to the workers that they should produce travel time surfaces and save them to s3 when calculating regional analysis tasks. This provides the files that will be used by the next version of the static sites UI.

Requires a few changes in analysis-backend (in a branch with the same name) to actually trigger the behavior.