### PR TITLE
Correct write ints to OutputStreams

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/TravelTimeComputer.java
+++ b/src/main/java/com/conveyal/r5/analyst/TravelTimeComputer.java
@@ -289,7 +289,7 @@ public class TravelTimeComputer {
                         waitTimesToStops, pathsToStops);
                 // TODO factor out identical lines in else clause
                 perTargetPropagater.travelTimeReducer = travelTimeReducer;
-                perTargetPropagater.pathWriter = new PathWriter(request, network, pathList);
+                perTargetPropagater.pathWriter = new PathWriter(request, network, pathList, egressModeLinkedDestinations.size(), transitTravelTimesToStops.length);
             } else {
                 perTargetPropagater = new PerTargetPropagater(egressModeLinkedDestinations, request,
                         transitTravelTimesToStops, nonTransitTravelTimesToDestinations, null, null, null);

--- a/src/main/java/com/conveyal/r5/analyst/TravelTimeComputer.java
+++ b/src/main/java/com/conveyal/r5/analyst/TravelTimeComputer.java
@@ -289,7 +289,7 @@ public class TravelTimeComputer {
                         waitTimesToStops, pathsToStops);
                 // TODO factor out identical lines in else clause
                 perTargetPropagater.travelTimeReducer = travelTimeReducer;
-                perTargetPropagater.pathWriter = new PathWriter(request, network, pathList, egressModeLinkedDestinations.size(), transitTravelTimesToStops.length);
+                perTargetPropagater.pathWriter = new PathWriter(request, network, pathList, egressModeLinkedDestinations.size(), iterations);
             } else {
                 perTargetPropagater = new PerTargetPropagater(egressModeLinkedDestinations, request,
                         transitTravelTimesToStops, nonTransitTravelTimesToDestinations, null, null, null);

--- a/src/main/java/com/conveyal/r5/analyst/cluster/PathWriter.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/PathWriter.java
@@ -2,7 +2,6 @@ package com.conveyal.r5.analyst.cluster;
 
 import com.conveyal.r5.multipoint.MultipointDataStore;
 import com.conveyal.r5.profile.Path;
-import com.conveyal.r5.profile.PerTargetPropagater;
 import com.conveyal.r5.transit.TransportNetwork;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,22 +32,26 @@ public class PathWriter {
 
     OutputStream outputStream;
 
-    public PathWriter (AnalysisTask task, TransportNetwork network, List<Path> pathList) {
+    public PathWriter (AnalysisTask task, TransportNetwork network, List<Path> pathList, int destinations, int iterations) {
         this.task = task;
         this.network = network;
         this.pathList = pathList;
         try {
             outputStream = MultipointDataStore.getOutputStream(task, task.taskId + "_paths.dat", "application/octet-stream");
             outputStream.write("PATHGRID".getBytes());
+            // In the header store the number of destinations stored and iterations used
+            writeInt(destinations);
+            writeInt(iterations);
+
             // Write the number of different paths used to reach all destination cells
-            outputStream.write(pathList.size());
+            writeInt(pathList.size());
             // Write the details for each of those paths
             for (Path path : pathList) {
-                outputStream.write(path.patterns.length);
+                writeInt(path.patterns.length);
                 for (int i = 0 ; i < path.patterns.length; i ++){
-                    outputStream.write(path.boardStops[i]);
-                    outputStream.write(path.patterns[i]);
-                    outputStream.write(path.alightStops[i]);
+                    writeInt(path.boardStops[i]);
+                    writeInt(path.patterns[i]);
+                    writeInt(path.alightStops[i]);
                 }
             }
         } catch (IOException e) {
@@ -61,12 +64,25 @@ public class PathWriter {
             // Write the path indexes used to reach this target at each iteration, delta coded within each target.
             int prev = 0;
             for (int pathIdx : paths) {
-                outputStream.write(pathIdx - prev);
+                writeInt(pathIdx - prev);
                 prev = pathIdx;
             }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     *
+     * @param value
+     * @throws IOException
+     */
+    private void writeInt (int value) throws IOException {
+        this.outputStream.write(new byte[] {
+            (byte)(value >>> 24),
+            (byte)(value >>> 16),
+            (byte)(value >>> 8),
+            (byte)value});
     }
 
     public void finishPaths(){

--- a/src/main/java/com/conveyal/r5/multipoint/MultipointDataStore.java
+++ b/src/main/java/com/conveyal/r5/multipoint/MultipointDataStore.java
@@ -5,9 +5,11 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.conveyal.r5.analyst.cluster.AnalysisTask;
-import org.joda.time.DateTime;
+import com.google.common.io.LittleEndianDataOutputStream;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
 import java.util.zip.GZIPOutputStream;
 
 /**
@@ -24,7 +26,7 @@ public abstract class MultipointDataStore {
      * Get an output stream to upload an object to S3 for the given static site request.
      * There is no need to gzip data going into this stream, it will be gzipped on upload in storage and when downloaded
      */
-    public static OutputStream getOutputStream (AnalysisTask req, String filename, String type) throws IOException {
+    public static LittleEndianDataOutputStream getOutputStream (AnalysisTask req, String filename, String type) throws IOException {
         ObjectMetadata md = new ObjectMetadata();
         // This way the browser will decompress on download
         // http://www.rightbrainnetworks.com/blog/serving-compressed-gzipped-static-files-from-amazon-s3-or-cloudfront/
@@ -44,6 +46,6 @@ public abstract class MultipointDataStore {
             s3.putObject(por);
         }).start();
 
-        return new GZIPOutputStream(pipeOut);
+        return new LittleEndianDataOutputStream(new GZIPOutputStream(pipeOut));
     }
 }


### PR DESCRIPTION
Previously we were using the base `write` method which only wrote the first 8 bits of an integer
when we were expecting the full 32. This PR corrects the writing of those ints and adds two more items to the path file headers for clarity.