### PR TITLE
Invert time grid storage loop and explicitly use LittleEndianDataOutputStreams

### DIFF
--- a/src/main/java/com/conveyal/r5/multipoint/MultipointDataStore.java
+++ b/src/main/java/com/conveyal/r5/multipoint/MultipointDataStore.java
@@ -16,11 +16,7 @@ import java.util.zip.GZIPOutputStream;
  * Store static site publication data in S3.
  */
 public abstract class MultipointDataStore {
-    private static AmazonS3 s3 = new AmazonS3Client();
-
-//    static {
-//        s3.setRegion(Region.getRegion(Regions.EU_WEST_1));
-//    }
+    private static AmazonS3 s3 = AmazonS3Client.builder().build();
 
     /**
      * Get an output stream to upload an object to S3 for the given static site request.


### PR DESCRIPTION
Utilizes the changes made in #405 and addresses #404. Will require front-end changes in the Analysis UI and Taui to work with the new storage format.

Intellij automatically expanded the `import java.io.*;` on save...is that the style we use?