### PR TITLE
Refinements: travel time for origin and destination on same edge, adjustable web Mercator zoom level

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/LinkageCache.java
+++ b/src/main/java/com/conveyal/r5/analyst/LinkageCache.java
@@ -95,7 +95,7 @@ public class LinkageCache {
                             key.streetLayer,
                             key.streetMode
                     );
-                    if (basePointSetLinkage != null) {
+                    if (basePointSetLinkage != null && basePointSet.zoom == keyPointSet.zoom) {
                         LOG.info("Cutting linkage for {} out of existing linkage for {}.", keyPointSet, basePointSet);
                         return new LinkedPointSet(basePointSetLinkage, keyPointSet);
                     }

--- a/src/main/java/com/conveyal/r5/analyst/NetworkPreloader.java
+++ b/src/main/java/com/conveyal/r5/analyst/NetworkPreloader.java
@@ -167,19 +167,7 @@ public class NetworkPreloader extends AsyncLoader<NetworkPreloader.Key, Transpor
             // Egress modes must be tracked independently since we need to build EgressDistanceTables for those.
             this.allModes = LegMode.toStreetModeSet(task.directModes, task.accessModes, task.egressModes);
             this.egressModes = LegMode.toStreetModeSet(task.egressModes);
-
-            if (task.isHighPriority() || task.makeTauiSite) {
-                // TODO replace isHighPriority with polymorphism - method to return destination extents from any AnalysisTask.
-                //      And generally remove the term "high priority" from the whole system.
-                // High Priority is an obsolete term for "single point task".
-                // For single point tasks and static sites, there is no opportunity grid. The grid of destinations is
-                // the extents given in the task, which for static sites is also the grid of origins.
-                this.destinationGridExtents = WebMercatorExtents.forTask(task);
-            } else {
-                // A non-static-site regional task. We expect a valid grid of opportunities to be specified as the
-                // destinations. This is necessary to compute accessibility. So we extract those bounds from the grids.
-                this.destinationGridExtents = WebMercatorExtents.forGrid(((RegionalTask)task).destinationPointSet);
-            }
+            this.destinationGridExtents = task.getWebMercatorExtents();
         }
 
         public static Key forTask(AnalysisTask task) {

--- a/src/main/java/com/conveyal/r5/analyst/TravelTimeComputer.java
+++ b/src/main/java/com/conveyal/r5/analyst/TravelTimeComputer.java
@@ -15,6 +15,7 @@ import com.conveyal.r5.profile.PerTargetPropagater;
 import com.conveyal.r5.profile.StreetMode;
 import com.conveyal.r5.streets.LinkedPointSet;
 import com.conveyal.r5.streets.PointSetTimes;
+import com.conveyal.r5.streets.Split;
 import com.conveyal.r5.streets.StreetRouter;
 import com.conveyal.r5.transit.TransportNetwork;
 import gnu.trove.map.TIntIntMap;
@@ -177,8 +178,17 @@ public class TravelTimeComputer {
             LinkedPointSet linkedDestinations = network.linkageCache
                     .getLinkage(destinations, network.streetLayer, accessMode);
             // FIXME this is iterating over every cell in the (possibly huge) destination grid just to get the access times around the origin.
-            PointSetTimes pointSetTimes = linkedDestinations.eval(sr::getTravelTimeToVertex,
-                    streetSpeedMillimetersPerSecond, walkSpeedMillimetersPerSecond);
+            // We could construct a sub-grid that's an envelope around sr.originSplit's lat/lon, then iterate over the
+            // points in that sub-grid.
+
+            Split origin = sr.getOriginSplit();
+
+            PointSetTimes pointSetTimes = linkedDestinations.eval(
+                    sr::getTravelTimeToVertex,
+                    streetSpeedMillimetersPerSecond,
+                    walkSpeedMillimetersPerSecond,
+                    origin
+            );
 
             if (carPickupDelaySeconds > 0) {
                 LOG.info("Delaying travel times by {} seconds (for car pick-up wait).", carPickupDelaySeconds);

--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalysisTask.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalysisTask.java
@@ -1,5 +1,6 @@
 package com.conveyal.r5.analyst.cluster;
 
+import com.conveyal.r5.analyst.WebMercatorExtents;
 import com.conveyal.r5.analyst.WebMercatorGridPointSetCache;
 import com.conveyal.r5.analyst.WorkerCategory;
 import com.conveyal.r5.profile.ProfileRequest;
@@ -112,11 +113,12 @@ public abstract class AnalysisTask extends ProfileRequest {
     public void setTypes (String type) {};
 
     /**
-     * Whether this task is high priority and should jump in front of other work.
-     * TODO eliminate and use polymorphism (e.g. task.getWebMercatorExtents()), this is only used in one place.
+     * @return extents for the appropriate destination grid, derived from task's bounds and zoom (for Taui site tasks
+     * and single-point travel time surface tasks) or destination pointset (for standard regional accessibility
+     * analysis tasks)
      */
     @JsonIgnore
-    public abstract boolean isHighPriority();
+    public abstract WebMercatorExtents getWebMercatorExtents();
 
     @JsonIgnore
     public WorkerCategory getWorkerCategory () {

--- a/src/main/java/com/conveyal/r5/analyst/cluster/RegionalTask.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/RegionalTask.java
@@ -1,6 +1,7 @@
 package com.conveyal.r5.analyst.cluster;
 
 import com.conveyal.r5.analyst.PointSet;
+import com.conveyal.r5.analyst.WebMercatorExtents;
 
 /**
  * Represents a task to be performed as part of a regional analysis.
@@ -55,9 +56,20 @@ public class RegionalTask extends AnalysisTask implements Cloneable {
         return Type.REGIONAL_ANALYSIS;
     }
 
+    /**
+     * For Taui sites, there is no opportunity grid. The grid of destinations is the extents given in the task,
+     * which for static sites is also the grid of origins.
+     *
+     * For standard, non-Taui regional analyses, we expect a valid grid of opportunities to be specified as the
+     * destinations. This is necessary to compute accessibility. So we extract those bounds from the grids.
+     */
     @Override
-    public boolean isHighPriority() {
-        return false; // regional analysis tasks are not high priority
+    public WebMercatorExtents getWebMercatorExtents() {
+        if (makeTauiSite) {
+            return WebMercatorExtents.forTask(this);
+        } else {
+            return WebMercatorExtents.forGrid(this.destinationPointSet);
+        }
     }
 
     public RegionalTask clone () {

--- a/src/main/java/com/conveyal/r5/analyst/cluster/TravelTimeSurfaceTask.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/TravelTimeSurfaceTask.java
@@ -1,5 +1,6 @@
 package com.conveyal.r5.analyst.cluster;
 
+import com.conveyal.r5.analyst.WebMercatorExtents;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 /**
@@ -15,11 +16,6 @@ public class TravelTimeSurfaceTask extends AnalysisTask {
     @Override
     public Type getType() {
         return Type.TRAVEL_TIME_SURFACE;
-    }
-
-    @Override
-    public boolean isHighPriority() {
-        return true;
     }
 
     @JsonIgnoreProperties(ignoreUnknown=true)
@@ -41,6 +37,11 @@ public class TravelTimeSurfaceTask extends AnalysisTask {
 
     public Format getFormat(){
         return format;
+    }
+
+    @Override
+    public WebMercatorExtents getWebMercatorExtents() {
+        return WebMercatorExtents.forTask(this);
     }
 
     @Override

--- a/src/main/java/com/conveyal/r5/streets/EgressCostTable.java
+++ b/src/main/java/com/conveyal/r5/streets/EgressCostTable.java
@@ -276,7 +276,8 @@ public class EgressCostTable implements Serializable {
                     PointSetTimes driveTimesToAllPoints = linkedPointSet.eval(
                             sr::getTravelTimeToVertex,
                             null,
-                            LinkedPointSet.OFF_STREET_SPEED_MILLIMETERS_PER_SECOND
+                            LinkedPointSet.OFF_STREET_SPEED_MILLIMETERS_PER_SECOND,
+                            null
                     );
                     // TODO optimization: should we make spatial index visit() method public to avoid copying results?
                     TIntList packedDriveTimes = new TIntArrayList();

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -226,8 +226,8 @@ public class LinkedPointSet implements Serializable {
                 int sourceColumn = subGrid.west + x - superGrid.west;
                 int sourceRow = subGrid.north + y - superGrid.north;
                 if (sourceColumn < 0 || sourceColumn >= superGrid.width || sourceRow < 0 || sourceRow >= superGrid.height) { //point is outside super-grid
-                    //Set the edge value to -1 to indicate no linkage.
-                    //Distances should never be read downstream, so they don't need to be set here.
+                    // Set the edge value to -1 to indicate no linkage.
+                    // Distances should never be read downstream, so they don't need to be set here.
                     edges[pixel] = -1;
                 } else { //point is inside super-grid
                     int sourcePixel = sourceRow * superGrid.width + sourceColumn;
@@ -350,7 +350,7 @@ public class LinkedPointSet implements Serializable {
     public PointSetTimes eval (TravelTimeFunction travelTimeForVertex) {
         // R5 used to not differentiate between seconds and meters, preserve that behavior in this deprecated function
         // by using 1 m / s
-        return eval(travelTimeForVertex, 1000, 1000);
+        return eval(travelTimeForVertex, 1000, 1000, null);
     }
 
     /**
@@ -363,12 +363,18 @@ public class LinkedPointSet implements Serializable {
      * @return wrapped int[] of travel times (in seconds) to reach the pointset points
      */
 
-    public PointSetTimes eval (TravelTimeFunction travelTimeForVertex, Integer onStreetSpeed, int offStreetSpeed) {
+    public PointSetTimes eval (
+                TravelTimeFunction travelTimeForVertex,
+                Integer onStreetSpeed,
+                int offStreetSpeed,
+                Split origin
+            ) {
         int[] travelTimes = new int[edges.length];
         // Iterate over all locations in this temporary vertex list.
         EdgeStore.Edge edge = streetLayer.edgeStore.getCursor();
         for (int i = 0; i < edges.length; i++) {
             if (edges[i] < 0) {
+                // Target point is unlinked.
                 travelTimes[i] = Integer.MAX_VALUE;
                 continue;
             }
@@ -377,6 +383,7 @@ public class LinkedPointSet implements Serializable {
             int time1 = travelTimeForVertex.getTravelTime(edge.getToVertex());
 
             if (time0 == Integer.MAX_VALUE && time1 == Integer.MAX_VALUE) {
+                // The target point lies along an edge with vertices that the street router could not reach.
                 travelTimes[i] = Integer.MAX_VALUE;
                 continue;
             }
@@ -388,6 +395,14 @@ public class LinkedPointSet implements Serializable {
             // If a null onStreetSpeed is supplied, look up the speed for cars
             if (onStreetSpeed == null) {
                 onStreetSpeed = (int) (edge.getCarSpeedMetersPerSecond() * 1000);
+            }
+
+            if (origin != null && origin.edge == edges[i]) {
+                // The target point lies along the same edge as the origin
+                int onStreetDistance_mm = Math.abs(origin.distance0_mm - distances0_mm[i]);
+                offstreetTime += origin.distanceToEdge_mm / offStreetSpeed;
+                travelTimes[i] = onStreetDistance_mm / onStreetSpeed + offstreetTime;
+                continue;
             }
 
             if (time0 != Integer.MAX_VALUE) {

--- a/src/main/java/com/conveyal/r5/streets/Split.java
+++ b/src/main/java/com/conveyal/r5/streets/Split.java
@@ -13,9 +13,6 @@ import org.slf4j.LoggerFactory;
 /**
  * Represents a potential split point along an existing edge, retaining some geometric calculation state so that
  * once the best candidate is found more detailed calculations can continue.
- * We don't yet handle initial and final Splits on the same edge. This can be a problem for Analysis if your
- * starting point is on a long road without intersections. Travel times to other points along that road would be
- * measured by going to the end of the road and back.
  */
 public class Split {
 

--- a/src/main/java/com/conveyal/r5/streets/StreetRouter.java
+++ b/src/main/java/com/conveyal/r5/streets/StreetRouter.java
@@ -816,6 +816,8 @@ public class StreetRouter {
         return destinationSplit;
     }
 
+    public Split getOriginSplit() { return originSplit; }
+
     /**
      * Given the geographic coordinates of a starting point...
      * Returns the State with the smaller weight to vertex0 or vertex1


### PR DESCRIPTION
Fixes #287

Consider an origin O and destination D linked to edge W-Z at split points X and Y:
```   
    O   D
    |   |    
W---X---Y-----Z
```
Previously, the travel time from O to D calculated by R5 would be too long, because it included required travel to one end of the edge (O-X-W-X-Y-D).  The change in this PR passes the origin split to LinkedPointSet::eval, allowing the calculation of the correct time (O-X-Y-D).

For analyses with cumulative-opportunity cutoffs shorter than the time to traverse an edge, and for analyses that use decay functions, this change will increase accessibility relative to past versions of R5.