### PR TITLE
Semantic release fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ after_success:
   # builds: one for the tag and one for the commit to the branch.
   - JAVADOC_TARGET=${TRAVIS_TAG:-$TRAVIS_BRANCH}
   - if [[ "$TRAVIS_PULL_REQUEST" = false ]]; then mvn javadoc:javadoc; aws s3 cp --cache-control max-age=300 --recursive /home/travis/build/conveyal/r5/target/site/apidocs s3://javadoc.conveyal.com/r5/${TRAVIS_BRANCH}/; fi
+  - yarn global add @conveyal/maven-semantic-release && maven-semantic-release
 
 sudo: true # sudo: true gets us more memory, which we need, at the expense of slower builds
 
@@ -68,6 +69,7 @@ git:
 cache:
   directories:
   - $HOME/.m2/repository
+  - $HOME/.yarn-cache
 
 notifications:
   slack: conveyal:vqrkN7708qU1OTL9XkbMqQFV

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,11 @@ before_install: |
     gpg --import --batch maven-artifact-signing-key.asc
   fi
 
+# install dependencies used in after_success here because they don't get cached if called in after_success
+before_script:
+  - pip install --user awscli && export PATH=$PATH:~/.local/bin/
+  - yarn global add @conveyal/maven-semantic-release semantic-release
+
 # Replace Travis's default build step.
 # Run all Maven phases at once up through verify, install, and deploy.
 script: |
@@ -47,9 +52,9 @@ after_success:
   # Upload shaded JAR to S3. The un-shaded jar was deployed to our Maven repo during the main build.
   # Ideally we'd use the Travis S3 deployer here instead of installing the AWS CLI software every time.
   # See the analyst-server travis.yml for how to copy specific files to a subdirectory and deploy those.
-  - pip install --user awscli && export PATH=$PATH:~/.local/bin/
   # Upload the shaded jar. It's named with git describe, so begins with the last tag name, so begins with the letter v.
   # On the other hand, the main un-shaded artifact will begin with the project name 'r5'.
+  - semantic-release --prepare @conveyal/maven-semantic-release --publish @semantic-release/github,@conveyal/maven-semantic-release --verify-conditions @semantic-release/github --verify-release @conveyal/maven-semantic-release
   - aws s3 cp --recursive --exclude "*" --include "v*.jar" /home/travis/build/conveyal/r5/target s3://r5-builds
   # copy Javadoc to S3
   # The syntax below sets JAVADOC_TARGET to TRAVIS_TAG if defined otherwise TRAVIS_BRANCH
@@ -57,7 +62,6 @@ after_success:
   # builds: one for the tag and one for the commit to the branch.
   - JAVADOC_TARGET=${TRAVIS_TAG:-$TRAVIS_BRANCH}
   - if [[ "$TRAVIS_PULL_REQUEST" = false ]]; then mvn javadoc:javadoc; aws s3 cp --cache-control max-age=300 --recursive /home/travis/build/conveyal/r5/target/site/apidocs s3://javadoc.conveyal.com/r5/${TRAVIS_BRANCH}/; fi
-  - yarn global add @conveyal/maven-semantic-release && maven-semantic-release
 
 sudo: true # sudo: true gets us more memory, which we need, at the expense of slower builds
 
@@ -68,8 +72,9 @@ git:
 # The Conveyal subdirectory is deleted in the script above to prevent retaining Conveyal snapshot artifacts across builds.
 cache:
   directories:
-  - $HOME/.m2/repository
-  - $HOME/.yarn-cache
+    - $HOME/.m2
+    - $HOME/.cache/yarn
+    - $HOME/.cache/pip
 
 notifications:
   slack: conveyal:vqrkN7708qU1OTL9XkbMqQFV

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,12 +49,13 @@ env:
 before_cache: rm -rf $HOME/.m2/repository/com/conveyal
 
 after_success:
+  # Perform a release to maven central using maven-semantic-release if needed
+  - semantic-release --prepare @conveyal/maven-semantic-release --publish @semantic-release/github,@conveyal/maven-semantic-release --verify-conditions @semantic-release/github --verify-release @conveyal/maven-semantic-release
   # Upload shaded JAR to S3. The un-shaded jar was deployed to our Maven repo during the main build.
   # Ideally we'd use the Travis S3 deployer here instead of installing the AWS CLI software every time.
   # See the analyst-server travis.yml for how to copy specific files to a subdirectory and deploy those.
   # Upload the shaded jar. It's named with git describe, so begins with the last tag name, so begins with the letter v.
   # On the other hand, the main un-shaded artifact will begin with the project name 'r5'.
-  - semantic-release --prepare @conveyal/maven-semantic-release --publish @semantic-release/github,@conveyal/maven-semantic-release --verify-conditions @semantic-release/github --verify-release @conveyal/maven-semantic-release
   - aws s3 cp --recursive --exclude "*" --include "v*.jar" /home/travis/build/conveyal/r5/target s3://r5-builds
   # copy Javadoc to S3
   # The syntax below sets JAVADOC_TARGET to TRAVIS_TAG if defined otherwise TRAVIS_BRANCH

--- a/README.md
+++ b/README.md
@@ -22,4 +22,5 @@ came from [OpenTripPlanner](http://opentripplanner.org). Many of the algorithms,
 R5 is developed primarily as a routing library for use in other projects (Conveyal Analysis, Modeify etc.) However for testing purposes there are commands to build a network and provide basic routing and visualization of network structure in a web interface. To build a network, place one or more GTFS feeds in a directory together with an OSM PBF file covering the same region. Then run `com.conveyal.r5.R5Main point --build /Users/me/path/to/inputs`, using the -Xmx switch to give the JVM a GB or two of memory if possible. This will create a file called `network.dat` in the same directory as the input files. Then run `com.conveyal.r5.R5Main point --graphs /path/to/input/files` to start up the web server. The routing interface should then be available at `http://localhost:8080/`, a somewhat more advanced interface at `http://localhost:8080/new.html` and a vector-based visualization for examining the contents of the network at `http://localhost:8080/debug.html`. For the debug visualization, you will need to zoom in fairly close before edges are loaded.
 
 ## Performing a Release
-See the section on "performing a release" at https://github.com/conveyal/JavaStyle.
+
+Releases are automatically generated using [maven-semantic-release](https://github.com/conveyal/maven-semantic-release).

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,9 @@
                 </executions>
                 <configuration>
                     <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+                    <gitDescribe>
+                        <tags>true</tags>
+                    </gitDescribe>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,11 @@
                 <configuration>
                     <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
                     <gitDescribe>
+                        <!--
+                        semantic-release appears to create lightweight tags, therefore the tags property here
+                        must be set to true so that the latest lightweight tag is recognized.
+                        See https://github.com/ktoso/maven-git-commit-id-plugin#git-describe-and-a-small-gotcha-with-tags
+                        -->
                         <tags>true</tags>
                     </gitDescribe>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.conveyal</groupId>
     <artifactId>r5</artifactId>
-    <version>4.1.2-SNAPSHOT</version>
+    <version>4.1.2</version>
     <packaging>jar</packaging>
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.conveyal</groupId>
     <artifactId>r5</artifactId>
-    <version>4.2.0</version>
+    <version>4.2.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.conveyal</groupId>
     <artifactId>r5</artifactId>
-    <version>4.1.3-SNAPSHOT</version>
+    <version>4.2.0</version>
     <packaging>jar</packaging>
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.conveyal</groupId>
     <artifactId>r5</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.1.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.conveyal</groupId>
     <artifactId>r5</artifactId>
-    <version>4.1.2</version>
+    <version>4.1.3-SNAPSHOT</version>
     <packaging>jar</packaging>
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.conveyal</groupId>
     <artifactId>r5</artifactId>
-    <version>4.2.0-SNAPSHOT</version>
+    <version>4.1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.conveyal</groupId>
     <artifactId>r5</artifactId>
-    <version>4.1.0</version>
+    <version>4.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <licenses>
         <license>


### PR DESCRIPTION
Sorry for the extra commits...  I branched off of master.

This PR updates maven-semantic-release to the latest version.  I refactored maven-semantic-release to act as a plugin to semantic-release since other semantic-release plugins also behave this way.  Also, I moved some stuff around in .travis.yml.  The installation of aws and semantic release now happen in before_script so that these items are cached.  Also, semantic-release is now ran before deploying to s3.  This way, when a new release is generated, that release will get uploaded to s3.  Finally, I also added an entry to the git-commit-id-plugin telling it to use lightweight tags because it looks like semantic release does not create annotated tags.