### PR TITLE
Analysis workers: break down throughput by job ID

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
@@ -40,7 +40,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -154,13 +153,8 @@ public class AnalystWorker implements Runnable {
     /** The last time (in milliseconds since the epoch) that we polled for work. */
     private long lastPollingTime;
 
-    /**
-     * A list of times at which tasks have been completed. Regularly truncated to only times in the last minute.
-     * This allows reporting average throughput over different timescales up to one minute.
-     */
-    // TODO replace with TaskStats containing more info about timing breakdown
-    // private List<TaskStats> taskStats = new LinkedList<>();
-    List<Long> recentTaskCompletionTimes = new LinkedList<>();
+    /** Keep track of how many tasks per minute this worker is processing, broken down by scenario ID. */
+    ThroughputTracker throughputTracker = new ThroughputTracker();
 
     /**
      * This has been pulled out into a method so the broker can also make a similar http client.
@@ -480,9 +474,7 @@ public class AnalystWorker implements Runnable {
                 // FIXME strangeness, only travel time results are returned from method, accessibility results return null and are accumulated for async delivery.
                 // Return raw byte array containing grid or TIFF file to caller, for return to client over HTTP.
                 byteArrayOutputStream.close();
-                synchronized (recentTaskCompletionTimes) {
-                    recentTaskCompletionTimes.add(System.currentTimeMillis());
-                }
+                throughputTracker.recordTaskCompletion(transportNetwork.scenarioId);
                 return byteArrayOutputStream.toByteArray();
             } else {
                 // This is a single task within a regional analysis with many origins.
@@ -503,9 +495,7 @@ public class AnalystWorker implements Runnable {
                 synchronized (workResults) {
                     workResults.add(oneOriginResult.toRegionalWorkResult(request));
                 }
-                synchronized (recentTaskCompletionTimes) {
-                    recentTaskCompletionTimes.add(System.currentTimeMillis());
-                }
+                throughputTracker.recordTaskCompletion(transportNetwork.scenarioId);
             }
         } catch (Exception ex) {
             // Catch any exceptions that were not handled by more specific catch clauses above.
@@ -551,13 +541,7 @@ public class AnalystWorker implements Runnable {
         // Compute throughput in tasks per minute and include it in the worker status report.
         // We poll too frequently to compute throughput just since the last poll operation.
         // TODO reduce polling frequency (larger queue in worker), compute shorter-term throughput.
-        synchronized (recentTaskCompletionTimes) {
-            long oneMinuteAgo = System.currentTimeMillis() - 1000 * 60;
-            while (!recentTaskCompletionTimes.isEmpty() && recentTaskCompletionTimes.get(0) < oneMinuteAgo) {
-                recentTaskCompletionTimes.remove(0);
-            }
-            workerStatus.tasksPerMinute = recentTaskCompletionTimes.size();
-        }
+        workerStatus.tasksPerMinuteByScenario = throughputTracker.getTasksPerMinuteByScenarioId();
 
         // Report how often we're polling for work, just for monitoring.
         long timeNow = System.currentTimeMillis();

--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
@@ -474,8 +474,8 @@ public class AnalystWorker implements Runnable {
                 // FIXME strangeness, only travel time results are returned from method, accessibility results return null and are accumulated for async delivery.
                 // Return raw byte array containing grid or TIFF file to caller, for return to client over HTTP.
                 byteArrayOutputStream.close();
-                // Single-point tasks don't have a job ID. Should we categorize them by scenario ID?
-                throughputTracker.recordTaskCompletion("SINGLE");
+                // Single-point tasks don't have a job ID. For now, we'll categorize them by scenario ID.
+                throughputTracker.recordTaskCompletion("SINGLE-" + transportNetwork.scenarioId);
                 return byteArrayOutputStream.toByteArray();
             } else {
                 // This is a single task within a regional analysis with many origins.

--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
@@ -474,7 +474,8 @@ public class AnalystWorker implements Runnable {
                 // FIXME strangeness, only travel time results are returned from method, accessibility results return null and are accumulated for async delivery.
                 // Return raw byte array containing grid or TIFF file to caller, for return to client over HTTP.
                 byteArrayOutputStream.close();
-                throughputTracker.recordTaskCompletion(transportNetwork.scenarioId);
+                // Single-point tasks don't have a job ID. Should we categorize them by scenario ID?
+                throughputTracker.recordTaskCompletion("SINGLE");
                 return byteArrayOutputStream.toByteArray();
             } else {
                 // This is a single task within a regional analysis with many origins.
@@ -495,7 +496,7 @@ public class AnalystWorker implements Runnable {
                 synchronized (workResults) {
                     workResults.add(oneOriginResult.toRegionalWorkResult(request));
                 }
-                throughputTracker.recordTaskCompletion(transportNetwork.scenarioId);
+                throughputTracker.recordTaskCompletion(request.jobId);
             }
         } catch (Exception ex) {
             // Catch any exceptions that were not handled by more specific catch clauses above.
@@ -541,7 +542,7 @@ public class AnalystWorker implements Runnable {
         // Compute throughput in tasks per minute and include it in the worker status report.
         // We poll too frequently to compute throughput just since the last poll operation.
         // TODO reduce polling frequency (larger queue in worker), compute shorter-term throughput.
-        workerStatus.tasksPerMinuteByScenario = throughputTracker.getTasksPerMinuteByScenarioId();
+        workerStatus.tasksPerMinuteByJobId = throughputTracker.getTasksPerMinuteByJobId();
 
         // Report how often we're polling for work, just for monitoring.
         long timeNow = System.currentTimeMillis();

--- a/src/main/java/com/conveyal/r5/analyst/cluster/ThroughputTracker.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/ThroughputTracker.java
@@ -1,0 +1,66 @@
+package com.conveyal.r5.analyst.cluster;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Keep track of tasks throughput on worker, grouped by scenario.
+ * All public methods should be synchronized since they will be called by several different threads at once.
+ */
+public class ThroughputTracker {
+
+    /**
+     * A list of times at which tasks have been completed. Regularly truncated to only times in the last minute.
+     * This allows reporting average throughput over different timescales up to one minute.
+     * TODO replace Long times with TaskStats containing more info about timing breakdown
+     */
+    private Map<String, List<Long>> recentTaskCompletionTimesByScenario = new HashMap<>();
+
+    /**
+     * Indicate to the tracker that a task has just been completed for the specified scenario.
+     */
+    public synchronized void recordTaskCompletion(String scenarioId) {
+        List<Long> times = recentTaskCompletionTimesByScenario.get(scenarioId);
+        if (times == null) {
+            // Use a linked list so that elsewhere we can efficiently repeatedly remove the zeroth element.
+            times = new LinkedList<>();
+            recentTaskCompletionTimesByScenario.put(scenarioId, times);
+        }
+        times.add(System.currentTimeMillis());
+    }
+
+    /**
+     * @return the number of tasks completed for each scenario in the last minute, intended to be serialized as JSON.
+     */
+    public synchronized Map<String, Integer> getTasksPerMinuteByScenarioId () {
+        // First clear out all tasks more than one minute old for every scenario.
+        removeOldTasks();
+        // Then summarize how many tasks were recorded in the last minute on each scenario.
+        Map<String, Integer> tasksPerMinuteByScenarioId = new HashMap<>();
+        recentTaskCompletionTimesByScenario.forEach((scenarioId, times) ->
+                tasksPerMinuteByScenarioId.put(scenarioId, times.size()));
+        return tasksPerMinuteByScenarioId;
+    }
+
+    /**
+     * Remove all tasks from the lists that are more than 1 minute old.
+     * Any scenarios for which no tasks have been finished in the last minute will be removed.
+     */
+    private synchronized void removeOldTasks () {
+        long oneMinuteAgo = System.currentTimeMillis() - 1000 * 60;
+        Iterator<Map.Entry<String, List<Long>>> iterator = recentTaskCompletionTimesByScenario.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<String, List<Long>> entry = iterator.next();
+            List<Long> times = entry.getValue();
+            while (!times.isEmpty() && times.get(0) < oneMinuteAgo) {
+                // For efficiency this should be operating on a linked list rather than an array.
+                times.remove(0);
+            }
+            if (times.isEmpty()) iterator.remove();
+        }
+    }
+
+}

--- a/src/main/java/com/conveyal/r5/analyst/cluster/WorkerStatus.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/WorkerStatus.java
@@ -38,7 +38,7 @@ public class WorkerStatus {
     public Set<String> networks = new HashSet<>();
     public Set<String> scenarios = new HashSet<>();
     public double secondsSinceLastPoll;
-    public Map<String, Integer> tasksPerMinuteByScenario;
+    public Map<String, Integer> tasksPerMinuteByJobId;
     @JsonUnwrapped(prefix = "ec2")
     public EC2Info ec2;
     public long jvmStartTime;

--- a/src/main/java/com/conveyal/r5/analyst/cluster/WorkerStatus.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/WorkerStatus.java
@@ -14,6 +14,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -37,7 +38,7 @@ public class WorkerStatus {
     public Set<String> networks = new HashSet<>();
     public Set<String> scenarios = new HashSet<>();
     public double secondsSinceLastPoll;
-    public double tasksPerMinute;
+    public Map<String, Integer> tasksPerMinuteByScenario;
     @JsonUnwrapped(prefix = "ec2")
     public EC2Info ec2;
     public long jvmStartTime;


### PR DESCRIPTION
@trevorgerhardt and I talked about this improvement the other day. In the Analysis admin panel, it would be nice to see which workers are working on which jobs. With this change, the throughput of the worker is broken down by job ID when it's reported, allowing workers to be filtered by which jobs they are working on.