### PR TITLE
EC2 startup and shutdown behavior

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalysisWorkerController.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalysisWorkerController.java
@@ -34,8 +34,6 @@ public class AnalysisWorkerController {
     }
 
     public Object handleSinglePoint (Request request, Response response) throws IOException {
-        // Record the fact that this worker is busy so it will not shut down
-        analystWorker.lastSinglePointTime = System.currentTimeMillis();
         // This header will cause the Spark Framework to gzip the data automatically if requested by the client.
         // FIXME I'm not seeing this on the wire, is the client asking for gzipped responses?
         response.header("Content-Encoding", "gzip");

--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
@@ -120,10 +120,10 @@ public class AnalystWorker implements Runnable {
     public static final int TESTING_FAILURE_RATE_PERCENT = 20;
 
     /** The minimum amount of time (in minutes) that this worker should stay alive after processing a single-point task. */
-    public static final int SINGLE_KEEPALIVE_MINUTES = 30;
+    public static final int SINGLE_KEEPALIVE_MINUTES = 20;
 
     /** The minimum amount of time (in minutes) that this worker should stay alive after processing a regional job task. */
-    public static final int REGIONAL_KEEPALIVE_MINUTES = 1;
+    public static final int REGIONAL_KEEPALIVE_MINUTES = 10;
 
     /** Whether this worker should shut down automatically when idle. */
     public final boolean autoShutdown;
@@ -257,9 +257,9 @@ public class AnalystWorker implements Runnable {
         this.networkPreloader = new NetworkPreloader(transportNetworkCache);
         this.autoShutdown = Boolean.parseBoolean(config.getProperty("auto-shutdown", "false"));
 
-        // Consider shutting this worker down once per hour, starting 55 minutes after it started up.
+        // Consider shutting this worker down every 10 minutes, starting 30 minutes after it started up.
         startupTime = System.currentTimeMillis();
-        nextShutdownCheckTime = startupTime + 55 * 60 * 1000;
+        nextShutdownCheckTime = startupTime + 30 * 60 * 1000;
 
         // Discover information about what EC2 instance / region we're running on, if any.
         // If the worker isn't running in Amazon EC2, then region will be unknown so fall back on a default, because
@@ -284,8 +284,8 @@ public class AnalystWorker implements Runnable {
     public void considerShuttingDown() {
         long now = System.currentTimeMillis();
         if (now > nextShutdownCheckTime && autoShutdown) {
-            // Check again exactly one hour later (assumes billing in one-hour increments)
-            nextShutdownCheckTime += 60 * 60 * 1000;
+            // Check again exactly ten minutes later (note that billing is now in second increments)
+            nextShutdownCheckTime += 10 * 60 * 1000;
             if (now > lastSinglePointTime + (SINGLE_KEEPALIVE_MINUTES * 60 * 1000) &&
                 now > lastRegionalTaskTime + (REGIONAL_KEEPALIVE_MINUTES * 60 * 1000)) {
                 LOG.info("Machine has been idle for at least {} minutes (single point) and {} minutes (regional), " +

--- a/src/main/resources/worker.sh
+++ b/src/main/resources/worker.sh
@@ -6,6 +6,10 @@
 # 0: the URL to grab the worker JAR from
 # 1: the AWS log group to use
 # 2: the worker configuration to use
+# 3: the (Auth0) accessGroup (useful for billing)
+# 4: the (Auth0) user who made the request that started the worker
+# 5: the UUID of the TransportNetwork the worker will start analyzing
+# 6: the worker version to use
 # If you are reading this comment inside the EC2 user data field, this variable substitution has already happened.
 # The string instance_id in curly brackets is substituted by EC2 at startup, not by our Java code. It and any shell
 # variable references that contain brackets are single-quoted to tell MessageFormat not to substitute them.
@@ -61,6 +65,17 @@ cat /etc/aws
 
 echo AWS Log agent logs:
 cat /var/log/awslogs.log
+
+# Set up aws cli
+mkdir ~/.aws
+cat > ~/.aws/config << EOF
+[default]
+region = $REGION
+EOF
+
+# Tag the instance (so we can identify it in the EC2 console)
+aws ec2 create-tags --resources '{instance_id}' --tags Key=Name,Value=AnalysisWorker,Key=Project,Value=Analysis&&
+Key=group,Value={3},Key=user,Value={4},Key=networkId,Value={5},Key=workerVersion,Value={6}
 
 # Download the worker
 sudo -u ec2-user wget -O ~ec2-user/r5.jar {0} >> $LOGFILE 2>&1

--- a/src/main/resources/worker.sh
+++ b/src/main/resources/worker.sh
@@ -66,7 +66,7 @@ cat /etc/aws
 echo AWS Log agent logs:
 cat /var/log/awslogs.log
 
-# Set up aws cli
+# Create a config file to tell the AWS CLI which region to operate in
 mkdir ~/.aws
 cat > ~/.aws/config << EOF
 [default]


### PR DESCRIPTION
Together with https://github.com/conveyal/analysis-backend/pull/191, addresses https://github.com/conveyal/analysis-backend/issues/182 by making workers tag themselves in the userData startup script.

Also updates shutdown behavior (in light of https://aws.amazon.com/blogs/aws/new-per-second-billing-for-ec2-instances-and-ebs-volumes/).  We should go over the initial shutdown check carefully to ensure workers won't shut down prematurely:

- If workers start polling before they have completed network building, they may consider shutting down before actually completely building a network.  
- Also, is it a problem that the UI now stops retrying requests after 5 minutes?  For example, a worker may take 6 minutes to build a graph, but if a user walks away from their computer, the worker might eventually shut down without ever providing results that are displayed.