### PR TITLE
Increase upper bound on shapefile feature size

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/Grid.java
+++ b/src/main/java/com/conveyal/r5/analyst/Grid.java
@@ -106,7 +106,7 @@ public class Grid {
     private static final double MAX_BOUNDING_BOX_AREA_SQ_KM = 250 000;
 
     /** Maximum area allowed for features in a shapefile upload */
-    double MAX_FEATURE_AREA_SQ_DEG = 0.01;
+    double MAX_FEATURE_AREA_SQ_DEG = 2;
 
     /**
      * @param zoom web mercator zoom level for the grid.


### PR DESCRIPTION
We need a more generous upper bound, because we intend users to upload large features for aggregation areas.