### PR TITLE
Linkage cache weighing

### DIFF
--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -462,5 +462,20 @@ public class LinkedPointSet implements Serializable {
         }
     }
 
+    /**
+     * Prototype method to estimate the number of bytes of memory consumed by holding a reference to this linkage.
+     * Intended use is in WeighingCache to control worker memory usage.
+     */
+    public long estimateMemoryConsumptionBytes () {
+        long nPoints = this.size();
+        long bytesForEdges = nPoints * Integer.BYTES;
+        long bytesForDistances = 2 * nPoints * Integer.BYTES;
+        long bytesForDistanceTables = stopToPointDistanceTables.stream().filter(Objects::nonNull).mapToLong(
+                array -> array.length * (long)Integer.BYTES).sum();
+        long bytesForInverseTables = pointToStopDistanceTables.stream().filter(Objects::nonNull).mapToLong(
+                intMap -> ((TIntIntHashMap) intMap)._set.length * 2L * Integer.BYTES).sum();
+        long bytesForStreetLayer = streetLayer.estimateMemoryConsumptionBytes();
+        return bytesForEdges + bytesForDistances + bytesForDistanceTables + bytesForInverseTables + bytesForStreetLayer;
+    }
 
 }

--- a/src/main/java/com/conveyal/r5/streets/StreetLayer.java
+++ b/src/main/java/com/conveyal/r5/streets/StreetLayer.java
@@ -1527,4 +1527,17 @@ public class StreetLayer implements Serializable, Cloneable {
         return bikeRentalStations;
     }
 
+    /**
+     * Prototype method to estimate the number of bytes of memory consumed by holding a reference to this StreetLayer.
+     * Intended use is in WeighingCache to control worker memory usage.
+     * NOTE: This is currently very inaccurate and doesn't include any of the temporary indexes.
+     */
+    public long estimateMemoryConsumptionBytes() {
+        final int bytesPerEdge = 3 * Integer.BYTES + Long.BYTES + 2 * Byte.BYTES;
+        final int bytesPerVertex = 2 * Integer.BYTES + Byte.BYTES;
+        int nVertices = vertexStore.getVertexCount();
+        int nEdges = edgeStore.nEdges();
+        return nVertices * bytesPerVertex + nEdges * bytesPerEdge;
+    }
+
 }


### PR DESCRIPTION
This builds on #469 but is more experimental. It provides a basic mechanism for estimating the size of linkages and distance tables in kB, and evicts from the cache based on estimated memory consumption instead of the number of linkages.