### PR TITLE
Give link edges a length

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -361,7 +361,7 @@
         <dependency>
             <groupId>com.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
-            <version>3.0.2</version>
+            <version>3.0.3</version>
         </dependency>
         <!-- Conveyal library for loading and storing OSM road data. -->
         <dependency>

--- a/src/main/java/com/conveyal/r5/streets/StreetLayer.java
+++ b/src/main/java/com/conveyal/r5/streets/StreetLayer.java
@@ -1290,15 +1290,9 @@ public class StreetLayer implements Serializable, Cloneable {
             return -1; // Unlinked
         }
 
-        double streetVertexLat = vertexStore.fixedLats.get(streetVertex)/FIXED_FACTOR;
-        double streetVertexLon = vertexStore.fixedLons.get(streetVertex)/FIXED_FACTOR;
-
-        ArrayList<Node> edgeNodes = new ArrayList<>();
-        edgeNodes.add(new Node(lat, lon));
-        edgeNodes.add(new Node(streetVertexLat,streetVertexLon));
-        int length = getEdgeLengthMillimeters(edgeNodes);
+        int length_mm = (int) (GeometryUtils.distance(lat,lon, vertexStore.getCursor(streetVertex).getLat(), vertexStore.getCursor(streetVertex).getLon())*1000);
         // Set OSM way ID is -1 because this edge is not derived from any OSM way.
-        Edge e = edgeStore.addStreetPair(stopVertex, streetVertex, length, -1);
+        Edge e = edgeStore.addStreetPair(stopVertex, streetVertex, length_mm, -1);
 
         // Allow all modes to traverse street-to-transit link edges.
         // In practice, mode permissions will be controlled by whatever street edges lead up to these link edges.

--- a/src/main/java/com/conveyal/r5/streets/StreetLayer.java
+++ b/src/main/java/com/conveyal/r5/streets/StreetLayer.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
+import static com.conveyal.r5.streets.VertexStore.FIXED_FACTOR;
 import static com.conveyal.r5.streets.VertexStore.fixedDegreeGeometryToFloating;
 import static com.conveyal.r5.streets.VertexStore.fixedDegreesToFloating;
 
@@ -1289,9 +1290,15 @@ public class StreetLayer implements Serializable, Cloneable {
             return -1; // Unlinked
         }
 
-        // TODO give link edges a length.
+        double streetVertexLat = vertexStore.fixedLats.get(streetVertex)/FIXED_FACTOR;
+        double streetVertexLon = vertexStore.fixedLons.get(streetVertex)/FIXED_FACTOR;
+
+        ArrayList<Node> edgeNodes = new ArrayList<>();
+        edgeNodes.add(new Node(lat, lon));
+        edgeNodes.add(new Node(streetVertexLat,streetVertexLon));
+        int length = getEdgeLengthMillimeters(edgeNodes);
         // Set OSM way ID is -1 because this edge is not derived from any OSM way.
-        Edge e = edgeStore.addStreetPair(stopVertex, streetVertex, 1, -1);
+        Edge e = edgeStore.addStreetPair(stopVertex, streetVertex, length, -1);
 
         // Allow all modes to traverse street-to-transit link edges.
         // In practice, mode permissions will be controlled by whatever street edges lead up to these link edges.

--- a/src/main/java/com/conveyal/r5/streets/StreetLayer.java
+++ b/src/main/java/com/conveyal/r5/streets/StreetLayer.java
@@ -1285,14 +1285,15 @@ public class StreetLayer implements Serializable, Cloneable {
      */
     public int createAndLinkVertex (double lat, double lon) {
         int stopVertex = vertexStore.addVertex(lat, lon);
-        int streetVertex = getOrCreateVertexNear(lat, lon, StreetMode.WALK);
-        if (streetVertex == -1) {
+        int streetVertexIndex = getOrCreateVertexNear(lat, lon, StreetMode.WALK);
+        if (streetVertexIndex == -1) {
             return -1; // Unlinked
         }
 
-        int length_mm = (int) (GeometryUtils.distance(lat,lon, vertexStore.getCursor(streetVertex).getLat(), vertexStore.getCursor(streetVertex).getLon())*1000);
+        VertexStore.Vertex streetVertex = vertexStore.getCursor(streetVertexIndex);
+        int length_mm = (int) (GeometryUtils.distance(lat,lon, streetVertex.getLat(), streetVertex.getLon())*1000);
         // Set OSM way ID is -1 because this edge is not derived from any OSM way.
-        Edge e = edgeStore.addStreetPair(stopVertex, streetVertex, length_mm, -1);
+        Edge e = edgeStore.addStreetPair(stopVertex, streetVertexIndex, length_mm, -1);
 
         // Allow all modes to traverse street-to-transit link edges.
         // In practice, mode permissions will be controlled by whatever street edges lead up to these link edges.


### PR DESCRIPTION
This PR addresses a previously identified TODO: giving a length to the edges that link newly created stops to the street network.  

Before this PR, these links were given a length of 1 mm.  In edge cases, this could shift the starting vertex of the street search to an unexpected location (see #422 )
