### PR TITLE
Set route type from modifications

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/scenario/AddTrips.java
+++ b/src/main/java/com/conveyal/r5/analyst/scenario/AddTrips.java
@@ -89,6 +89,7 @@ public class AddTrips extends Modification {
         info.route_short_name = "";
         info.route_long_name = this.comment;
         info.route_id = this.routeId;
+        info.route_type = this.mode;
         info.color = "4444FF";
         this.routeIndex = transitLayer.routes.size();
         transitLayer.routes.add(info);


### PR DESCRIPTION
The mode of travel for added trips (routes) still can't be set in the UI, but this change at least copies over the default value (bus) from the AddTrips modification class. This has been confirmed to work - when bus is deselected in the UI, added routes are not considered. It should suffice to include a mode property in the modification JSON.

I don't want to merge this right away because it will change behavior in a way that may surprise users - if they are used to turning off buses and still seeing their added routes.