### PR TITLE
fix(half-headway): don't board before frequency entry starts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install: |
 # install dependencies used in after_success here because they don't get cached if called in after_success
 before_script:
   - pip install --user awscli && export PATH=$PATH:~/.local/bin/
-  - yarn global add @conveyal/maven-semantic-release@4.4.0 semantic-release@15.13.27
+  - yarn global add @conveyal/maven-semantic-release semantic-release
 
 # Replace Travis's default build step.
 # Run all Maven phases at once up through verify, install, and deploy.

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install: |
 # install dependencies used in after_success here because they don't get cached if called in after_success
 before_script:
   - pip install --user awscli && export PATH=$PATH:~/.local/bin/
-  - yarn global add @conveyal/maven-semantic-release semantic-release@15.13.27
+  - yarn global add @conveyal/maven-semantic-release@4.4.0 semantic-release@15.13.27
 
 # Replace Travis's default build step.
 # Run all Maven phases at once up through verify, install, and deploy.

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install: |
 # install dependencies used in after_success here because they don't get cached if called in after_success
 before_script:
   - pip install --user awscli && export PATH=$PATH:~/.local/bin/
-  - yarn global add @conveyal/maven-semantic-release semantic-release@15
+  - yarn global add @conveyal/maven-semantic-release semantic-release@15.13.27
 
 # Replace Travis's default build step.
 # Run all Maven phases at once up through verify, install, and deploy.

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install: |
 # install dependencies used in after_success here because they don't get cached if called in after_success
 before_script:
   - pip install --user awscli && export PATH=$PATH:~/.local/bin/
-  - yarn global add @conveyal/maven-semantic-release semantic-release
+  - yarn global add @conveyal/maven-semantic-release semantic-release@15
 
 # Replace Travis's default build step.
 # Run all Maven phases at once up through verify, install, and deploy.

--- a/src/main/java/com/conveyal/r5/profile/FastRaptorWorker.java
+++ b/src/main/java/com/conveyal/r5/profile/FastRaptorWorker.java
@@ -741,7 +741,7 @@ public class FastRaptorWorker {
      *
      * TODO account for possible dwell time?
      *
-     * @param earliestTime earliestTime the time at or after which to find a departure time (i.e. when a passenger is
+     * @param earliestTime the time at or after which to find a departure time (i.e. when a passenger is
      *                    ready to board).
      *
      * @return clock time at which a passenger boards this frequency entry at this stop
@@ -766,7 +766,7 @@ public class FastRaptorWorker {
 
         int headway = schedule.headwaySeconds[frequencyEntryIdx];
         int halfHeadway = headway / 2;
-        
+
         return halfHeadway + (Math.max(earliestTime, frequencyStartsAtThisStop));
 
     }

--- a/src/main/java/com/conveyal/r5/profile/FastRaptorWorker.java
+++ b/src/main/java/com/conveyal/r5/profile/FastRaptorWorker.java
@@ -733,7 +733,18 @@ public class FastRaptorWorker {
     }
 
     /**
-     * For half-headway (non-monte-carlo) evaluation of frequency-based routes.
+     * For half-headway (non-monte-carlo) evaluation of frequency-based routes. The caller should be looping through
+     * all frequency entries (e.g. to allow a passenger to wait at a stop for a subsequent frequency entry to start).
+     *
+     * The departure time is assumed to be half-headway after the later (maximum) of the passenger's earliest possible
+     * boarding time at the stop or the frequency entry's earliest possible arrival at the stop.
+     *
+     * TODO account for possible dwell time?
+     *
+     * @param earliestTime earliestTime the time at or after which to find a departure time (i.e. when a passenger is
+     *                    ready to board).
+     *
+     * @return clock time at which a passenger boards this frequency entry at this stop
      */
     public static int getAverageCaseFrequencyDepartureTime (
             TripSchedule schedule,
@@ -741,24 +752,23 @@ public class FastRaptorWorker {
             int frequencyEntryIdx,
             int earliestTime
     ) {
-        int headway = schedule.headwaySeconds[frequencyEntryIdx];
-        int halfHeadway = headway / 2;
-
-        // Ensure the schedule is still running.
         int travelTimeFromStartOfTrip = schedule.departures[stopPositionInPattern];
 
-        // Not strictly correct, should be revised: the last vehicle could leave the terminal as early as headwaySeconds
-        // before the end of the frequency entry. We might want to take the minimum or average of waiting for the
-        // current entry, and waiting for the next entry. We need to exclude entries that have ended, but not entries
-        // that have not yet started (because you can wait for them to start). See issue #122
+        // Ensure the schedule has not ceased at this stop. Note that this approach assumes no trip for this frequency
+        // entry leaves the first stop of the pattern after end_time, which is different from the assumption in the
+        // approaches above. See discussion in issue #122
         int frequencyEndsAtThisStop = schedule.endTimes[frequencyEntryIdx] + travelTimeFromStartOfTrip;
         if (frequencyEndsAtThisStop < earliestTime) {
             return -1;
         }
 
-        int boardTime = earliestTime + halfHeadway;
+        int frequencyStartsAtThisStop = schedule.startTimes[frequencyEntryIdx] + travelTimeFromStartOfTrip;
 
-        return boardTime;
+        int headway = schedule.headwaySeconds[frequencyEntryIdx];
+        int halfHeadway = headway / 2;
+        
+        return halfHeadway + (Math.max(earliestTime, frequencyStartsAtThisStop));
+
     }
 
     private void doTransfers (RaptorState state) {


### PR DESCRIPTION
In half-headway mode, passengers should board a frequency entry half the headway after the later of:
* their earliest possible arrival at the stop (`earliestTime`)
* the earliest possible arrival at the stop of the frequency entry

At https://github.com/conveyal/r5/commit/523a7601ef2a2d9302d0f48dd7463f78b6a3a421#diff-1b10c1587ece1a5ee7a4ce929d4bbb82L742, I replaced the latter with the former. We need both (cf. the maximum used in the return of `getWorstCaseFrequencyDepartureTime`).

This likely explains the recent unexpected results in the Santiago research, where the half-headway results showed much lower travel times than the MC results. In half-headway mode, passengers could board later frequency entries (e.g. with faster, off-peak speeds) without having to wait for those entries to actually start running.