### PR TITLE
Respond to single-point requests with scenario errors that arise

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
@@ -565,7 +565,7 @@ public class AnalystWorker implements Runnable {
             // Use the lenient object mapper here in case the broker is a newer version so sending unrecognizable fields
             return JsonUtilities.lenientObjectMapper.readValue(entity.getContent(), new TypeReference<List<AnalysisTask>>() {});
         } catch (Exception e) {
-            LOG.error("Exception while polling backend for work: {}", e.toString());
+            LOG.error("Exception while polling backend for work: {}",ExceptionUtils.asString(e));
         }
         return null;
     }
@@ -590,7 +590,7 @@ public class AnalystWorker implements Runnable {
                 LOG.warn("Errors while completing task:\n" + taskErrors.toString());
             }
         } catch (Exception e) {
-            LOG.error("An exception occurred while attempting to report an error:\n" + e.toString());
+            LOG.error("An exception occurred while attempting to report an error:\n" + ExceptionUtils.asString(e));
         }
         return null;
     }
@@ -614,7 +614,7 @@ public class AnalystWorker implements Runnable {
             buffer = PersistenceBuffer.serializeAsJson(transitiveNetwork);
             AnalystWorker.filePersistence.saveStaticSiteData(analysisTask, "transitive.json", buffer);
         } catch (Exception e) {
-            LOG.error("Exception saving static metadata: {}", e.toString());
+            LOG.error("Exception saving static metadata: {}", ExceptionUtils.asString(e));
             throw new RuntimeException(e);
         }
     }
@@ -641,13 +641,13 @@ public class AnalystWorker implements Runnable {
         try (InputStream configInputStream = new FileInputStream(new File(configFileName))) {
             config.load(configInputStream);
         } catch (Exception e) {
-            LOG.error("Error loading worker configuration, shutting down. " + e.toString());
+            LOG.error("Error loading worker configuration, shutting down. " + ExceptionUtils.asString(e));
             return;
         }
         try {
             AnalystWorker.forConfig(config).run();
         } catch (Exception e) {
-            LOG.error("Unhandled error in analyst worker, shutting down. " + e.toString());
+            LOG.error("Unhandled error in analyst worker, shutting down. " + ExceptionUtils.asString(e));
         }
     }
 

--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
@@ -436,11 +436,8 @@ public class AnalystWorker implements Runnable {
                 transportNetwork = transportNetworkCache.getNetworkForScenario(networkId, request);
             } catch (ScenarioApplicationException scenarioException) {
                 // Handle exceptions specifically representing a failure to apply the scenario.
-                // These exceptions can be turned into structured JSON.
-                // Report the error back to the broker, which can then pass it back out to the client.
                 // Any other kinds of exceptions will be caught by the outer catch clause
-                reportTaskErrors(request.taskId, HttpStatus.BAD_REQUEST_400, scenarioException.taskErrors);
-                return null;
+                return reportTaskErrors(request, scenarioException.taskErrors);
             }
 
             // If we are generating a static site, there must be a single metadata file for an entire batch of results.
@@ -503,7 +500,7 @@ public class AnalystWorker implements Runnable {
             // This ensures that some form of error message is passed all the way back up to the web UI.
             TaskError taskError = new TaskError(ex);
             LOG.error("An error occurred while routing: {}", ExceptionUtils.asString(ex));
-            reportTaskErrors(request.taskId, HttpStatus.INTERNAL_SERVER_ERROR_500, Arrays.asList(taskError));
+            reportTaskErrors(request, Arrays.asList(taskError));
         }
         return null;
     }
@@ -580,19 +577,25 @@ public class AnalystWorker implements Runnable {
      * FIXME this task reporting mechanism seems to be using an endpoint that's no longer defined.
      * We should probably just include errors in the regional results JSON returned to the backend.
      */
-    public void reportTaskErrors(int taskId, int httpStatusCode, List<TaskError> taskErrors) {
-        String url = brokerBaseUrl + String.format("/complete/%d/%s", httpStatusCode, taskId);
+    public byte[] reportTaskErrors(AnalysisTask request, List<TaskError> taskErrors) {
         try {
-            HttpPost httpPost = new HttpPost(url);
-            httpPost.setHeader("Content-type", "application/json");
-            httpPost.setEntity(JsonUtilities.objectToJsonHttpEntity(taskErrors));
-            // Send the JSON serialized error object to the broker.
-            HttpResponse response = httpClient.execute(httpPost);
-            // Tell the http client library that we won't do anything with the broker's response, allowing connection reuse.
-            EntityUtils.consumeQuietly(response.getEntity());
+            if (request.isHighPriority()) {
+                // For single-point requests, return a TimeGrid filled with UNREACHABLE, with the errors appended
+                LOG.warn("Reporting errors in response to single-point request:\n" + taskErrors.toString());
+                TimeGrid emptyTimeGrid = new TimeGrid(request.zoom, request.west, request.north, request.width, request.height, request.percentiles.length);
+                ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+                emptyTimeGrid.writeGridToDataOutput(new LittleEndianDataOutputStream(byteArrayOutputStream));
+                addErrorJson(byteArrayOutputStream, taskErrors);
+                byteArrayOutputStream.close();
+                return byteArrayOutputStream.toByteArray();
+            } else {
+                // TODO handle regional result errors, or force users to "preflight" regional results by running single-point request in UI
+                LOG.warn("Errors while completing task:\n" + taskErrors.toString());
+            }
         } catch (Exception e) {
-            LOG.error("An exception occurred while attempting to report an error to the broker:\n" + e.getStackTrace());
+            LOG.error("An exception occurred while attempting to report an error:\n" + e.toString());
         }
+        return null;
     }
 
     /**

--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
@@ -571,11 +571,8 @@ public class AnalystWorker implements Runnable {
     }
 
     /**
-     * Report to the broker that the task taskId could not be processed due to errors.
-     * The broker should then pass the errors back up to the client that enqueued that task.
-     * Those objects are always the same type (TaskError) so the client knows what to expect.
-     * FIXME this task reporting mechanism seems to be using an endpoint that's no longer defined.
-     * We should probably just include errors in the regional results JSON returned to the backend.
+     * Report that the task could not be processed due to errors.
+     * For the moment, we are sending back the list of TaskErrors appended as json to a default response.
      */
     public byte[] reportTaskErrors(AnalysisTask request, List<TaskError> taskErrors) {
         try {


### PR DESCRIPTION
Addresses #424 

We still don't have a good way of handling errors that arise in regional analyses.  I've had users request support when their analyses are stuck at 0, and I find basic bundle/scenario errors upon checking logs.

One option would be forcing users to "preflight" regional runs with a single-point request by disabling the "New Regional Analysis" button in the UI unless isochrones are shown.