### PR TITLE
refactor(Grid): remove PreparedGeometryFactory

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/Grid.java
+++ b/src/main/java/com/conveyal/r5/analyst/Grid.java
@@ -13,8 +13,9 @@ import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.MultiPolygon;
 import com.vividsolutions.jts.geom.Point;
 import com.vividsolutions.jts.geom.Polygon;
+import com.vividsolutions.jts.geom.Polygonal;
 import com.vividsolutions.jts.geom.prep.PreparedGeometry;
-import com.vividsolutions.jts.geom.prep.PreparedGeometryFactory;
+import com.vividsolutions.jts.geom.prep.PreparedPolygon;
 import org.apache.commons.math3.util.FastMath;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.grid.GridCoverageFactory;
@@ -168,10 +169,6 @@ public class Grid extends PointSet {
         return getPixelWeights(geometry, false);
     }
 
-    // PreparedGeometry is often faster for small numbers of vertices;
-    // see https://github.com/chrisbennight/intersection-test
-    private PreparedGeometryFactory pgFact = new PreparedGeometryFactory();
-
     /**
      * Get the proportions of an input polygon feature that overlap each grid cell, for use in lists of PixelWeights.
      * These lists can then be fed into the incrementFromPixelWeights function to actually burn a polygon into the
@@ -202,7 +199,11 @@ public class Grid extends PointSet {
             throw new IllegalArgumentException("Feature geometry is too large.");
         }
 
-        PreparedGeometry preparedGeom = pgFact.create(geometry);
+        // PreparedGeometry is often faster for small numbers of vertices;
+        // see https://github.com/chrisbennight/intersection-test
+        // We know this is a polygon so don't need flexible PreparedGeometryFactory, which I'd rather not use because
+        // its only method seems inherently static but is implemented in a way that requires instantiating the factory.
+        PreparedGeometry preparedGeom = new PreparedPolygon((Polygonal) geometry);
 
         Envelope env = geometry.getEnvelopeInternal();
 

--- a/src/main/java/com/conveyal/r5/analyst/scenario/RoadCongestion.java
+++ b/src/main/java/com/conveyal/r5/analyst/scenario/RoadCongestion.java
@@ -121,7 +121,9 @@ public class RoadCongestion extends Modification {
             LOG.info("Validating features and creating spatial index...");
             polygonSpatialIndex = new STRtree();
             FeatureType featureType = featureCollection.getSchema();
-            // Check CRS:
+            // Check CRS. If none is present, according to GeoJSON spec it is in WGS84.
+            // Unfortunately our version of Geotools cannot understand the common urn:ogc:def:crs:OGC:1.3:CRS84
+            // so it's better to just remove the CRS from all input files.
             CoordinateReferenceSystem crs = featureType.getCoordinateReferenceSystem();
             if (crs != null && !DefaultGeographicCRS.WGS84.equals(crs) && !CRS.decode("CRS:84").equals(crs)) {
                 errors.add("GeoJSON should specify no coordinate reference system, and contain unprojected WGS84 " +


### PR DESCRIPTION
An instance of PreparedGeometryFactory was being used to create PreparedGeometries.

A separate instance of this factory was being created for each instance of Grid, rather than being created in a local variable or placed in a static field. Looking at the implementation of the factory (there is no Javadoc) it seems threadsafe so could be static, and seems trivial to construct so could also just be constructed quickly as a local variable.

However the implementation is strange in that it seems inherently static (the factory holds no state) but is not declared static. I think we don't need the factory at all since we know this is a polygon - we can just inline the branch of the factory's code that creates a prepared polygon.
