### PR TITLE
Splitting and linking fixes

### DIFF
--- a/src/main/java/com/conveyal/r5/profile/ProfileRequest.java
+++ b/src/main/java/com/conveyal/r5/profile/ProfileRequest.java
@@ -63,7 +63,7 @@ public class ProfileRequest implements Serializable, Cloneable {
     public int bikeTrafficStress = 4;
     
     /** The speed of driving, in meters per second. Roads from OSM use the speed limit, this is the speed used when propagating from the street network to a pointset. */
-    public float carSpeed = 11; // ~40 km/h
+    public float carSpeed = 2.22f; // ~8 km/h
 
     /** Maximum time to reach the destination without using transit in minutes */
     public int    streetTime = 60;

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -56,10 +56,12 @@ public class LinkedPointSet implements Serializable {
      */
     public int[] edges;
 
-    /** For each point, distance from the initial vertex of the edge to the split point. */
+    /** For each point, distance from the beginning vertex of the edge geometry up to the split point for a link point,
+     * plus the distance from the link point to the split point */
     public int[] distances0_mm;
 
-    /** For each point, distance from the final vertex of the edge to the split point. */
+    /** For each point, distance from the end vertex of the edge geometry up to the split point for a link point,
+     * plus the distance from the link point to the split point*/
     public int[] distances1_mm;
 
     /** For each transit stop, the distances to nearby PointSet points as packed (point_index, distance) pairs. */

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -56,12 +56,12 @@ public class LinkedPointSet implements Serializable {
      */
     public int[] edges;
 
-    /** For each point, distance from the beginning vertex of the edge geometry up to the split point for a link point,
-     * plus the distance from the link point to the split point */
+    /** For each point, distance from the beginning vertex of the edge geometry up to the split point (closest
+     * point on the edge to the point to be linked), plus the distance from the linked point to the split point */
     public int[] distances0_mm;
 
-    /** For each point, distance from the end vertex of the edge geometry up to the split point for a link point,
-     * plus the distance from the link point to the split point*/
+    /** For each point, distance from the end vertex of the edge geometry up to the split point (closest
+     * point on the edge to the point to be linked), plus the distance from the linked point to the split point */
     public int[] distances1_mm;
 
     /** For each transit stop, the distances to nearby PointSet points as packed (point_index, distance) pairs. */

--- a/src/main/java/com/conveyal/r5/streets/StreetRouter.java
+++ b/src/main/java/com/conveyal/r5/streets/StreetRouter.java
@@ -317,11 +317,14 @@ public class StreetRouter {
         // Uses weight based on distance from end vertices, and speed on edge which depends on transport mode
         float speedMetersPerSecond = edge.calculateSpeed(profileRequest, streetMode);
         startState1.weight = (int) ((split.distance1_mm / 1000) / speedMetersPerSecond);
+        startState1.durationSeconds = startState1.weight;
+        startState1.distance = split.distance1_mm;
         edge.advance();
         // Speed can be different on opposite sides of the same street
         speedMetersPerSecond = edge.calculateSpeed(profileRequest, streetMode);
         startState0.weight = (int) ((split.distance0_mm / 1000) / speedMetersPerSecond);
-        // FIXME we're setting weight but not time and distance on these states above!
+        startState0.durationSeconds = startState0.weight;
+        startState0.distance = split.distance0_mm;
 
         // FIXME Below is reversing the vertices, but then aren't the weights, times, distances wrong? Why are we even doing this?
         if (profileRequest.reverseSearch) {

--- a/src/main/java/com/conveyal/r5/streets/StreetRouter.java
+++ b/src/main/java/com/conveyal/r5/streets/StreetRouter.java
@@ -942,21 +942,14 @@ public class StreetRouter {
                 //defectiveTraversal = true;
                 return;
             }
-/*
-            durationSeconds += seconds;
-            time += seconds;
-*/
             //TODO: decrease time
             if (false) {
-
                 durationSeconds-=seconds;
                 durationFromOriginSeconds -= seconds;
             } else {
-
                 durationSeconds+=seconds;
                 durationFromOriginSeconds += seconds;
             }
-
 
         }
 


### PR DESCRIPTION
Relevant issues: #373, #422, #360 

The main change here is adding the time and distance required to reach the first vertex of the streetLayer.

This change will make a comment in Split more salient: 
>  We don't yet handle initial and final Splits on the same edge. This can be a problem for Analysis if your starting point is on a long road without intersections. Travel times to other points along that road would be measured by going to the end of the road and back.

We could consider using something like StreetLayer.getOrCreateVertexNear() to actually perform a split at the origin.