### PR TITLE
Only build cost tables on egress modes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: java
 
-# R5 uses Java 8 features and Travis doesn't (yet) support OpenJDK 8
+# Oracle JDK is EOL, use OpenJDK 8
 jdk:
-- oraclejdk8
+- openjdk8
 
 # Maven semantic-release uses v10 now
 node_js:

--- a/src/main/java/com/conveyal/r5/analyst/NetworkPreloader.java
+++ b/src/main/java/com/conveyal/r5/analyst/NetworkPreloader.java
@@ -2,6 +2,7 @@ package com.conveyal.r5.analyst;
 
 import com.conveyal.r5.analyst.cluster.AnalysisTask;
 import com.conveyal.r5.analyst.cluster.RegionalTask;
+import com.conveyal.r5.analyst.progress.NetworkPreloaderProgressListener;
 import com.conveyal.r5.analyst.progress.ProgressListener;
 import com.conveyal.r5.api.util.LegMode;
 import com.conveyal.r5.profile.StreetMode;
@@ -88,8 +89,6 @@ public class NetworkPreloader extends AsyncLoader<NetworkPreloader.Key, Transpor
     @Override
     protected TransportNetwork buildValue(Key key) {
 
-        ProgressListener progressListener = new ProgressListener();
-
         // First get the network, apply the scenario, and (re)build distance tables.
         // Those steps should eventually be pulled out of the cache loaders to make progress reporting more granular.
         setProgress(key, 0, "Building network...");
@@ -109,8 +108,10 @@ public class NetworkPreloader extends AsyncLoader<NetworkPreloader.Key, Transpor
         // good idea to keep progressListener objects in fields on Factory classes rather than passing them as parameters
         // into constructors or factory methods.
         for (StreetMode mode : key.allModes) {
+            setProgress(key, 0, "Linking destination grid to streets for " + mode + "...");
             LinkedPointSet linkedPointSet = pointSet.getLinkage(scenarioNetwork.streetLayer, mode);
             if (key.egressModes.contains(mode)) {
+                ProgressListener progressListener = new NetworkPreloaderProgressListener(this, key);
                 linkedPointSet.getEgressCostTable(progressListener);
             }
         }

--- a/src/main/java/com/conveyal/r5/analyst/PointSet.java
+++ b/src/main/java/com/conveyal/r5/analyst/PointSet.java
@@ -66,6 +66,8 @@ public abstract class PointSet {
     /**
      * Build a linkage and store it, bypassing the PointSet's internal cache of linkages because we want this particular
      * linkage to be serialized with the network (the Guava cache does not serialize its contents) and never evicted.
+     * The newly constructed linkage will also have an EgressCostTable built (since that's actually the slowest part of
+     * linkage, and one we want to serialize for later reuse).
      */
     public void buildUnevictableLinkage(StreetLayer streetLayer, StreetMode mode) {
         Tuple2<StreetLayer, StreetMode> key = new Tuple2<>(streetLayer, mode);
@@ -73,6 +75,7 @@ public abstract class PointSet {
             LOG.error("Un-evictable linkage is being built more than once.");
         }
         LinkedPointSet newLinkage = new LinkedPointSet(this, streetLayer, mode, null);
+        newLinkage.getEgressCostTable();
         linkageMap.put(key, newLinkage);
     }
 

--- a/src/main/java/com/conveyal/r5/analyst/PointSet.java
+++ b/src/main/java/com/conveyal/r5/analyst/PointSet.java
@@ -111,7 +111,8 @@ public abstract class PointSet {
      * Constructor for a PointSet that initializes its cache of linkages upon deserialization.
      */
     public PointSet() {
-        this.linkageCache = CacheBuilder.newBuilder().maximumSize(LINKAGE_CACHE_SIZE)
+        this.linkageCache = CacheBuilder.newBuilder()
+                .maximumSize(LINKAGE_CACHE_SIZE)
                 .removalListener(notification -> LOG.warn("LINKAGE CACHE EVICTION. key: {}, cause: {}",
                         notification.getKey(), notification.getCause()))
                 .build(new LinkageCacheLoader());

--- a/src/main/java/com/conveyal/r5/analyst/WebMercatorGridPointSetCache.java
+++ b/src/main/java/com/conveyal/r5/analyst/WebMercatorGridPointSetCache.java
@@ -18,6 +18,7 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * Note that this cache will be serialized with the PointSet, but serializing a Guava cache only serializes the
  * cache instance and its settings, not the contents of the cache. We consider this sane behavior.
+ * TODO verify the above comment, this doesn't seem to be serialized anywhere and it doesn't contain a Guava cache.
  */
 public class WebMercatorGridPointSetCache {
 

--- a/src/main/java/com/conveyal/r5/analyst/progress/NetworkPreloaderProgressListener.java
+++ b/src/main/java/com/conveyal/r5/analyst/progress/NetworkPreloaderProgressListener.java
@@ -1,0 +1,66 @@
+package com.conveyal.r5.analyst.progress;
+
+import com.conveyal.r5.analyst.NetworkPreloader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This implementaton of ProgressListener posts updates to the NetworkPreloader about progress on preparing needed
+ * inputs for a particular request.
+ */
+public class NetworkPreloaderProgressListener implements ProgressListener {
+
+    // We can eventually perform console logging here rather than through separate LambdaCounters.
+    // In fact the LambdaCounter is a kind of ProgressListener.
+    // Perhaps allow setting the logger field so log entries reflect the calling class instead of ProgressListener.
+    private static final Logger LOG = LoggerFactory.getLogger(NetworkPreloaderProgressListener.class);
+
+    private int totalElements;
+
+    protected String description;
+
+    private int currentElement;
+
+    private final NetworkPreloader networkPreloader;
+
+    private final NetworkPreloader.Key key;
+
+    /**
+     * Every how many work units we'll post an update.
+     * There is no point in doing this more often than the percentage changes.
+     */
+    private int updateFrequency;
+
+    /**
+     * Construct a ProgressListener that will post updated for a given key in the NetworkPreloader.
+     * @param networkPreloader The NetworkPreloader instance to which we'll post updates.
+     * @param key The key for the entry within the NetworkPreloader to which we'll post updates.
+     */
+    public NetworkPreloaderProgressListener(NetworkPreloader networkPreloader, NetworkPreloader.Key key) {
+        this.networkPreloader = networkPreloader;
+        this.key = key;
+    }
+
+    @Override
+    public void beginTask(String description, int totalElements) {
+        this.description = description;
+        this.totalElements = totalElements;
+        this.currentElement = 0;
+        this.updateFrequency = totalElements / 100;
+    }
+
+    @Override
+    public synchronized void increment () {
+        currentElement += 1;
+        if (currentElement % updateFrequency == 0) {
+            int percent = getPercentComplete();
+            String status = String.format("%s... (%d%%)", description, percent);
+            networkPreloader.setProgress(key, percent, status);
+        }
+    }
+
+    private int getPercentComplete () {
+        return (currentElement * 100) / totalElements;
+    }
+
+}

--- a/src/main/java/com/conveyal/r5/analyst/progress/NoopProgressListener.java
+++ b/src/main/java/com/conveyal/r5/analyst/progress/NoopProgressListener.java
@@ -1,0 +1,15 @@
+package com.conveyal.r5.analyst.progress;
+
+public class NoopProgressListener implements ProgressListener {
+
+    @Override
+    public void beginTask(String description, int totalElements) {
+
+    }
+
+    @Override
+    public void increment() {
+
+    }
+
+}

--- a/src/main/java/com/conveyal/r5/analyst/progress/ProgressListener.java
+++ b/src/main/java/com/conveyal/r5/analyst/progress/ProgressListener.java
@@ -1,17 +1,24 @@
 package com.conveyal.r5.analyst.progress;
 
-public class ProgressListener {
+/**
+ * This interface provides simple callbacks to allow long running, asynchronous operations to report on their progress.
+ */
+public interface ProgressListener {
 
-    private int totalElements;
+    /**
+     * Call this method once at the beginning of a new task, specifying how many sub-units of work will be performed.
+     * This does not allow for subsequently starting sub-tasks that use the same ProgressListener while progress is
+     * still being reported. Any recursion launching sub-tasks will need to be head- or tail-recursion, launched before
+     * you call beginTask or after the last unit of work is complete.
+     * Rather than implementing some kind of push/pop mechanism, we may eventually have some kind of nested task system,
+     * where all tasks are retrieved in a hierarchy and progress on sub-tasks bubbles up to super-tasks.
+     * Or alternatively, we may never recurse into lazy-loading code, which is probably a better long term goal.
+     */
+    void beginTask(String description, int totalElements);
 
-    private int currentElement;
-
-    private int logFrequency;
-
-    private String description;
-
-    public synchronized void increment () {
-        currentElement += 1;
-    }
+    /**
+     * Call this method to report that one unit of work has been performed.
+     */
+    void increment();
 
 }

--- a/src/main/java/com/conveyal/r5/analyst/progress/ProgressListener.java
+++ b/src/main/java/com/conveyal/r5/analyst/progress/ProgressListener.java
@@ -1,0 +1,17 @@
+package com.conveyal.r5.analyst.progress;
+
+public class ProgressListener {
+
+    private int totalElements;
+
+    private int currentElement;
+
+    private int logFrequency;
+
+    private String description;
+
+    public synchronized void increment () {
+        currentElement += 1;
+    }
+
+}

--- a/src/main/java/com/conveyal/r5/analyst/progress/Task.java
+++ b/src/main/java/com/conveyal/r5/analyst/progress/Task.java
@@ -1,9 +1,208 @@
 package com.conveyal.r5.analyst.progress;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 
-public class Task {
+/**
+ * This is a draft for a more advanced task progress system. It is not yet complete or functional.
+ *
+ * A Task (or some interface that it implements) could be used by the AsyncLoader to track progress. Together with some
+ * AsyncLoader functionality it will be a bit like a Future with progress reporting. Use of AsyncLoader could then be
+ * generalized to building TranportNetworks, EgressCostTables, etc. We don't want to run too far with lazy Async loading
+ * though, since the end goal is for users to trigger builds manually.
+ *
+ * Each task should be able to have subtasks, each of which represents an expected percentage of the parent task.
+ * Or an expected number of "relative work units" if new sub-tasks will be added on the fly, so absolutes are not known.
+ * Tasks should implement ProgressListener functionality, and bubble up progress to parent tasks.
+ *
+ * This class serves simultaneously as an internal domain object for tracking task execution, and an external API model
+ * object for communicating relevant information to the web UI (when serialized to JSON).
+ */
+public class Task implements Runnable, ProgressListener {
 
-    List<Task> subtasks;
+    // User and group are only relevant on the backend. On workers, we want to show network or cost table build progress
+    // to everyone in the organization, even if someone else's action kicked off the process.
+
+    private String user;
+
+    private String group;
+
+    // Timestamps to track execution time and wait time.
+
+    private Instant enqueued;
+
+    private Instant began;
+
+    private Instant completed;
+
+    private int bubbleUpdateFrequency = 0;
+
+    private int logFrequency = 0;
+
+    public String description;
+
+    public int totalWorkUnits;
+
+    public int currentWorkUnit;
+
+    /** To be on the safe side all tasks are considered heavyweight unless we explicitly set them to be lightweight. */
+    private boolean isHeavy = true;
+
+    /** Like a runnable, encapsulating the actual work that this task will perform. */
+    private TaskAction action;
+
+    // For operations that may perform a lot of fast copies?
+    // Maybe instead we should just always pre-calculate how many fast copies will happen, log that before even starting,
+    // and only track progress on the slow ones.
+    public int nWorkUnitsSkipped;
+
+    public boolean errored;
+
+    private Throwable throwable;
+
+    /** How often (every how many work units) this task will log progress on the backend. */
+    private int loggingFrequency;
+
+    @JsonIgnore
+    private Task parentTask;
+
+    // Maybe TObjectIntMap<Task> to store subtask weights.
+    public List<Task> subTasks;
+
+    // For non-hierarchical chaining? This may be needed even if our executor is backed by a queue,
+    // to prevent simultaneous execution of sequential tasks.
+    public Task nextTask;
+
+    public double getPercentComplete() {
+        return (currentWorkUnit * 100D) / totalWorkUnits;
+    }
+
+    List<Task> subtasks = new ArrayList<>();
+
+    /**
+     * Private constructor to encourage use of fluent methods.
+     */
+    private Task () {}
+
+    public void addSubtask (Task subtask) {
+
+    }
+
+    // Because of the subtask / next task mechanism, we don't let the actions mark tasks complete.
+    // This is another reason to pass the actions only a limited progress reporting interface.
+    private void markComplete () {
+        this.completed = Instant.now();
+    }
+
+    public boolean isHeavy () {
+        return this.isHeavy;
+    }
+
+    /**
+     * Abort the current task and cancel any subtasks or following tasks.
+     * @param throwable the reason for aborting this task.
+     */
+    public void abort (Throwable throwable) {
+        this.throwable = throwable;
+        // LOG?
+        this.markComplete();
+    }
+
+    protected void bubbleUpProgress() {
+        // weight progress of each subtask
+        double totalWeight = 0;
+        double totalProgress = 0;
+        for (Task task : subtasks) {
+            // Task weight could also be a property of the task itself.
+            double weight = 1; // fetch weight
+            totalWeight += weight;
+            double weightedProgress = (task.currentWorkUnit * weight) / task.totalWorkUnits;
+            totalProgress += weightedProgress;
+        }
+        totalProgress /= totalWeight;
+        // do something with total progress...
+        parentTask.bubbleUpProgress();
+    }
+
+    /**
+     * Check that all necesary fields have been set before enqueueing for execution, and check any invariants.
+     */
+    public void validate () {
+        if (this.user == null) {
+            throw new AssertionError("Task must have a defined user.");
+        }
+        // etc.
+    }
+
+    @Override
+    public void run () {
+        // The main action is run before the subtasks. It may not make sense progress reporting-wise for tasks to have
+        // both their own actions and subtasks with their own actions. Perhaps series of tasks are a special kind of
+        // action, which should encapsulate the bubble-up progress computation.
+        this.action.action(this);
+        for (Task subtask : subtasks) {
+            subtask.run();
+        }
+        this.markComplete();
+        this.nextTask.run();
+    }
+
+    @Override
+    public void beginTask(String description, int totalElements) {
+        // Just using an existing interface that may eventually be modified to not include this method.
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void increment () {
+        this.currentWorkUnit += 1;
+        // Occasionally bubble up progress to parent tasks, log to console, etc.
+        if (this.bubbleUpdateFrequency > 0 && (currentWorkUnit % bubbleUpdateFrequency == 0)) {
+            parentTask.bubbleUpProgress();
+        }
+        if (this.logFrequency > 0 && (currentWorkUnit % logFrequency == 0)) {
+            // LOG.info...
+        }
+    }
+
+    // FLUENT METHODS FOR CONFIGURING
+
+    // Really we should make a User object that combines user and group fields.
+    public Task forUser (String user, String group) {
+        this.user = user;
+        this.group = group;
+        return this;
+    }
+
+    public Task withDescription (String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * We may actually want the TaskAction to set the total work units via its restricted ProgressReporter interface.
+     */
+    public Task withTotalWorkUnits (int totalWorkUnits) {
+        this.totalWorkUnits = totalWorkUnits;
+        this.bubbleUpdateFrequency = totalWorkUnits / 100;
+        return this;
+    }
+
+    public Task withAction (TaskAction action) {
+        this.action = action;
+        return this;
+    }
+
+    public Task setHeavy (boolean heavy) {
+        this.isHeavy = heavy;
+        return this;
+    }
+
+    public static Task newTask () {
+        return new Task();
+    }
 
 }

--- a/src/main/java/com/conveyal/r5/analyst/progress/Task.java
+++ b/src/main/java/com/conveyal/r5/analyst/progress/Task.java
@@ -1,0 +1,9 @@
+package com.conveyal.r5.analyst.progress;
+
+import java.util.List;
+
+public class Task {
+
+    List<Task> subtasks;
+
+}

--- a/src/main/java/com/conveyal/r5/analyst/progress/TaskAction.java
+++ b/src/main/java/com/conveyal/r5/analyst/progress/TaskAction.java
@@ -1,0 +1,18 @@
+package com.conveyal.r5.analyst.progress;
+
+/**
+ * This represents the work actually carried out by a Task.
+ * It's a single-method interface so it can be defined with lambda functions, or other objects can implement it.
+ * When the action is run, it will receive an object implementing an interface through which it can report progress
+ * and errors.
+ */
+public interface TaskAction {
+
+    /**
+     * This method will define an asynchronous action to take.
+     * The parameter is a simpler interface of Task that only allows progress reporting, to encapsulate actions and
+     * prevent them from seeing or modifying the task hierarchy that triggers and manages them.
+     */
+    public void action (ProgressListener progressListener);
+
+}

--- a/src/main/java/com/conveyal/r5/analyst/progress/TaskExecutor.java
+++ b/src/main/java/com/conveyal/r5/analyst/progress/TaskExecutor.java
@@ -1,0 +1,66 @@
+package com.conveyal.r5.analyst.progress;
+
+import com.google.common.collect.Lists;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * This could replace our current bare ExecutorServices class. This can remain all-static for simplicity at first.
+ * Like many other things in Analysis it should probably become a singleton instance (though this is a pure question of
+ * style for the moment, as we never have more than one instance running in the same JVM).
+ *
+ * This executor is in R5 rather than analysis-backend, so does not now have access to AnalysisServerConfig.lightThreads
+ * and AnalysisServerConfig.heavyThreads config options. Pool sizes would need to be initialized manually at startup.
+ * There might not be any reason for it to be in R5 if it's entirely managing backend tasks. But we do expect to at
+ * least manage and report on progress building networks and distance tables, which needs to happen in a specific
+ * versioned worker instance.
+ *
+ * This is moving in the direction of having a single unified task management and reporting system across the backend
+ * and workers. It could be interesting to gather task status from the whole cluster of workers and merge them together
+ * into one view. This could conceivably even include regional analyses and chunks of work for regional analyses on
+ * workers. But even if such merging doesn't occur, it will be convenient to always report progress from backend and
+ * workers to the UI in the same data structures.
+ */
+public abstract class TaskExecutor {
+
+    private static final ExecutorService light = Executors.newFixedThreadPool(10);
+    private static final ExecutorService heavy = Executors.newFixedThreadPool(2);
+
+    public static void enqueue (Task task) {
+        task.validate();
+        if (task.isHeavy()) {
+            heavy.submit(task);
+        } else {
+            light.submit(task);
+        }
+    }
+
+    /**
+     * Just demonstrating how this would be used.
+     */
+    public static void example () {
+        TaskExecutor.enqueue(Task.newTask()
+                .forUser("abyrd@conveyal.com", "conveyal")
+                .withDescription("Process some complicated things")
+                .withTotalWorkUnits(1024)
+                .withAction((progressListener -> {
+                    double sum = 0;
+                    for (int i = 0; i < 1024; i++) {
+                        sum += Math.sqrt(i);
+                        progressListener.increment();
+                    }
+                }))
+        );
+    }
+
+    /**
+     * @return a hierarchical structure of all currently executing tasks, for serialization and transmission to the UI.
+     */
+    public static List<Task> getAllTasksForUI () {
+        // Hmm, we need to get all the tasks back out of the Executor once they're seen as Runnables...
+        return Lists.newArrayList();
+    }
+
+}

--- a/src/main/java/com/conveyal/r5/analyst/scenario/AddTrips.java
+++ b/src/main/java/com/conveyal/r5/analyst/scenario/AddTrips.java
@@ -87,6 +87,7 @@ public class AddTrips extends Modification {
         info.route_type = this.mode;
         info.color = "4444FF";
         this.routeIndex = transitLayer.routes.size();
+        // No protective copy is made here because TransportNetwork.scenarioCopy already deep-copies certain collections.
         transitLayer.routes.add(info);
 
         generatePattern(transitLayer, 0);

--- a/src/main/java/com/conveyal/r5/analyst/scenario/ModificationTypeResolver.java
+++ b/src/main/java/com/conveyal/r5/analyst/scenario/ModificationTypeResolver.java
@@ -71,7 +71,13 @@ public class ModificationTypeResolver extends TypeIdResolverBase {
     @Override
     public JavaType typeFromId (DatabindContext context, String id) {
         // All types of modifications that this worker understands should be in the table.
-        return context.getTypeFactory().constructType(modificationTypes.get(id));
+        Class<? extends Modification> modificationClass = modificationTypes.get(id);
+        if (modificationClass == null) {
+            String message = String.format("The modification type ID '%s' was not recognized by this R5 worker.", id);
+            LOG.error(message);
+            throw new IllegalArgumentException(message);
+        }
+        return context.getTypeFactory().constructType(modificationClass);
     }
 
     @Override

--- a/src/main/java/com/conveyal/r5/api/util/LegMode.java
+++ b/src/main/java/com/conveyal/r5/api/util/LegMode.java
@@ -1,7 +1,6 @@
 package com.conveyal.r5.api.util;
 
 import com.conveyal.r5.profile.StreetMode;
-import org.hsqldb.lib.Collection;
 
 import java.util.EnumSet;
 import java.util.Set;
@@ -9,7 +8,7 @@ import java.util.Set;
 /**
  * Modes of transport on access or egress legs
  */
-public enum  LegMode {
+public enum LegMode {
     WALK, BICYCLE, CAR,
     //Renting a bicycle
     BICYCLE_RENT,
@@ -23,18 +22,21 @@ public enum  LegMode {
         else return StreetMode.WALK;
     }
 
-    /** Convert between these two enum types */
+    /**
+     * Convert between these two enum types.
+     * Additional qualifiers (RENT and PARK) on LegMode will be lost in the conversion to StreetMode.
+     */
     public static StreetMode toStreetMode (LegMode legMode) {
         if (legMode == LegMode.WALK) {
             return StreetMode.WALK;
         }
-        if (legMode == LegMode.BICYCLE) {
+        if (legMode == LegMode.BICYCLE || legMode == LegMode.BICYCLE_RENT) {
             return StreetMode.BICYCLE;
         }
-        if (legMode == LegMode.CAR) {
+        if (legMode == LegMode.CAR || legMode == LegMode.CAR_PARK) {
             return StreetMode.CAR;
         }
-        throw new RuntimeException("Unrecognized mode.");
+        throw new AssertionError("This enum value is not covered by a conditional branch: " + legMode);
     }
 
     public static EnumSet<StreetMode> toStreetModeSet (EnumSet<LegMode>... legModeSets) {

--- a/src/main/java/com/conveyal/r5/profile/PerTargetPropagater.java
+++ b/src/main/java/com/conveyal/r5/profile/PerTargetPropagater.java
@@ -6,7 +6,6 @@ import com.conveyal.r5.analyst.PointSet;
 import com.conveyal.r5.analyst.TravelTimeReducer;
 import com.conveyal.r5.analyst.cluster.AnalysisTask;
 import com.conveyal.r5.analyst.cluster.PathWriter;
-import com.conveyal.r5.api.util.LegMode;
 import com.conveyal.r5.streets.LinkedPointSet;
 import com.conveyal.r5.streets.StreetLayer;
 import com.conveyal.r5.streets.StreetRouter;
@@ -125,7 +124,7 @@ public class PerTargetPropagater {
         linkedTargets = new ArrayList<>(modes.size());
         for (StreetMode mode : modes) {
             LinkedPointSet linkedTargetsForMode = targets.getLinkage(streetLayer, mode);
-            linkedTargetsForMode.makePointToStopDistanceTablesIfNeeded();
+            linkedTargetsForMode.transposeLinkageCostTablesIfNeeded();
             linkedTargets.add(linkedTargetsForMode);
         }
     }

--- a/src/main/java/com/conveyal/r5/profile/PerTargetPropagater.java
+++ b/src/main/java/com/conveyal/r5/profile/PerTargetPropagater.java
@@ -127,7 +127,7 @@ public class PerTargetPropagater {
             LinkedPointSet linkedTargetsForMode = targets.getLinkage(streetLayer, mode);
             // Transpose the cost table for propagation. Some tables are never used for propagation (like the
             // region-wide baseline). Transposing them only when needed should save a lot of memory.
-            linkedTargetsForMode.egressCostTable.makePointToStopTablesAsNeeded();
+            linkedTargetsForMode.egressCostTable.destructivelyTransposeForPropagationAsNeeded();
             linkedTargets.add(linkedTargetsForMode);
         }
     }

--- a/src/main/java/com/conveyal/r5/profile/PerTargetPropagater.java
+++ b/src/main/java/com/conveyal/r5/profile/PerTargetPropagater.java
@@ -127,7 +127,7 @@ public class PerTargetPropagater {
             LinkedPointSet linkedTargetsForMode = targets.getLinkage(streetLayer, mode);
             // Transpose the cost table for propagation. Some tables are never used for propagation (like the
             // region-wide baseline). Transposing them only when needed should save a lot of memory.
-            linkedTargetsForMode.egressCostTable.destructivelyTransposeForPropagationAsNeeded();
+            linkedTargetsForMode.getEgressCostTable().destructivelyTransposeForPropagationAsNeeded();
             linkedTargets.add(linkedTargetsForMode);
         }
     }
@@ -248,7 +248,7 @@ public class PerTargetPropagater {
     private void propagateTransit (int targetIndex, LinkedPointSet linkedTargets) {
 
         // Grab the set of nearby stops for this target, with their distances.
-        EgressCostTable egressCostTable = linkedTargets.egressCostTable;
+        EgressCostTable egressCostTable = linkedTargets.getEgressCostTable();
         TIntIntMap pointToStopLinkageCostTable = egressCostTable.getCostTableForPoint(targetIndex);
         StreetRouter.State.RoutingVariable unit = egressCostTable.linkageCostUnit;
 

--- a/src/main/java/com/conveyal/r5/profile/PerTargetPropagater.java
+++ b/src/main/java/com/conveyal/r5/profile/PerTargetPropagater.java
@@ -125,6 +125,9 @@ public class PerTargetPropagater {
         linkedTargets = new ArrayList<>(modes.size());
         for (StreetMode mode : modes) {
             LinkedPointSet linkedTargetsForMode = targets.getLinkage(streetLayer, mode);
+            // Transpose the cost table for propagation. Some tables are never used for propagation (like the
+            // region-wide baseline). Transposing them only when needed should save a lot of memory.
+            linkedTargetsForMode.egressCostTable.makePointToStopTablesAsNeeded();
             linkedTargets.add(linkedTargetsForMode);
         }
     }
@@ -246,7 +249,7 @@ public class PerTargetPropagater {
 
         // Grab the set of nearby stops for this target, with their distances.
         EgressCostTable egressCostTable = linkedTargets.egressCostTable;
-        TIntIntMap pointToStopLinkageCostTable = egressCostTable.pointToStopLinkageCostTables.get(targetIndex);
+        TIntIntMap pointToStopLinkageCostTable = egressCostTable.getCostTableForPoint(targetIndex);
         StreetRouter.State.RoutingVariable unit = egressCostTable.linkageCostUnit;
 
         /**

--- a/src/main/java/com/conveyal/r5/profile/PerTargetPropagater.java
+++ b/src/main/java/com/conveyal/r5/profile/PerTargetPropagater.java
@@ -6,6 +6,7 @@ import com.conveyal.r5.analyst.PointSet;
 import com.conveyal.r5.analyst.TravelTimeReducer;
 import com.conveyal.r5.analyst.cluster.AnalysisTask;
 import com.conveyal.r5.analyst.cluster.PathWriter;
+import com.conveyal.r5.streets.EgressCostTable;
 import com.conveyal.r5.streets.LinkedPointSet;
 import com.conveyal.r5.streets.StreetLayer;
 import com.conveyal.r5.streets.StreetRouter;
@@ -124,7 +125,6 @@ public class PerTargetPropagater {
         linkedTargets = new ArrayList<>(modes.size());
         for (StreetMode mode : modes) {
             LinkedPointSet linkedTargetsForMode = targets.getLinkage(streetLayer, mode);
-            linkedTargetsForMode.transposeLinkageCostTablesIfNeeded();
             linkedTargets.add(linkedTargetsForMode);
         }
     }
@@ -245,8 +245,9 @@ public class PerTargetPropagater {
     private void propagateTransit (int targetIndex, LinkedPointSet linkedTargets) {
 
         // Grab the set of nearby stops for this target, with their distances.
-        TIntIntMap pointToStopLinkageCostTable = linkedTargets.pointToStopLinkageCostTables.get(targetIndex);
-        StreetRouter.State.RoutingVariable unit = linkedTargets.linkageCostUnit;
+        EgressCostTable egressCostTable = linkedTargets.egressCostTable;
+        TIntIntMap pointToStopLinkageCostTable = egressCostTable.pointToStopLinkageCostTables.get(targetIndex);
+        StreetRouter.State.RoutingVariable unit = egressCostTable.linkageCostUnit;
 
         /**
          * Pre-compute and retain a pre-multiplied integer speed to avoid float math in the loop below.

--- a/src/main/java/com/conveyal/r5/streets/EgressCostTable.java
+++ b/src/main/java/com/conveyal/r5/streets/EgressCostTable.java
@@ -203,7 +203,11 @@ public class EgressCostTable implements Serializable {
 
         // TODO only report progress on slow operations (building new tables), not copying existing ones?
         // Precomputing which stops should be rebuilt would allow for nicer progress reporting.
-        progressListener.beginTask("Building egress impedance table for mode " + linkedPointSet.streetMode, nStops);
+        String taskDescription = String.format("Building %s egress tables for %s",
+                linkedPointSet.streetLayer.isScenarioCopy() ? "scenario" : "baseline",
+                streetMode.toString().toLowerCase()
+        );
+        progressListener.beginTask(taskDescription, nStops);
 
         final LambdaCounter computeCounter = new LambdaCounter(LOG, nStops, computeLogFrequency,
                 "Computed new stop -> point tables for {} of {} transit stops.");

--- a/src/main/java/com/conveyal/r5/streets/EgressCostTable.java
+++ b/src/main/java/com/conveyal/r5/streets/EgressCostTable.java
@@ -102,6 +102,8 @@ public class EgressCostTable implements Serializable {
      *
      * It would be possible to pull out pure (even static) functions to set these final fields.
      * Or make some factory methods or classes which produce immutable tables.
+     *
+     * BaseLinkage may be null if an EgressCostTable is being built for a baseline network.
      */
     public EgressCostTable (LinkedPointSet linkedPointSet, LinkedPointSet baseLinkage) {
 
@@ -112,7 +114,7 @@ public class EgressCostTable implements Serializable {
         } else {
             this.linkageCostUnit = StreetRouter.State.RoutingVariable.DISTANCE_MILLIMETERS;
         }
-        if (baseLinkage != null && this.linkageCostUnit != baseLinkage.egressCostTable.linkageCostUnit) {
+        if (baseLinkage != null && this.linkageCostUnit != baseLinkage.getEgressCostTable().linkageCostUnit) {
             throw new AssertionError("The base linkage's cost table is in the wrong units.");
         }
 
@@ -210,7 +212,7 @@ public class EgressCostTable implements Serializable {
                 // This conditional is handling stops outside the relink zone, which should always have existed before
                 // scenario application. Therefore they should be present in the base linkage cost tables.
                 copyCounter.increment();
-                return baseLinkage.egressCostTable.stopToPointLinkageCostTables.get(stopIndex);
+                return baseLinkage.getEgressCostTable().stopToPointLinkageCostTables.get(stopIndex);
             }
 
             computeCounter.increment();

--- a/src/main/java/com/conveyal/r5/streets/EgressCostTable.java
+++ b/src/main/java/com/conveyal/r5/streets/EgressCostTable.java
@@ -1,0 +1,323 @@
+package com.conveyal.r5.streets;
+
+import com.conveyal.r5.analyst.WebMercatorGridPointSet;
+import com.conveyal.r5.common.GeometryUtils;
+import com.conveyal.r5.profile.StreetMode;
+import com.conveyal.r5.transit.TransitLayer;
+import com.conveyal.r5.util.LambdaCounter;
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.Point;
+import gnu.trove.list.TIntList;
+import gnu.trove.list.array.TIntArrayList;
+import gnu.trove.map.TIntIntMap;
+import gnu.trove.map.hash.TIntIntHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.conveyal.r5.transit.TransitLayer.WALK_DISTANCE_LIMIT_METERS;
+
+/**
+ * This holds pre-calculated distances from stops to points (and vice versa)
+ */
+public class EgressCostTable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(EgressCostTable.class);
+
+    // CONSTANTS
+
+    public static final int BICYCLE_DISTANCE_LINKING_LIMIT_METERS = 5000;
+
+    public static final int CAR_TIME_LINKING_LIMIT_SECONDS = 30 * 60;
+
+    public static final int MAX_CAR_SPEED_METERS_PER_SECOND = 44; // ~160 kilometers per hour
+
+    /** The linkage from which these cost tables are built. */
+    public final LinkedPointSet linkedPointSet;
+
+    /**
+     * By default, linkage costs are distances (between stops and pointset points). For modes where speeds vary
+     * by link, it doesn't make sense to store distances, so we store times.
+     * TODO perhaps we should leave this uninitialized, only initializing once the linkage mode is known around L510-540.
+     * We would then fail fast on any programming errors that don't set or copy the cost unit.
+     */
+    public final StreetRouter.State.RoutingVariable linkageCostUnit;
+
+    /** For each transit stop, the distances (or times) to nearby PointSet points as packed (point_index, distance)
+     * pairs. */
+    public final List<int[]> stopToPointLinkageCostTables;
+
+    /**
+     * For each pointset point, the stops reachable without using transit, as a map from StopID to distance. For walk
+     * and bike, distance is in millimeters; for car, distance is actually time in seconds. Inverted version of
+     * stopToPointLinkageCostTables. This is used in PerTargetPropagator to find all the stops near a particular point
+     * (grid cell) so we can perform propagation to that grid cell only. We only retain a few percentiles of travel
+     * time at each target cell, so doing one cell at a time allows us to keep the output size within reason.
+     * TODO why is this transient? When is this serialized? Maybe just because it's bigger and has more references than the source table?
+     */
+    public transient List<TIntIntMap> pointToStopLinkageCostTables;
+
+    /**
+     * For each transit stop in the associated TransportNetwork, make a table of distances to nearby points in this
+     * PointSet.
+     * At one point we experimented with doing the entire search from the transit stops all the way up to the points
+     * within this method. However, that takes too long when switching PointSets. So we pre-cache distances to all
+     * street vertices in the TransitNetwork, and then just extend those tables to the points in the PointSet.
+     * This is one of the slowest steps in working with a new scenario. It takes about 50 seconds to link 400000 points.
+     * The run time is not shocking when you consider the complexity of the operation: there are nStops * nPoints
+     * iterations, which is 8000 * 400000 in the example case. This means 6 msec per transit stop, or 2e-8 sec per point
+     * iteration, which is not horribly slow. There are just too many iterations.
+     *
+     * It would be possible to pull out pure (even static) functions to set these final fields.
+     * Or make some factory methods or classes which produce immutable tables.
+     */
+    public EgressCostTable(LinkedPointSet linkedPointSet, LinkedPointSet baseLinkage) {
+
+        this.linkedPointSet = linkedPointSet;
+
+        if (linkedPointSet.streetMode == StreetMode.CAR) {
+            this.linkageCostUnit = StreetRouter.State.RoutingVariable.DURATION_SECONDS;
+        } else {
+            this.linkageCostUnit = StreetRouter.State.RoutingVariable.DISTANCE_MILLIMETERS;
+        }
+        if (baseLinkage != null && this.linkageCostUnit != baseLinkage.egressCostTable.linkageCostUnit) {
+            throw new AssertionError("The base linkage's cost table is in the wrong units.");
+        }
+
+        // The regions within which we want to link points to edges, then connect transit stops to points.
+        // Null means relink and rebuild everything. This will be constrained below if a base linkage was supplied, to
+        // encompass only areas near changed or created edges.
+        //
+        // Only build trees for stops inside this geometry in FIXED POINT DEGREES, leaving all the others alone.
+        // If null, build trees for all stops.
+        final Geometry rebuildZone;
+
+        final StreetMode streetMode = linkedPointSet.streetMode;
+
+        /**
+         * Limit to use when building linkageCostTables, re-calculated for different streetModes as needed, using the
+         * constants specified above. The value should be larger than any per-leg street mode limits that can be requested
+         * in the UI.
+         * FIXME we should leave this uninitialized, only initializing once the linkage mode is known.
+         * We would then fail fast on any programming errors that don't set or copy the limit.
+         * FIXME this appears to be used only in the constructor, should we really save it in an instance field? Maybe, just for debugging.
+         */
+        final int linkingDistanceLimitMeters;
+
+        if (baseLinkage != null) {
+            // TODO perhaps create alternate constructor of EgressCostTable which copies an existing one
+            // TODO We need to determine which points to re-link and which stops should have their stop-to-point tables re-built.
+            // TODO check where and how we re-link to streets split/modified by the scenario.
+            // This should be all the points within the (bird-fly) linking radius of any modified edge.
+            // The stop-to-vertex trees should already be rebuilt elsewhere when applying the scenario.
+            // This should be all the stops within the (network or bird-fly) tree radius of any modified edge, including
+            // any new stops that were created by the scenario (which will naturally fall within this distance).
+            // And build trees from stops to points.
+            // Even though currently the only changes to the street network are re-splitting edges to connect new
+            // transit stops, we still need to re-link points and rebuild stop trees (both the trees to the vertices
+            // and the trees to the points, because some existing stop-to-vertex trees might not include new splitter
+            // vertices).
+            // FIXME wait why are we only calculating a distance limit when a base linkage is supplied? Because otherwise we link all points and don't need a radius.
+            if (streetMode == StreetMode.WALK) {
+                linkingDistanceLimitMeters = WALK_DISTANCE_LIMIT_METERS;
+            } else if (streetMode == StreetMode.BICYCLE) {
+                linkingDistanceLimitMeters = BICYCLE_DISTANCE_LINKING_LIMIT_METERS;
+            } else if (streetMode == StreetMode.CAR) {
+                linkingDistanceLimitMeters = CAR_TIME_LINKING_LIMIT_SECONDS * MAX_CAR_SPEED_METERS_PER_SECOND;
+            } else {
+                throw new UnsupportedOperationException("Unrecognized streetMode");
+            }
+            rebuildZone = linkedPointSet.streetLayer.scenarioEdgesBoundingGeometry(linkingDistanceLimitMeters);
+        } else {
+            rebuildZone = null; // rebuild everything.
+            linkingDistanceLimitMeters = WALK_DISTANCE_LIMIT_METERS; // TODO check pre-refactor code, isn't this assuming WALK mode unless there's a base linkage?
+        }
+
+         LOG.info("Creating linkage cost tables from each transit stop to PointSet points.");
+         // FIXME using a spatial index is wasting a lot of memory and not needed for gridded pointsets - overload for gridded and freeform PointSets
+         // We could just do this in the method that uses the pointset spatial index (extendDistanceTableToPoints) but that's called in a tight loop.
+         linkedPointSet.pointSet.createSpatialIndexAsNeeded();
+
+        if (rebuildZone != null) {
+            LOG.info("Selectively computing tables for only those stops that might be affected by the scenario.");
+        }
+        TransitLayer transitLayer = linkedPointSet.streetLayer.parentNetwork.transitLayer;
+        int nStops = transitLayer.getStopCount();
+
+        int logFrequency = 1000;
+        if (streetMode == StreetMode.CAR) {
+            // Log more often because car searches are very slow.
+            logFrequency = 100;
+        }
+        LambdaCounter counter = new LambdaCounter(LOG, nStops, logFrequency,
+                "Computed distances to PointSet points from {} of {} transit stops.");
+        // Create a distance table from each transit stop to the points in this PointSet in parallel.
+        // Each table is a flattened 2D array. Two values for each point reachable from this stop: (pointIndex, cost)
+        // When applying a scenario, keep the existing distance table for those stops that could not be affected.
+        // TODO factor out the function that computes a cost table for one stop.
+        stopToPointLinkageCostTables = IntStream.range(0, nStops).parallel().mapToObj(stopIndex -> {
+            Point stopPoint = transitLayer.getJTSPointForStopFixed(stopIndex);
+            // If the stop is not linked to the street network, it should have no distance table.
+            if (stopPoint == null) return null;
+            if (rebuildZone != null && !rebuildZone.contains(stopPoint)) {
+                // This cannot be affected by the scenario. Return the existing distance table.
+                // All new stops created by a scenario should be inside the relink zone, so
+                // all stops outside the relink zone should already have a distance table entry.
+                // TODO having a rebuild zone always implies there is a baseLinkage? If it's possible to not have a base linkage, this should return null.
+                // All stops created by the scenario should by definition be inside the relink zone.
+                // This conditional is handling stops outside the relink zone, which should always have existed before
+                // scenario application. Therefore they should be present in the base linkage cost tables.
+                return baseLinkage.egressCostTable.stopToPointLinkageCostTables.get(stopIndex);
+            }
+
+            counter.increment();
+            Envelope envelopeAroundStop = stopPoint.getEnvelopeInternal();
+            GeometryUtils.expandEnvelopeFixed(envelopeAroundStop, linkingDistanceLimitMeters);
+
+            if (streetMode == StreetMode.WALK) {
+                // Walking distances from stops to street vertices are saved in the TransitLayer.
+                // Get the pre-computed walking distance table from the stop to the street vertices,
+                // then extend that table out from the street vertices to the points in this PointSet.
+                // TODO reuse the code that computes the walk tables at TransitLayer.buildOneDistanceTable() rather than duplicating it below for other modes.
+                TIntIntMap distanceTableToVertices = transitLayer.stopToVertexDistanceTables.get(stopIndex);
+                return distanceTableToVertices == null ? null :
+                        linkedPointSet.extendDistanceTableToPoints(distanceTableToVertices, envelopeAroundStop);
+            } else {
+
+                StreetRouter sr = new StreetRouter(transitLayer.parentNetwork.streetLayer);
+                sr.streetMode = streetMode;
+                int vertexId = transitLayer.streetVertexForStop.get(stopIndex);
+                if (vertexId < 0) {
+                    LOG.warn("Stop unlinked, cannot build distance table: {}", stopIndex);
+                    return null;
+                }
+                // TODO setting the origin point of the router to the stop vertex does not work.
+                // This is probably because link edges do not allow car traversal. We could traverse them.
+                // As a stopgap we perform car linking at the geographic coordinate of the stop.
+                // sr.setOrigin(vertexId);
+                VertexStore.Vertex vertex = linkedPointSet.streetLayer.vertexStore.getCursor(vertexId);
+                sr.setOrigin(vertex.getLat(), vertex.getLon());
+
+                if (streetMode == StreetMode.BICYCLE) {
+                    sr.distanceLimitMeters = linkingDistanceLimitMeters;
+                    sr.quantityToMinimize = linkageCostUnit;
+                    sr.route();
+                    return linkedPointSet.extendDistanceTableToPoints(sr.getReachedVertices(), envelopeAroundStop);
+                } else if (streetMode == StreetMode.CAR) {
+                    // The speeds for Walk and Bicycle can be specified in an analysis request, so it makes sense above to
+                    // store distances and apply the requested speed. In contrast, car speeds vary by link and cannot be
+                    // set in analysis requests, so it makes sense to use seconds directly as the linkage cost.
+                    // TODO confirm this works as expected when modifications can affect street layer.
+                    sr.timeLimitSeconds = CAR_TIME_LINKING_LIMIT_SECONDS;
+                    sr.quantityToMinimize = linkageCostUnit;
+                    sr.route();
+                    // TODO optimization: We probably shouldn't evaluate at every point in this LinkedPointSet in case it's much bigger than the driving radius.
+                    PointSetTimes driveTimesToAllPoints = linkedPointSet.eval(
+                            sr::getTravelTimeToVertex,
+                            null,
+                            LinkedPointSet.OFF_STREET_SPEED_MILLIMETERS_PER_SECOND
+                    );
+                    // TODO optimization: should we make spatial index visit() method public to avoid copying results?
+                    TIntList packedDriveTimes = new TIntArrayList();
+                    for (int p = 0; p < driveTimesToAllPoints.size(); p++) {
+                        int driveTimeToPoint = driveTimesToAllPoints.getTravelTimeToPoint(p);
+                        if (driveTimeToPoint != Integer.MAX_VALUE) {
+                            packedDriveTimes.add(p);
+                            packedDriveTimes.add(driveTimeToPoint);
+                        }
+                    }
+                    if (packedDriveTimes.isEmpty()) {
+                        return null;
+                    } else {
+                        return packedDriveTimes.toArray();
+                    }
+                } else {
+                    throw new UnsupportedOperationException("Tried to link a pointset with an unsupported street mode");
+                }
+            }
+        }).collect(Collectors.toList());
+        counter.done();
+
+        // Transpose the table, making the one that's actually used in routing.
+        makePointToStopTables();
+    }
+
+    /**
+     * Constructor for copying a strict sub-geographic area, with no rebuilding of any linkages or tables.
+     * Interestingly this has exactly the same signature as the other constructor, which makes me wonder if they can
+     * be combined into a single constructor.
+     */
+    public EgressCostTable (LinkedPointSet linkedPointSet, LinkedPointSet baseLinkage) {
+
+        this.linkedPointSet = linkedPointSet;
+        this.linkageCostUnit = x;
+
+        WebMercatorGridPointSet superGrid = (WebMercatorGridPointSet) baseLinkage.pointSet;
+        WebMercatorGridPointSet subGrid = (WebMercatorGridPointSet) linkedPointSet.pointSet;
+
+        // For each transit stop, we have a table of costs to reach pointset points (or null if none can be reached).
+        // If such tables have already been built for the source linkage, copy them and crop to a smaller rectangle as
+        // needed (as was done for the basic linkage information above).
+        stopToPointLinkageCostTables = baseLinkage.egressCostTable.stopToPointLinkageCostTables.stream()
+                .map(distanceTable -> {
+                    if (distanceTable == null) {
+                        // If the stop could not reach any points in the super-pointset,
+                        // it cannot reach any points in this sub-pointset.
+                        return null;
+                    }
+                    TIntList newDistanceTable = new TIntArrayList();
+                    for (int i = 0; i < distanceTable.length; i += 2) {
+                        int targetInSuperLinkage = distanceTable[i];
+                        int distance = distanceTable[i + 1];
+
+                        int superX = targetInSuperLinkage % superGrid.width;
+                        int superY = targetInSuperLinkage / superGrid.width;
+
+                        int subX = superX + superGrid.west - subGrid.west;
+                        int subY = superY + superGrid.north - subGrid.north;
+
+                        // Only retain distance information for points that fall within this sub-grid.
+                        if (subX >= 0 && subX < subGrid.width && subY >= 0 && subY < subGrid.height) {
+                            int targetInSubLinkage = subY * subGrid.width + subX;
+                            newDistanceTable.add(targetInSubLinkage);
+                            newDistanceTable.add(distance); // distance to target does not change when we crop the pointset
+                        }
+                    }
+                    if (newDistanceTable.isEmpty()) {
+                        // No points in the sub-pointset can be reached from this transit stop.
+                        return null;
+                    }
+                    return newDistanceTable.toArray();
+                })
+                .collect(Collectors.toList());
+
+    }
+
+    /**
+     * This method transposes the cost tables, yielding impedance from each point back to all stops that can reach it.
+     * The original calculation is performed from each stop out to the points it can reach.
+     * TODO Can we throw away the original stop -> point tables? That would save a lot of memory.
+     * TODO The target field is now final and transient. We should decide whether this is rebuilding a transient field, or a persistent field.
+     */
+    public void makePointToStopTables () {
+        TIntIntMap[] result = new TIntIntMap[linkedPointSet.size()];
+        for (int stop = 0; stop < stopToPointLinkageCostTables.size(); stop++) {
+            int[] stopToPointDistanceTable = stopToPointLinkageCostTables.get(stop);
+            if (stopToPointDistanceTable == null) continue;
+
+            for (int idx = 0; idx < stopToPointDistanceTable.length; idx += 2) {
+                int point = stopToPointDistanceTable[idx];
+                int distance = stopToPointDistanceTable[idx + 1];
+                if (result[point] == null) result[point] = new TIntIntHashMap();
+                result[point].put(stop, distance);
+            }
+        }
+        this.pointToStopLinkageCostTables = Arrays.asList(result);
+    }
+
+}

--- a/src/main/java/com/conveyal/r5/streets/EgressCostTable.java
+++ b/src/main/java/com/conveyal/r5/streets/EgressCostTable.java
@@ -132,7 +132,8 @@ public class EgressCostTable implements Serializable {
          * in the UI.
          * FIXME we should leave this uninitialized, only initializing once the linkage mode is known.
          * We would then fail fast on any programming errors that don't set or copy the limit.
-         * FIXME this appears to be used only in the constructor, should we really save it in an instance field? Maybe, just for debugging.
+         * FIXME this appears to be used only in the constructor, should we really save it in an instance field? Maybe,
+         *       just for debugging.
          */
         final int linkingDistanceLimitMeters;
 
@@ -149,7 +150,8 @@ public class EgressCostTable implements Serializable {
             // transit stops, we still need to re-link points and rebuild stop trees (both the trees to the vertices
             // and the trees to the points, because some existing stop-to-vertex trees might not include new splitter
             // vertices).
-            // FIXME wait why are we only calculating a distance limit when a base linkage is supplied? Because otherwise we link all points and don't need a radius.
+            // FIXME wait why are we only calculating a distance limit when a base linkage is supplied? Because
+            //       otherwise we link all points and don't need a radius.
             if (streetMode == StreetMode.WALK) {
                 linkingDistanceLimitMeters = WALK_DISTANCE_LIMIT_METERS;
             } else if (streetMode == StreetMode.BICYCLE) {
@@ -162,12 +164,14 @@ public class EgressCostTable implements Serializable {
             rebuildZone = linkedPointSet.streetLayer.scenarioEdgesBoundingGeometry(linkingDistanceLimitMeters);
         } else {
             rebuildZone = null; // rebuild everything.
-            linkingDistanceLimitMeters = WALK_DISTANCE_LIMIT_METERS; // TODO check pre-refactor code, isn't this assuming WALK mode unless there's a base linkage?
+            // TODO check pre-refactor code, isn't this assuming WALK mode unless there's a base linkage?
+            linkingDistanceLimitMeters = WALK_DISTANCE_LIMIT_METERS;
         }
 
          LOG.info("Creating linkage cost tables from each transit stop to PointSet points.");
-         // FIXME using a spatial index is wasting a lot of memory and not needed for gridded pointsets - overload for gridded and freeform PointSets
-         // We could just do this in the method that uses the pointset spatial index (extendDistanceTableToPoints) but that's called in a tight loop.
+         // FIXME using a spatial index is wasting a lot of memory and not needed for gridded pointsets - overload for
+        //        gridded and freeform PointSets. We could just do this in the method that uses the pointset spatial
+        //        index (extendDistanceTableToPoints) but that's called in a tight loop.
          linkedPointSet.pointSet.createSpatialIndexAsNeeded();
 
         if (rebuildZone != null) {
@@ -195,7 +199,8 @@ public class EgressCostTable implements Serializable {
                 // This cannot be affected by the scenario. Return the existing distance table.
                 // All new stops created by a scenario should be inside the relink zone, so
                 // all stops outside the relink zone should already have a distance table entry.
-                // TODO having a rebuild zone always implies there is a baseLinkage? If it's possible to not have a base linkage, this should return null.
+                // TODO having a rebuild zone always implies there is a baseLinkage? If it's possible to not have a base
+                //      linkage, this should return null.
                 // All stops created by the scenario should by definition be inside the relink zone.
                 // This conditional is handling stops outside the relink zone, which should always have existed before
                 // scenario application. Therefore they should be present in the base linkage cost tables.
@@ -210,7 +215,8 @@ public class EgressCostTable implements Serializable {
                 // Walking distances from stops to street vertices are saved in the TransitLayer.
                 // Get the pre-computed walking distance table from the stop to the street vertices,
                 // then extend that table out from the street vertices to the points in this PointSet.
-                // TODO reuse the code that computes the walk tables at TransitLayer.buildOneDistanceTable() rather than duplicating it below for other modes.
+                // TODO reuse the code that computes the walk tables at TransitLayer.buildOneDistanceTable() rather than
+                //      duplicating it below for other modes.
                 TIntIntMap distanceTableToVertices = transitLayer.stopToVertexDistanceTables.get(stopIndex);
                 return distanceTableToVertices == null ? null :
                         linkedPointSet.extendDistanceTableToPoints(distanceTableToVertices, envelopeAroundStop);
@@ -243,7 +249,8 @@ public class EgressCostTable implements Serializable {
                     sr.timeLimitSeconds = CAR_TIME_LINKING_LIMIT_SECONDS;
                     sr.quantityToMinimize = linkageCostUnit;
                     sr.route();
-                    // TODO optimization: We probably shouldn't evaluate at every point in this LinkedPointSet in case it's much bigger than the driving radius.
+                    // TODO optimization: We probably shouldn't evaluate at every point in this LinkedPointSet in case
+                    //      it's much bigger than the driving radius.
                     PointSetTimes driveTimesToAllPoints = linkedPointSet.eval(
                             sr::getTravelTimeToVertex,
                             null,

--- a/src/main/java/com/conveyal/r5/streets/EgressCostTable.java
+++ b/src/main/java/com/conveyal/r5/streets/EgressCostTable.java
@@ -52,7 +52,7 @@ public class EgressCostTable implements Serializable {
 
     public static final int CAR_TIME_LINKING_LIMIT_SECONDS = 30 * 60;
 
-    public static final int MAX_CAR_SPEED_METERS_PER_SECOND = 44; // ~160 kilometers per hour
+    public static final int MAX_CAR_SPEED_METERS_PER_SECOND = 22; // ~80 kilometers per hour
 
     // FIELDS
 

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -220,7 +220,7 @@ public class LinkedPointSet implements Serializable {
             }
         }
 
-        this.egressCostTable = new EgressCostTable(this, sourceLinkage, subGrid);
+        this.egressCostTable = EgressCostTable.geographicallyCroppedCopy(this, sourceLinkage.egressCostTable);
     }
 
 

--- a/src/main/java/com/conveyal/r5/util/AsyncLoader.java
+++ b/src/main/java/com/conveyal/r5/util/AsyncLoader.java
@@ -144,7 +144,7 @@ public abstract class AsyncLoader<K,V> {
     /**
      * Call this method inside the buildValue method to indicate progress.
      */
-    protected void setProgress(K key, int percentComplete, String message) {
+    public void setProgress(K key, int percentComplete, String message) {
         synchronized (map) {
             map.put(key, new LoaderState(Status.BUILDING, message, percentComplete, null));
         }


### PR DESCRIPTION
This PR fixes #540 (Build distance tables only for egress).

Recently we made it possible to use car or bicycle, rather than just walking, for egress from public transit. Egress from transit is "propagated" using precomputed cost tables, so we now make those cost tables for all modes used in a search, in case a mode is used for egress from transit.

However, building these cost tables is very time consuming, and not necessary for a mode that serves only for access to transit, or direct access to destinations, but not for egress. We needed to separate the concept of "linkage" from "cost tables", building linkages for all street modes in use (access, direct, and egress), but cost tables only for egress modes.

This PR makes those changes, defining a new class for EgressCostTables. The refactoring process has revealed some redundant code (for geographic cropping) and a somewhat confusing divergence in the code path when handling two different kinds of "base linkages". However the redundant code and multiple code paths have been maintained in the interest of performing one refactor at a time, avoiding excessive disruption to these critical chunks of code.

This PR also adds a mechanism that continuously reports progress of distance table construction to the NetworkPreloader, making it visible to the UI in status messages. Contrary to what I stated in a recent call, although there's a percentComplete field internally, this field is not currently exposed to the UI, so I have just included the percentage in the message text. Therefore it should work with no changes to the UI.

This PR also makes some changes that should significantly reduce memory consumption. Previously, we would end up with both stop-to-point and point-to-stop distance tables on many LinkedPointSets. The stop-to-point tables are source data and never actually used during analysis. In our current system, distance tables are either used as sources for other distance tables, or are used in routing, but never both. So I have made the table transposition operation irreversible - after the transposed tables are built (to facilitate routing) we release the original non-transposed data for garbage collection. 

There are a bunch of TODOs in this code. I may clean some of them out before merge, but I do intend to eventually do another round or two of refactoring in this area.