### PR TITLE
Pin semantic-release to v15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install: |
 # install dependencies used in after_success here because they don't get cached if called in after_success
 before_script:
   - pip install --user awscli && export PATH=$PATH:~/.local/bin/
-  - yarn global add @conveyal/maven-semantic-release semantic-release
+  - yarn global add @conveyal/maven-semantic-release semantic-release@15
 
 # Replace Travis's default build step.
 # Run all Maven phases at once up through verify, install, and deploy.


### PR DESCRIPTION
Semantic-release v16 is going to have a breaking change that will make maven-semantic-release not work properly (see https://github.com/conveyal/maven-semantic-release/issues/10). Therefore this change preemptively fixes semantic-release to v15.x.x to prevent future breakage until maven-semantic-release can be updated to support semantic-release v16. 