### PR TITLE
Hardcode percentiles (DO NOT MERGE)

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
@@ -314,6 +314,7 @@ public class AnalystWorker implements Runnable {
     private void handleOneRequest(AnalysisTask request) {
         if (request.isHighPriority()) {
             lastHighPriorityTaskProcessed = System.currentTimeMillis();
+            request.percentiles = new double[] {5,10,15,20,25};
             if (!sideChannelOpen) {
                 openSideChannel();
             }


### PR DESCRIPTION
A user needs accessibility values given 15th percentile travel times.  This hack will display the right values in the UI.