### PR TITLE
Refine paths

### DIFF
--- a/src/main/java/com/conveyal/r5/profile/FastRaptorWorker.java
+++ b/src/main/java/com/conveyal/r5/profile/FastRaptorWorker.java
@@ -511,13 +511,14 @@ public class FastRaptorWorker {
                 // that we don't check for alighting when boarding
                 if (onTrip > -1 && pattern.dropoffs[stopPositionInPattern] != PickDropType.NONE) {
                     int alightTime = schedule.arrivals[stopPositionInPattern];
-                    int onVehicleTime = alightTime - boardTime;
+                    int inVehicleTime = alightTime - boardTime;
 
-                    if (waitTime + onVehicleTime + inputState.bestTimes[boardStop] > alightTime) {
+                    // Use checkState instead?
+                    if (waitTime + inVehicleTime + inputState.bestTimes[boardStop] > alightTime) {
                         LOG.error("Components of travel time are larger than travel time!");
                     }
 
-                    outputState.setTimeAtStop(stop, alightTime, patternIndex, boardStop, waitTime, onVehicleTime, false);
+                    outputState.setTimeAtStop(stop, alightTime, patternIndex, boardStop, waitTime, inVehicleTime, false);
                 }
 
                 // Don't attempt to board if this stop was not reached in the last round or if pick up is not allowed.

--- a/src/main/java/com/conveyal/r5/profile/FastRaptorWorker.java
+++ b/src/main/java/com/conveyal/r5/profile/FastRaptorWorker.java
@@ -1,5 +1,6 @@
 package com.conveyal.r5.profile;
 
+import com.conveyal.r5.analyst.cluster.AnalysisWorkerTask;
 import com.conveyal.r5.api.util.TransitModes;
 import com.conveyal.r5.transit.PickDropType;
 import com.conveyal.r5.transit.RouteInfo;
@@ -108,7 +109,7 @@ public class FastRaptorWorker {
     private final TIntIntMap accessStops;
 
     /** The routing parameters. */
-    private final ProfileRequest request;
+    private final AnalysisWorkerTask request;
 
     /** The indexes of the trip patterns running on a given day with frequency-based trips of selected modes. */
     private final BitSet runningFrequencyPatterns = new BitSet();
@@ -141,7 +142,7 @@ public class FastRaptorWorker {
     /** If we're going to store paths to every destination (e.g. for static sites) then they'll be retained here. */
     public List<Path[]> pathsPerIteration;
 
-    public FastRaptorWorker (TransitLayer transitLayer, ProfileRequest request, TIntIntMap accessStops) {
+    public FastRaptorWorker (TransitLayer transitLayer, AnalysisWorkerTask request, TIntIntMap accessStops) {
         this.transit = transitLayer;
         this.request = request;
         this.accessStops = accessStops;
@@ -571,6 +572,8 @@ public class FastRaptorWorker {
                             } else {
                                 // The trip under consideration arrives too early,
                                 // stop searching since trips are sorted by departure time within a pattern.
+                                // The trip under consideration arrives at this stop earlier than one could feasibly
+                                // board. Stop searching, because trips are sorted by departure time within a pattern.
                                 break;
                             }
                         }

--- a/src/main/java/com/conveyal/r5/profile/RaptorState.java
+++ b/src/main/java/com/conveyal/r5/profile/RaptorState.java
@@ -341,15 +341,18 @@ public class RaptorState {
     }
 
     /**
-     * Checks whether boarding a at one stop allows for shorter access/transfer legs than boarding at another stop.
+     * @param here stopIndex
+     * @param there stopIndex
+     * @return true if the access/transfer leg to reach one stop (here) is shorter than the access/transfer leg to
+     * reach another stop (there) within this round.
      */
     public boolean shorterAccessOrTransferLeg(int here, int there) {
 
         if (here == there) return false;
 
         if (this.previous == null) {
-            // In the first transit round (when the pre-transit state is the input state), arriving at this stop before
-            // arriving at the upstream stop implies shorter access time.
+            // If there is no previous state, the pre-transit access round is being checked. Arriving here before
+            // arriving there implies shorter access time.
             return this.bestTimes[here] < this.bestTimes[there];
         } else {
             // In subsequent transit rounds, we want to compare the length of the transfer legs.
@@ -359,9 +362,13 @@ public class RaptorState {
         }
     }
 
-    private int transferTime(int stop) {
-        int fromStop = this.transferStop[stop];
-        return fromStop == -1 ? 0 : this.bestTimes[stop] - this.bestNonTransferTimes[fromStop];
+    /**
+     * Returns the length of time walking (or using some other street mode) within this round, to achieve the optimal
+     * route to the given stop in this round.
+     */
+    private int transferTime(int stopIndex) {
+        int fromStop = this.transferStop[stopIndex];
+        return fromStop == -1 ? 0 : this.bestTimes[stopIndex] - this.bestNonTransferTimes[fromStop];
     }
 
 }

--- a/src/main/java/com/conveyal/r5/transit/TripPattern.java
+++ b/src/main/java/com/conveyal/r5/transit/TripPattern.java
@@ -43,6 +43,9 @@ public class TripPattern implements Serializable, Cloneable {
     public PickDropType[] pickups;
     public PickDropType[] dropoffs;
     public BitSet wheelchairAccessible; // One bit per stop
+
+    /** TripSchedules for all trips following this pattern, sorted in ascending order by time of departure from first
+     *  stop */
     public List<TripSchedule> tripSchedules = new ArrayList<>();
 
     /** GTFS shape for this pattern. Should be left null in non-customer-facing applications */


### PR DESCRIPTION
https://github.com/conveyal/r5/commit/4a3b115bfff49be13f49303ed0d3e571fd2f3c23 favors paths that reduce access and transfer time, addressing #638. Other commits on this PR address a few miscellaneous cleanup TODOs.

We should discuss the assertions.

Based on the way we iterate through trips, it appears we assume trips on a pattern do not overtake each other. We may want to add a note about that and other limitations in how we use GTFS (e.g. transfers, handling of exact_times) to the user manual.