### PR TITLE
Revise definition of non-interpolated percentile

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/Grid.java
+++ b/src/main/java/com/conveyal/r5/analyst/Grid.java
@@ -75,6 +75,8 @@ import static org.apache.commons.math3.util.FastMath.tan;
  * Class that represents a grid in the spherical Mercator "projection" at a given zoom level.
  * This is actually a sub-grid of the full-world web mercator grid, with a specified width and height and offset from
  * the edges of the world.
+ *
+ * Note that writing a grid out and reading it back in rounds the data values, which start out as fractional doubles.
  */
 public class Grid {
 
@@ -270,7 +272,10 @@ public class Grid {
         }
     }
 
-    /** Write this grid out in R5 binary grid format. */
+    /**
+     * Write this grid out in R5 binary grid format.
+     * Note that writing a grid out and reading it back in rounds the data values, which start out as fractional doubles.
+     */
     public void write (OutputStream outputStream) throws IOException {
         // Java's DataOutputStream only outputs big-endian format ("network byte order").
         // These grids will be read out of Javascript typed arrays which use the machine's native byte order.
@@ -357,6 +362,9 @@ public class Grid {
         }
     }
 
+    /**
+     * Note that writing a grid out and reading it back in rounds the data values, which start out as fractional doubles.
+     */
     public static Grid read (InputStream inputStream) throws  IOException {
         LittleEndianDataInputStream data = new LittleEndianDataInputStream(inputStream);
         int zoom = data.readInt();


### PR DESCRIPTION
These changes were made during today's work session. We decided to exactly follow the standard definition of percentile to avoid any future confusion. Also added some comments based on our discussions about inclusive/exclusive comparisons when computing accessibility.