### PR TITLE
Various fixes to PointSet Linking

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/PointSet.java
+++ b/src/main/java/com/conveyal/r5/analyst/PointSet.java
@@ -130,6 +130,9 @@ public abstract class PointSet {
             if (value == null) {
                 value = linkageCache.get(new Tuple2<>(streetLayer, streetMode));
             }
+            if (value != null && value.pointSet != this) {
+                throw new AssertionError("A PointSet should only hold linkages for itself, not for other PointSets.");
+            }
             return value;
         } catch (ExecutionException e) {
             throw new RuntimeException("Failed to link PointSet to StreetLayer.", e);

--- a/src/main/java/com/conveyal/r5/profile/PerTargetPropagater.java
+++ b/src/main/java/com/conveyal/r5/profile/PerTargetPropagater.java
@@ -256,8 +256,7 @@ public class PerTargetPropagater {
                         }
 
                         int timeAtTarget = timeAtStop + secondsFromStopToTarget;
-                        if (timeAtTarget < cutoffSeconds &&
-                                timeAtTarget < perIterationTravelTimes[iteration]) {
+                        if (timeAtTarget < cutoffSeconds && timeAtTarget < perIterationTravelTimes[iteration]) {
                             // To reach this target, alighting at this stop is faster than any previously checked stop.
                             perIterationTravelTimes[iteration] = timeAtTarget;
                             if (calculateComponents) {

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -134,11 +134,19 @@ public class LinkedPointSet implements Serializable {
         Geometry linkageCostRebuildZone = null;
 
         // TODO general purpose method to check compatability
-        if (baseLinkage != null && (
-                baseLinkage.pointSet != pointSet ||
-                baseLinkage.streetLayer != streetLayer.baseStreetLayer ||
-                baseLinkage.streetMode != streetMode)) {
-            throw new UnsupportedOperationException("Requested characteristics do not match baseLinkage");
+        // The supplied baseLinkage must be for exactly the same pointSet as the linkage we're creating.
+        // This constructor expects them to have the same number of entries for the exact same geographic points.
+        // The supplied base linkage should be for the same mode, and for the base street network of this street network.
+        if (baseLinkage != null) {
+            if (baseLinkage.pointSet != pointSet) {
+                throw new AssertionError("baseLinkage must be for the same pointSet as the linkage being created.");
+            }
+            if (baseLinkage.streetMode != streetMode) {
+                throw new AssertionError("baseLinkage must be for the same mode as the linkage being created.");
+            }
+            if (baseLinkage.streetLayer != streetLayer.baseStreetLayer) {
+                throw new AssertionError("baseLinkage must be for the baseStreetLayer of the streetLayer of the linkage being created.");
+            }
         }
 
         if (baseLinkage == null) {
@@ -156,6 +164,7 @@ public class LinkedPointSet implements Serializable {
             // The new linkage has the same PointSet as the base linkage, so the linkage arrays remain the same length
             // as in the base linkage. However, if the TransitLayer was also modified by the scenario, the
             // stopToVertexDistanceTables list might need to grow.
+            // TODO add assertion that arrays may grow but will never shrink. Check expected array lengths.
             edges = Arrays.copyOf(baseLinkage.edges, nPoints);
             distances0_mm = Arrays.copyOf(baseLinkage.distances0_mm, nPoints);
             distances1_mm = Arrays.copyOf(baseLinkage.distances1_mm, nPoints);

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -484,7 +484,12 @@ public class LinkedPointSet implements Serializable {
         }
         TransitLayer transitLayer = streetLayer.parentNetwork.transitLayer;
         int nStops = transitLayer.getStopCount();
-        LambdaCounter counter = new LambdaCounter(LOG, nStops, 1000,
+        int logFrequency = 1000;
+        if (streetMode == StreetMode.CAR) {
+            // Log more often because car searches are very slow.
+            logFrequency = 100;
+        }
+        LambdaCounter counter = new LambdaCounter(LOG, nStops, logFrequency,
                 "Computed distances to PointSet points from {} of {} transit stops.");
         // Create a distance table from each transit stop to the points in this PointSet in parallel.
         // Each table is a flattened 2D array. Two values for each point reachable from this stop: (pointIndex, cost)

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -168,6 +168,7 @@ public class LinkedPointSet implements Serializable {
             distances0_mm = Arrays.copyOf(baseLinkage.distances0_mm, nPoints);
             distances1_mm = Arrays.copyOf(baseLinkage.distances1_mm, nPoints);
             stopToPointLinkageCostTables = new ArrayList<>(baseLinkage.stopToPointLinkageCostTables);
+            linkageCostUnit = baseLinkage.linkageCostUnit;
             // TODO We need to determine which points to re-link and which stops should have their stop-to-point tables re-built.
             // This should be all the points within the (bird-fly) linking radius of any modified edge.
             // The stop-to-vertex trees should already be rebuilt elsewhere when applying the scenario.

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -517,7 +517,17 @@ public class LinkedPointSet implements Serializable {
 
                 StreetRouter sr = new StreetRouter(transitLayer.parentNetwork.streetLayer);
                 sr.streetMode = streetMode;
-                sr.setOrigin(transitLayer.streetVertexForStop.get(stopIndex));
+                int vertexId = transitLayer.streetVertexForStop.get(stopIndex);
+                if (vertexId < 0) {
+                    LOG.warn("Stop unlinked, cannot build distance table: {}", stopIndex);
+                    return null;
+                }
+                // TODO setting the origin point of the router to the stop vertex does not work.
+                // This is probably because link edges do not allow car traversal. We could traverse them.
+                // As a stopgap we perform car linking at the geographic coordinate of the stop.
+                // sr.setOrigin(vertexId);
+                VertexStore.Vertex vertex = streetLayer.vertexStore.getCursor(vertexId);
+                sr.setOrigin(vertex.getLat(), vertex.getLon());
 
                 if (streetMode == StreetMode.BICYCLE) {
 

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -105,7 +105,6 @@ public class LinkedPointSet implements Serializable {
      * By default, linkage costs are distances (between stops and pointset points). For modes where speeds vary
      * by link, it doesn't make sense to store distances, so we store times.
      */
-
     public RoutingVariable linkageCostUnit = RoutingVariable.DISTANCE_MILLIMETERS;
 
     /**
@@ -179,7 +178,6 @@ public class LinkedPointSet implements Serializable {
             // transit stops, we still need to re-link points and rebuild stop trees (both the trees to the vertices
             // and the trees to the points, because some existing stop-to-vertex trees might not include new splitter
             // vertices).
-
             if (streetMode == StreetMode.WALK) {
                 // limit already set for WALK.
             } else if (streetMode == StreetMode.BICYCLE) {

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -230,8 +230,9 @@ public class LinkedPointSet implements Serializable {
             LOG.warn("Sub-grid is entirely outside the super-grid.  Points will not be linked to any street edges.");
         }
 
-        // Initialize the fields of the new LinkedPointSet instance
-        pointSet = sourceLinkage.pointSet;
+        // Initialize the fields of the new LinkedPointSet instance.
+        // Most characteristics are the same, but the new linkage is for the subset of points in the subGrid.
+        pointSet = subGrid;
         streetLayer = sourceLinkage.streetLayer;
         streetMode = sourceLinkage.streetMode;
 

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -508,10 +508,9 @@ public class LinkedPointSet implements Serializable {
                 return stopToPointLinkageCostTables.get(stopIndex);
             }
 
+            counter.increment();
             Envelope distanceTableZone = stopPoint.getEnvelopeInternal();
             GeometryUtils.expandEnvelopeFixed(distanceTableZone, linkingDistanceLimitMeters);
-
-            int[] linkageCostToPoints;
 
             if (streetMode == StreetMode.WALK) {
                 // Walking distances from stops to street vertices are saved in the transitLayer.
@@ -519,7 +518,7 @@ public class LinkedPointSet implements Serializable {
                 // then extend that table out from the street vertices to the points in this PointSet.
                 // TODO reuse the code that computes the walk tables at com.conveyal.r5.transit.TransitLayer.buildOneDistanceTable() rather than duplicating it below for other modes.
                 TIntIntMap distanceTableToVertices = transitLayer.stopToVertexDistanceTables.get(stopIndex);
-                linkageCostToPoints = distanceTableToVertices == null ? null :
+                return distanceTableToVertices == null ? null :
                         extendDistanceTableToPoints(distanceTableToVertices, distanceTableZone);
             } else {
 
@@ -542,7 +541,7 @@ public class LinkedPointSet implements Serializable {
                     sr.distanceLimitMeters = linkingDistanceLimitMeters;
                     sr.quantityToMinimize = linkageCostUnit;
                     sr.route();
-                    linkageCostToPoints = extendDistanceTableToPoints(sr.getReachedVertices(), distanceTableZone);
+                    return extendDistanceTableToPoints(sr.getReachedVertices(), distanceTableZone);
 
                 } else if (streetMode == StreetMode.CAR) {
                     // The speeds for Walk and Bicycle can be specified in an analysis request, so it makes sense above to
@@ -574,10 +573,6 @@ public class LinkedPointSet implements Serializable {
                     throw new UnsupportedOperationException("Tried to link a pointset with an unsupported street mode");
                 }
             }
-
-            counter.increment();
-            return linkageCostToPoints;
-
         }).collect(Collectors.toList());
         counter.done();
     }


### PR DESCRIPTION
## Various fixes to PointSet Linking
This is for review only - do not merge this PR yet, as the solution to #503 may be related and may be included in this PR.

**Fix broken assumptions in LinkedPointSet constructor**

Recently we re-enabled some assertions in the LinkedPointSet constructor, checking that the supplied base base linkage is compatible with the linkage being constructed. With those assertions enabled, R5 throws an exception as soon as I do a single point search.

The initial failure is due to a check on the base street layer. That check just seems to have been expressed incorrectly. But another problem came to light: The part of the LinkedPointSet constructor that copies the linkages clearly assumes that the base point set and supplied point set are the same size (and says so in its comments). It appeared that this was not the case in practice, for example when setting custom geographic bounds: a pointset with a smaller extent is used. Yet the results displayed on the map (isochrones) look correct.

Because of how the base linkage is fetched, a pointset mismatch should be impossible here. The only way a mismatch could occur is if the linkage cache within a particular pointset contained linkages for a different pointset, which should never happen. I added assertions to ensure such a mismatch would be caught.

From there I traced the problem to another constructor of LinkedPointSet: `LinkedPointSet (LinkedPointSet sourceLinkage, WebMercatorGridPointSet subGrid)`. It was incorrectly setting the pointSet field of newly created sub-grid linkages. The linkages were in fact for the correct sub-grid, but the pointSet field was being set to the super-grid. 

**Fix Car Linking**

Several other problems were fixed:

- The field specifying the linkage units was not being copied from a base linkage. 
- The car router was not able to exit transit stop vertices, linking method was (temporarily?) changed
- Car linking code was changed to return an interleaved array of (pointId, cost) as done by other modes
