### PR TITLE
burn analysis parameters into geotiff metadata, fixes #454.

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
@@ -475,7 +475,7 @@ public class AnalystWorker implements Runnable {
                     oneOriginResult.timeGrid.writeGridToDataOutput(new LittleEndianDataOutputStream(byteArrayOutputStream));
                     addErrorJson(byteArrayOutputStream, transportNetwork.scenarioApplicationWarnings);
                 } else if (timeSurfaceTask.getFormat() == TravelTimeSurfaceTask.Format.GEOTIFF) {
-                    oneOriginResult.timeGrid.writeGeotiff(byteArrayOutputStream);
+                    oneOriginResult.timeGrid.writeGeotiff(byteArrayOutputStream, request);
                 }
                 // FIXME strangeness, only travel time results are returned from method, accessibility results return null and are accumulated for async delivery.
                 // Return raw byte array containing grid or TIFF file to caller, for return to client over HTTP.


### PR DESCRIPTION
Adds the full profile request to the GeoTIFF metadata; it can be viewed with gdalinfo. Resulting TIFF files can still be read in QGIS (confirmed).

Example:

```
jentilly:r5 matthewc$ gdalinfo ~/Downloads/analysis-geotiff-T-0\ \(11\).geotiff 
...
Metadata:
  AREA_OR_POINT=Area
  TIFFTAG_IMAGEDESCRIPTION={
  "type" : "TRAVEL_TIME_SURFACE",
  "fromLat" : 42.35822296142578,
  "fromLon" : -71.06211853027344,
  "toLat" : 0.0,
  "toLon" : 0.0,
  "fromTime" : 25200,
  "toTime" : 32400,
  "walkSpeed" : 1.3888888,
  "bikeSpeed" : 4.1666665,
  "bikeTrafficStress" : 4,
  "carSpeed" : 20.0,
  "streetTime" : 90,
  "maxWalkTime" : 20,
  "maxBikeTime" : 20,
  "maxCarTime" : 45,
  "minBikeTime" : 10,
  "minCarTime" : 10,
  "date" : "2018-07-07",
  "limit" : 0,
  "accessModes" : "WALK",
  "egressModes" : "WALK",
  "directModes" : "WALK",
  "transitModes" : "TRAM,SUBWAY,RAIL,BUS,FERRY,CABLE_CAR,GONDOLA,FUNICULAR",
  "suboptimalMinutes" : 5,
  "maxTripDurationMinutes" : 240,
  "maxRides" : 4,
  "scenario" : null,
  "scenarioId" : "5bcf584e6b56120c1eef02e2-0-223132457",
  "zoneId" : "Z",
  "wheelchair" : false,
  "maxFare" : -1,
  "monteCarloDraws" : 200,
  "zoom" : 9,
  "west" : 39581,
  "north" : 48395,
  "width" : 206,
  "height" : 185,
  "graphId" : "5bcf57f46b56120c1eef02df",
  "workerVersion" : "v4.1.1",
  "jobId" : "5bcf584e6b56120c1eef02e2-0-223132457",
  "id" : null,
  "taskId" : 0,
  "makeStaticSite" : false,
  "travelTimeBreakdown" : false,
  "returnPaths" : false,
  "percentiles" : [ 5.0, 25.0, 50.0, 75.0, 95.0 ],
  "nPathsPerTarget" : 3,
  "format" : "GEOTIFF",
  "type" : "TRAVEL_TIME_SURFACE"
}
  TIFFTAG_RESOLUTIONUNIT=1 (unitless)
  TIFFTAG_SOFTWARE=Conveyal R5
...
```