### PR TITLE
Regional patches

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
@@ -474,7 +474,8 @@ public class AnalystWorker implements Runnable {
             // Note we're completely bypassing the async loader here and relying on the older nested LoadingCaches.
             // If those are ever removed, the async loader will need a synchronous mode with per-key blocking (kind of
             // reinventing the wheel of LoadingCache) or we'll need to make preparation for regional tasks async.
-            TransportNetwork transportNetwork = networkPreloader.transportNetworkCache.getNetwork(task.graphId);
+            TransportNetwork transportNetwork = networkPreloader.transportNetworkCache.getNetworkForScenario(task
+                    .graphId, task.scenarioId);
 
             // If we are generating a static site, there must be a single metadata file for an entire batch of results.
             // Arbitrarily we create this metadata as part of the first task in the job.

--- a/src/main/java/com/conveyal/r5/transit/TransportNetworkCache.java
+++ b/src/main/java/com/conveyal/r5/transit/TransportNetworkCache.java
@@ -424,7 +424,7 @@ public class TransportNetworkCache {
     /**
      * Given a network and scenario ID, retrieve that scenario from the local disk cache (falling back on S3).
      */
-    private Scenario resolveScenario (String networkId, String scenarioId) {
+    private synchronized Scenario resolveScenario (String networkId, String scenarioId) {
         // First try to get the scenario from the local memory cache. This should be sufficient for single point tasks.
         Scenario scenario = scenarioCache.getScenario(scenarioId);
         if (scenario != null) {

--- a/src/main/java/com/conveyal/r5/transit/TransportNetworkCache.java
+++ b/src/main/java/com/conveyal/r5/transit/TransportNetworkCache.java
@@ -441,7 +441,6 @@ public class TransportNetworkCache {
                 InputStream is = obj.getObjectContent();
                 OutputStream os = new BufferedOutputStream(new FileOutputStream(scenarioFile));
                 ByteStreams.copy(is, os);
-                Files.copy(is, scenarioFile.toPath());
                 is.close();
                 os.close();
             } catch (Exception e) {

--- a/src/main/java/com/conveyal/r5/transit/TransportNetworkCache.java
+++ b/src/main/java/com/conveyal/r5/transit/TransportNetworkCache.java
@@ -424,7 +424,7 @@ public class TransportNetworkCache {
     /**
      * Given a network and scenario ID, retrieve that scenario from the local disk cache (falling back on S3).
      */
-    private synchronized Scenario resolveScenario (String networkId, String scenarioId) {
+    private Scenario resolveScenario (String networkId, String scenarioId) {
         // First try to get the scenario from the local memory cache. This should be sufficient for single point tasks.
         Scenario scenario = scenarioCache.getScenario(scenarioId);
         if (scenario != null) {

--- a/src/main/resources/worker.sh
+++ b/src/main/resources/worker.sh
@@ -74,10 +74,6 @@ cat > /home/ec2-user/.aws/config << EOF
 region = $REGION
 EOF
 
-# Tag the instance (so we can identify it in the EC2 console)
-sudo -u ec2-user aws ec2 create-tags --resources $INSTANCE --tags Key=Name,Value=AnalysisWorker \
-Key=Project,Value=Analysis Key=group,Value={3} Key=user,Value={4} Key=networkId,Value={5} Key=workerVersion,Value={6}
-
 # Download the worker
 sudo -u ec2-user wget -O ~ec2-user/r5.jar {0} >> $LOGFILE 2>&1
 
@@ -86,7 +82,6 @@ sudo -u ec2-user wget -O ~ec2-user/r5.jar {0} >> $LOGFILE 2>&1
 TOTAL_MEM=`grep MemTotal /proc/meminfo | sed ''s/[^0-9]//g''`
 # 2097152 kb is 2GB, leave that much for the OS
 MEM=`echo $TOTAL_MEM - 2097152 | bc`
-
 
 # Start the worker
 # run in the home directory for ec2-user, in the subshell
@@ -102,3 +97,8 @@ MEM=`echo $TOTAL_MEM - 2097152 | bc`
     halt -p
 } &
 '
+
+# Tag the instance (so we can identify it in the EC2 console), with jitter up to 3 min. for AWS rate limits
+sleep $[$RANDOM % 360]s
+sudo -u ec2-user aws ec2 create-tags --resources $INSTANCE --tags Key=Name,Value=AnalysisWorker \
+Key=Project,Value=Analysis Key=group,Value={3} Key=user,Value={4} Key=networkId,Value={5} Key=workerVersion,Value={6}


### PR DESCRIPTION
https://github.com/conveyal/analysis-backend/issues/200 was a specific case of a more general problem -- scenarios not being applied for regional analyses.  Fixes:
- [x] Request scenario-applied network from cache
- [x] Apply scenario when downloading from S3 (#483)

Separately,
- [x] Add jitter to auto-tagging (#480 )