### PR TITLE
Give workers longer to complete single-point task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install: |
 # install dependencies used in after_success here because they don't get cached if called in after_success
 before_script:
   - pip install --user awscli && export PATH=$PATH:~/.local/bin/
-  - yarn global add @conveyal/maven-semantic-release semantic-release@15
+  - yarn global add @conveyal/maven-semantic-release semantic-release@15 --ignore-engines
 
 # Replace Travis's default build step.
 # Run all Maven phases at once up through verify, install, and deploy.

--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
@@ -151,10 +151,10 @@ public class AnalystWorker implements Runnable {
 
     /**
      * This timeout should be longer than the longest expected worker calculation for a single-point request.
-     * Of course when linking a large grid, a worker could take much longer. We're just going to have to accept
-     * timeouts in those situations until we implement fail-fast 202 responses from workers for long lived operations.
+     * Preparing networks or linking grids will take longer, but those cases are now handled with
+     * WorkerNotReadyException.
      */
-    private static final int HTTP_CLIENT_TIMEOUT_SEC = 30;
+    private static final int HTTP_CLIENT_TIMEOUT_SEC = 45;
 
     /**
      * The results of finished work accumulate here, and will be sent in batches back to the broker.

--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalystWorker.java
@@ -154,7 +154,7 @@ public class AnalystWorker implements Runnable {
      * Preparing networks or linking grids will take longer, but those cases are now handled with
      * WorkerNotReadyException.
      */
-    private static final int HTTP_CLIENT_TIMEOUT_SEC = 45;
+    private static final int HTTP_CLIENT_TIMEOUT_SEC = 55;
 
     /**
      * The results of finished work accumulate here, and will be sent in batches back to the broker.


### PR DESCRIPTION
I thought this was already merged, but apparently I never opened the PR.

As of https://github.com/conveyal/analysis-backend/pull/238, the Broker triggers an error if this timeout is exceeded. I've seen cases where the worker stably handles complex analyses, but it needs more time than this cutoff.

We may want to set this to an even longer value (e.g. 55 seconds). I'm hesitant to set it beyond 60, where we might cause problems by inadvertently exceeding some opaque Apache HTTP defaults.

Fixes #519
