### PR TITLE
Limit shapefile size

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/Grid.java
+++ b/src/main/java/com/conveyal/r5/analyst/Grid.java
@@ -103,7 +103,7 @@ public class Grid {
     public final double[][] grid;
 
     /** Maximum area allowed for the bounding box of an uploaded shapefile -- large enough for New York State.  */
-    private static final double MAX_BOUNDING_BOX_AREA_SQ_KM = 250000;
+    private static final double MAX_BOUNDING_BOX_AREA_SQ_KM = 250 000;
 
     /** Maximum area allowed for features in a shapefile upload */
     double MAX_FEATURE_AREA_SQ_DEG = 0.01;

--- a/src/main/java/com/conveyal/r5/analyst/Grid.java
+++ b/src/main/java/com/conveyal/r5/analyst/Grid.java
@@ -105,6 +105,9 @@ public class Grid {
     /** Maximum area allowed for the bounding box of an uploaded shapefile -- large enough for New York State.  */
     private static final double MAX_BOUNDING_BOX_AREA_SQ_KM = 250000;
 
+    /** Maximum area allowed for features in a shapefile upload */
+    double MAX_FEATURE_AREA_SQ_DEG = 0.01;
+
     /**
      * @param zoom web mercator zoom level for the grid.
      * @param north latitude in decimal degrees of the north edge of this grid.

--- a/src/main/java/com/conveyal/r5/analyst/Grid.java
+++ b/src/main/java/com/conveyal/r5/analyst/Grid.java
@@ -102,6 +102,9 @@ public class Grid {
     /** The data values for each pixel within this grid. */
     public final double[][] grid;
 
+    /** Maximum area allowed for the bounding box of an uploaded shapefile -- large enough for New York State.  */
+    private static final double MAX_BOUNDING_BOX_AREA_SQ_KM = 250000;
+
     /**
      * @param zoom web mercator zoom level for the grid.
      * @param north latitude in decimal degrees of the north edge of this grid.
@@ -183,7 +186,11 @@ public class Grid {
 
         double area = geometry.getArea();
         if (area < 1e-12) {
-            throw new IllegalArgumentException("Geometry is too small");
+            throw new IllegalArgumentException("Feature geometry is too small");
+        }
+
+        if (area > MAX_FEATURE_AREA_SQ_DEG) {
+            throw new IllegalArgumentException("Feature geometry is too large");
         }
 
         PreparedGeometry preparedGeom = pgFact.create(geometry);
@@ -595,6 +602,13 @@ public class Grid {
     public static Map<String, Grid> fromShapefile (File shapefile, int zoom, BiConsumer<Integer, Integer> statusListener) throws IOException, FactoryException, TransformException {
         Map<String, Grid> grids = new HashMap<>();
         ShapefileReader reader = new ShapefileReader(shapefile);
+
+        double boundingBoxAreaSqKm = reader.getAreaSqKm();
+
+        if (boundingBoxAreaSqKm > MAX_BOUNDING_BOX_AREA_SQ_KM){
+            throw new IllegalArgumentException("Shapefile extent (" + boundingBoxAreaSqKm + " sq. km.) exceeds limit (" +
+                    MAX_BOUNDING_BOX_AREA_SQ_KM + "sq. km.).");
+        }
 
         Envelope envelope = reader.wgs84Bounds();
         int total = reader.getFeatureCount();

--- a/src/main/java/com/conveyal/r5/util/ShapefileReader.java
+++ b/src/main/java/com/conveyal/r5/util/ShapefileReader.java
@@ -52,6 +52,11 @@ public class ShapefileReader {
 
         features = source.getFeatures(filter);
         crs = features.getSchema().getCoordinateReferenceSystem();
+
+        if (crs == null) {
+            throw new IllegalArgumentException("Unrecognized shapefile projection");
+        }
+
         transform = CRS.findMathTransform(crs, DefaultGeographicCRS.WGS84, true);
     }
 

--- a/src/main/java/com/conveyal/r5/util/ShapefileReader.java
+++ b/src/main/java/com/conveyal/r5/util/ShapefileReader.java
@@ -77,6 +77,14 @@ public class ShapefileReader {
         return source.getBounds();
     }
 
+    public double getAreaSqKm () throws IOException, TransformException, FactoryException {
+        CoordinateReferenceSystem webMercatorCRS = CRS.decode("EPSG:3857");
+        MathTransform webMercatorTransform = CRS.findMathTransform(crs, webMercatorCRS, true);
+        Envelope mercatorEnvelope = JTS.transform(getBounds(), webMercatorTransform);
+        return mercatorEnvelope.getArea() / 1000 / 1000;
+
+    }
+
     public Stream<SimpleFeature> wgs84Stream () throws IOException, TransformException {
         return stream().map(f -> {
             Geometry g = (Geometry) f.getDefaultGeometry();


### PR DESCRIPTION
We've had multiple instances of users locking up the server by uploading geometries that are too large.  These large geometries usually indicate data errors (e.g. features at null island) or incorrect projections.

This PR should help avoid locking up by throwing explicit exceptions if:
- The shapefile projection is unrecognized
- The area of the overall shapefile bounding box exceeds 250,000 sq. km.
- The area of any feature exceeds 0.01 sq. degrees.  The individual features are processed as WGS84, so to avoid doing a large number of transformations, I'm proposing to use an area limit in square degrees.  This should be fine unless we start doing accessibility analyses in Antarctica.