### PR TITLE
Propagation cleanup

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/TravelTimeComputer.java
+++ b/src/main/java/com/conveyal/r5/analyst/TravelTimeComputer.java
@@ -180,43 +180,51 @@ public class TravelTimeComputer {
                 minMergeMap(accessTimes, travelTimesToStopsSeconds);
             }
 
-            // Calculate times to reach destinations directly by this street mode, without using transit
-            LinkedPointSet linkedDestinations = network.linkageCache.getLinkage(
-                    destinations,
-                    network.streetLayer,
-                    accessMode
-            );
+            // Calculate times to reach destinations directly by this street mode, without using transit.
+            //
+            // The current implementation iterates over every cell in the destination grid. That usually makes sense
+            // for non-transit searches, where we need to evaluate times up to the full travel time limit. But for
+            // transit searches, where sr.timeLimitSeconds is typically small, it may not make sense to iterate over
+            // every cell in a (possibly huge) destination grid. If this is measured to be inefficient, we could
+            // construct a sub-grid that's an envelope around sr.originSplit's lat/lon (sized according to sr
+            // .timeLimitSeconds and a mode-specific speed?), then iterate over the points in that sub-grid.
+            {
+                LinkedPointSet linkedDestinations = network.linkageCache.getLinkage(
+                        destinations,
+                        network.streetLayer,
+                        accessMode
+                );
 
-            int streetSpeedMillimetersPerSecond =  (int) (request.getSpeedForMode(accessMode) * 1000);
-            if (streetSpeedMillimetersPerSecond <= 0){
-                throw new IllegalArgumentException("Speed of access mode must be greater than 0.");
-            }
-
-            // Convert from floating point meters per second (in request) to integer millimeters per second (internal).
-            int walkSpeedMillimetersPerSecond = (int) (request.walkSpeed * MM_PER_METER);
-
-            Split origin = sr.getOriginSplit();
-
-            // TODO refactor so this method takes sr as the sole argument
-            PointSetTimes pointSetTimes = linkedDestinations.eval(
-                    sr::getTravelTimeToVertex,
-                    streetSpeedMillimetersPerSecond,
-                    walkSpeedMillimetersPerSecond,
-                    origin
-            );
-
-            if (accessService != NO_WAIT_ALL_STOPS) {
-                LOG.info("Delaying direct travel times by {} seconds (to wait for {} pick-up).",
-                        accessService.waitTimeSeconds, accessMode);
-                if (accessService.stopsReachable != null) {
-                    // Disallow direct travel to destination if pickupDelay zones are associated with stops.
-                    pointSetTimes = PointSetTimes.allUnreached(destinations);
-                } else {
-                    // Allow direct travel to destination using services not associated with specific stops.
-                    pointSetTimes.incrementAllReachable(accessService.waitTimeSeconds);
+                int streetSpeedMillimetersPerSecond = (int) (request.getSpeedForMode(accessMode) * 1000);
+                if (streetSpeedMillimetersPerSecond <= 0) {
+                    throw new IllegalArgumentException("Speed of access mode must be greater than 0.");
                 }
+
+                // Convert from floating point meters per second (in request) to integer millimeters per second (internal).
+                int walkSpeedMillimetersPerSecond = (int) (request.walkSpeed * MM_PER_METER);
+
+                Split origin = sr.getOriginSplit();
+
+                PointSetTimes pointSetTimes = linkedDestinations.eval(
+                        sr::getTravelTimeToVertex,
+                        streetSpeedMillimetersPerSecond,
+                        walkSpeedMillimetersPerSecond,
+                        origin
+                );
+
+                if (accessService != NO_WAIT_ALL_STOPS) {
+                    LOG.info("Delaying direct travel times by {} seconds (to wait for {} pick-up).",
+                            accessService.waitTimeSeconds, accessMode);
+                    if (accessService.stopsReachable != null) {
+                        // Disallow direct travel to destination if pickupDelay zones are associated with stops.
+                        pointSetTimes = PointSetTimes.allUnreached(destinations);
+                    } else {
+                        // Allow direct travel to destination using services not associated with specific stops.
+                        pointSetTimes.incrementAllReachable(accessService.waitTimeSeconds);
+                    }
+                }
+                nonTransitTravelTimesToDestinations = PointSetTimes.minMerge(nonTransitTravelTimesToDestinations, pointSetTimes);
             }
-            nonTransitTravelTimesToDestinations = PointSetTimes.minMerge(nonTransitTravelTimesToDestinations, pointSetTimes);
         }
 
         // Handle park+ride, a mode represented in the request LegMode but not in the internal StreetMode.

--- a/src/main/java/com/conveyal/r5/analyst/TravelTimeComputer.java
+++ b/src/main/java/com/conveyal/r5/analyst/TravelTimeComputer.java
@@ -193,10 +193,6 @@ public class TravelTimeComputer {
                     accessMode
             );
 
-            // This is iterating over every cell in the (possibly huge) destination grid just to get the access times
-            // around the origin. If this is measured to be inefficient, we could construct a sub-grid that's an
-            // envelope around sr.originSplit's lat/lon, then iterate over the points in that sub-grid.
-
             Split origin = sr.getOriginSplit();
 
             PointSetTimes pointSetTimes = linkedDestinations.eval(

--- a/src/main/java/com/conveyal/r5/analyst/scenario/PickupWaitTimes.java
+++ b/src/main/java/com/conveyal/r5/analyst/scenario/PickupWaitTimes.java
@@ -165,10 +165,6 @@ public class PickupWaitTimes {
 
     }
 
-    public boolean egressUnavailable(int stop, StreetMode mode) {
-            return this.streetMode == mode && egressServiceForStop.get(stop) == null && getDefaultWaitInSeconds() == -1;
-    }
-
     public int getDefaultWaitInSeconds() {
         return (int) (polygons.defaultData * 60);
     }

--- a/src/main/java/com/conveyal/r5/analyst/scenario/PickupWaitTimes.java
+++ b/src/main/java/com/conveyal/r5/analyst/scenario/PickupWaitTimes.java
@@ -82,7 +82,7 @@ public class PickupWaitTimes {
         }
         // Service is available here. Determine the waiting time, and any restrictions on which stops can be reached.
         // By default all stops can be reached (null means no restrictions applied).
-        int waitTimeSeconds = (int) waitTimeMinutes * 60;
+        int waitTimeSeconds = (int) (waitTimeMinutes * 60);
         TIntSet stopsReachable = null;
         // If an association has been made between pickup polygons and stop polygons, that restricts reachable stops.
         if (stopNumbersForZonePolygon != null) {
@@ -170,7 +170,7 @@ public class PickupWaitTimes {
     }
 
     public int getDefaultWaitInSeconds() {
-        return (int) polygons.defaultData * 60;
+        return (int) (polygons.defaultData * 60);
     }
 
     /**

--- a/src/main/java/com/conveyal/r5/analyst/scenario/PickupWaitTimes.java
+++ b/src/main/java/com/conveyal/r5/analyst/scenario/PickupWaitTimes.java
@@ -76,12 +76,13 @@ public class PickupWaitTimes {
     public AccessService getAccessService (double lat, double lon) {
         Point point = GeometryUtils.geometryFactory.createPoint(new Coordinate(lon, lat));
         ModificationPolygon polygon = polygons.getWinningPolygon(point);
-        if (polygon == null || polygon.data == -1) {
+        double waitTimeMinutes = polygon == null ? polygons.defaultData : polygon.data;
+        if (waitTimeMinutes == -1) {
             return NO_SERVICE_HERE;
         }
         // Service is available here. Determine the waiting time, and any restrictions on which stops can be reached.
         // By default all stops can be reached (null means no restrictions applied).
-        int waitTimeSeconds = (int) (polygon.data * 60);
+        int waitTimeSeconds = (int) waitTimeMinutes * 60;
         TIntSet stopsReachable = null;
         // If an association has been made between pickup polygons and stop polygons, that restricts reachable stops.
         if (stopNumbersForZonePolygon != null) {
@@ -162,6 +163,14 @@ public class PickupWaitTimes {
             this.serviceArea = serviceArea;
         }
 
+    }
+
+    public boolean egressUnavailable(int stop, StreetMode mode) {
+            return this.streetMode == mode && egressServiceForStop.get(stop) == null && getDefaultWaitInSeconds() == -1;
+    }
+
+    public int getDefaultWaitInSeconds() {
+        return (int) polygons.defaultData * 60;
     }
 
     /**

--- a/src/main/java/com/conveyal/r5/profile/FastRaptorWorker.java
+++ b/src/main/java/com/conveyal/r5/profile/FastRaptorWorker.java
@@ -161,7 +161,8 @@ public class FastRaptorWorker {
     }
 
     /**
-     * For each iteration (minute + MC draw combination), return the minimum travel time to each transit stop in seconds.
+     * For each iteration (minute + MC draw combination), return the minimum travel time (duration) to each transit stop
+     * in seconds.
      * Return value dimension order is [searchIteration][transitStopIndex]
      * TODO Create proper types for return values?
      */

--- a/src/main/java/com/conveyal/r5/profile/PerTargetPropagater.java
+++ b/src/main/java/com/conveyal/r5/profile/PerTargetPropagater.java
@@ -317,6 +317,18 @@ public class PerTargetPropagater {
                     throw new UnsupportedOperationException("Linkage costs have an unknown unit.");
                 }
                 if (secondsFromStopToTarget < egressLegTimeLimitSeconds){
+                    // Account for any additional delay waiting for pickup at the egress stop.
+                    if (egressCostTable.egressStopDelaysSeconds != null) {
+                        int delayAtEgress = egressCostTable.egressStopDelaysSeconds[stop];
+                        if (delayAtEgress < 0) {
+                            // Pickup for this mode not allowed at this stop, so trove iteration should
+                            // continue
+                            return true;
+                        } else {
+                            secondsFromStopToTarget += delayAtEgress;
+                        }
+                    }
+
                     for (int iteration = 0; iteration < nIterations; iteration++) {
                         // The travel time (in seconds) needed to reach this stop. Note this is indeed a duration, as
                         // calculated in the Raptor route() method.
@@ -325,18 +337,6 @@ public class PerTargetPropagater {
                             // Skip propagation if the travel time to reach this stop is longer than the maximum
                             // travel time, or the travel time all the way to this target (via another stop).
                             continue;
-                        }
-
-                        // Account for any additional delay waiting for pickup at the egress stop.
-                        if (egressCostTable.egressStopDelaysSeconds != null) {
-                            int delayAtEgress = egressCostTable.egressStopDelaysSeconds[stop];
-                            if (delayAtEgress < 0) {
-                                // Pickup for this mode not allowed at this stop, so trove iteration should
-                                // continue
-                                return true;
-                            } else {
-                                secondsFromStopToTarget += delayAtEgress;
-                            }
                         }
 
                         int timeToReachTarget = timeToReachStop + secondsFromStopToTarget;

--- a/src/main/java/com/conveyal/r5/profile/PerTargetPropagater.java
+++ b/src/main/java/com/conveyal/r5/profile/PerTargetPropagater.java
@@ -327,27 +327,16 @@ public class PerTargetPropagater {
                             continue;
                         }
 
-                        // TODO shouldn't all the below egress delays be baked into linkedTargets.getEgressCostTable()
-                        //  .getCostTableForPoint(targetIndex)? At the end of the EgressCostTable constructor, we can
-                        //  see via linkedPointSet.streetLayer.waitTimePolygons (or a new wrapper class
-                        //  AccessEgressWaitTimes) whether each stop has an egress delay and add it in to all stops.
-                        //  Applying the pickup delay modification creates a new street layer, so a new linkage.
-
                         // Account for any additional delay waiting for pickup at the egress stop.
-                        // FIXME This adds delays to regular BICYCLE egress if BICYCLE_RENT egress has previously been
-                        //  requested (triggering the building of egressStopDelayTables above, which leads to
-                        //  non-null egressStopDelaysSeconds). Maybe this is fine -- as with CAR, the delays should
-                        //  be ignored when running a scenario without pickup delay modifications.
-                        if ((linkedTargets.streetMode == StreetMode.CAR || linkedTargets.streetMode == StreetMode.BICYCLE)
-                                && linkedTargets.egressStopDelaysSeconds != null) {
-                                    int delayAtEgress = linkedTargets.egressStopDelaysSeconds[stop];
-                                    if (delayAtEgress < 0) {
-                                        // Pickup for this mode not allowed at this stop, so trove iteration should
-                                        // continue
-                                        return true;
-                                    } else {
-                                        secondsFromStopToTarget += delayAtEgress;
-                                    }
+                        if (egressCostTable.egressStopDelaysSeconds != null) {
+                            int delayAtEgress = egressCostTable.egressStopDelaysSeconds[stop];
+                            if (delayAtEgress < 0) {
+                                // Pickup for this mode not allowed at this stop, so trove iteration should
+                                // continue
+                                return true;
+                            } else {
+                                secondsFromStopToTarget += delayAtEgress;
+                            }
                         }
 
                         int timeToReachTarget = timeToReachStop + secondsFromStopToTarget;

--- a/src/main/java/com/conveyal/r5/profile/PerTargetPropagater.java
+++ b/src/main/java/com/conveyal/r5/profile/PerTargetPropagater.java
@@ -302,9 +302,6 @@ public class PerTargetPropagater {
         int speedMillimetersPerSecond = (int) (request.getSpeedForMode(linkedTargets.streetMode) * MM_PER_METER);
         int egressLegTimeLimitSeconds = request.getMaxTimeSeconds(linkedTargets.streetMode);
 
-        // If handling car egress, and car hailing waiting times are defined, initialize with default hail wait time.
-        // FIXME ensure this ^ is baked into the PickupDelay class
-
         // Only try to propagate transit travel times if there are transit stops near this target.
         // Even if we don't propagate transit travel times, we still need to pass these non-transit times to
         // the reducer later in the caller, because you can walk even where there is no transit.

--- a/src/main/java/com/conveyal/r5/profile/ProfileRequest.java
+++ b/src/main/java/com/conveyal/r5/profile/ProfileRequest.java
@@ -77,7 +77,11 @@ public class ProfileRequest implements Serializable, Cloneable {
      * linking the street network to a pointset (i.e. it is applied between the true origin and the first street
      * vertex, and between the last street vertex and the true destination). Note that slow speeds specified here may
      * result in longer travel times than expected on long, high-speed blocks. But we tolerate some imprecision at
-     * the scale of individual blocks (see conversation at #436)*/
+     * the scale of individual blocks (see conversation at #436)
+     *
+     * This value is used only in the goal direction heuristic of the PointToPoint router. Code used in analysis may
+     * appear to use this value, but various conditionals ensure edge-specific speeds take precedence.
+     */
     public float carSpeed = 2.22f; // ~8 km/h
 
     /** Maximum time to reach the destination without using transit in minutes */
@@ -269,6 +273,9 @@ public class ProfileRequest implements Serializable, Cloneable {
 
     /**
      * @return the speed at which the given mode will traverse street edges, in floating point meters per second.
+     *
+     * This will return a default value for CAR. Callers should implement logic to replace this default with
+     * appropriate per-edge speeds.
      */
     @JsonIgnore
     public float getSpeedForMode (StreetMode streetMode) {

--- a/src/main/java/com/conveyal/r5/profile/ProfileRequest.java
+++ b/src/main/java/com/conveyal/r5/profile/ProfileRequest.java
@@ -274,8 +274,9 @@ public class ProfileRequest implements Serializable, Cloneable {
     /**
      * @return the speed at which the given mode will traverse street edges, in floating point meters per second.
      *
-     * This will return a default value for CAR. Callers should implement logic to replace this default with
-     * appropriate per-edge speeds.
+     * For WALK and BICYCLE, it makes sense to allow users to adjust speeds in the request. For CAR (where speeds
+     * vary by edge) callers should implement logic that uses appropriate per-edge speeds instead of the returned
+     * carSpeed. TODO throw exception if streetMode == CAR
      */
     @JsonIgnore
     public float getSpeedForMode (StreetMode streetMode) {

--- a/src/main/java/com/conveyal/r5/streets/EgressCostTable.java
+++ b/src/main/java/com/conveyal/r5/streets/EgressCostTable.java
@@ -293,8 +293,10 @@ public class EgressCostTable implements Serializable {
                 // values with any stop-specific values.
                 if (egressStopDelaysSeconds != null) {
                     PickupWaitTimes.EgressService egressService = pickupWaitTimes.getEgressService(stopIndex);
-                    egressArea = egressService.serviceArea;
-                    egressStopDelaysSeconds[stopIndex] = egressService.waitTimeSeconds;
+                    if (egressService != null) {
+                        egressArea = egressService.serviceArea;
+                        egressStopDelaysSeconds[stopIndex] = egressService.waitTimeSeconds;
+                    }
                 }
 
                 if (streetMode == StreetMode.BICYCLE) {

--- a/src/main/java/com/conveyal/r5/streets/EgressCostTable.java
+++ b/src/main/java/com/conveyal/r5/streets/EgressCostTable.java
@@ -313,7 +313,10 @@ public class EgressCostTable implements Serializable {
                 }
                 sr.quantityToMinimize = linkageCostUnit;
                 sr.route();
-                return linkedPointSet.extendCostsToPoints(sr, envelopeAroundStop, egressArea);
+                return linkedPointSet.extendCostsToPoints(sr.getReachedVertices()::get,
+                        sr.quantityToMinimize,
+                        envelopeAroundStop,
+                        egressArea);
             }
         }).collect(Collectors.toList());
         computeCounter.done();

--- a/src/main/java/com/conveyal/r5/streets/EgressCostTable.java
+++ b/src/main/java/com/conveyal/r5/streets/EgressCostTable.java
@@ -324,11 +324,12 @@ public class EgressCostTable implements Serializable {
      * Private constructor used by factory methods or other constructors to allow fields to be immutable.
      */
     private EgressCostTable (LinkedPointSet linkedPointSet,
-                            StreetRouter.State.RoutingVariable linkageCostUnit,
+                            EgressCostTable superCostTable,
                             List<int[]> stopToPointLinkageCostTables) {
         this.linkedPointSet = linkedPointSet;
-        this.linkageCostUnit = linkageCostUnit;
+        this.linkageCostUnit = superCostTable.linkageCostUnit;
         this.stopToPointLinkageCostTables = stopToPointLinkageCostTables;
+        this.egressStopDelaysSeconds = superCostTable.egressStopDelaysSeconds;
     }
 
     /**
@@ -384,7 +385,7 @@ public class EgressCostTable implements Serializable {
                 })
                 .collect(Collectors.toList());
 
-        return new EgressCostTable(subLinkage, superCostTable.linkageCostUnit, stopToPointLinkageCostTables);
+        return new EgressCostTable(subLinkage, superCostTable, stopToPointLinkageCostTables);
     }
 
     /**

--- a/src/main/java/com/conveyal/r5/streets/EgressCostTable.java
+++ b/src/main/java/com/conveyal/r5/streets/EgressCostTable.java
@@ -269,7 +269,7 @@ public class EgressCostTable implements Serializable {
                         linkedPointSet.extendDistanceTableToPoints(distanceTableToVertices, envelopeAroundStop);
             } else {
                 if (pickupWaitTimes != null && pickupWaitTimes.egressUnavailable(stopIndex, streetMode)) {
-                    LOG.info("{} egress from stop {} unavailable in pickup delay modification", streetMode, stopIndex);
+                    LOG.debug("{} egress from stop {} unavailable in pickup delay modification", streetMode, stopIndex);
                     return null;
                 }
                 StreetRouter sr = new StreetRouter(transitLayer.parentNetwork.streetLayer);

--- a/src/main/java/com/conveyal/r5/streets/EgressCostTable.java
+++ b/src/main/java/com/conveyal/r5/streets/EgressCostTable.java
@@ -241,7 +241,7 @@ public class EgressCostTable implements Serializable {
             Point stopPoint = transitLayer.getJTSPointForStopFixed(stopIndex);
             // If the stop is not linked to the street network, it should have no distance table.
             if (stopPoint == null) return null;
-            if (rebuildZone != null && !rebuildZone.contains(stopPoint)) {
+            if (rebuildZone != null && !rebuildZone.contains(stopPoint) && egressStopDelaysSeconds == null) {
                 // This cannot be affected by the scenario. Return the existing distance table.
                 // All new stops created by a scenario should be inside the relink zone, so
                 // all stops outside the relink zone should already have a distance table entry.
@@ -268,10 +268,29 @@ public class EgressCostTable implements Serializable {
                 return distanceTableToVertices == null ? null :
                         linkedPointSet.extendDistanceTableToPoints(distanceTableToVertices, envelopeAroundStop);
             } else {
-                if (pickupWaitTimes != null && pickupWaitTimes.egressUnavailable(stopIndex, streetMode)) {
-                    LOG.debug("{} egress from stop {} unavailable in pickup delay modification", streetMode, stopIndex);
-                    return null;
+
+                Geometry egressArea = null;
+
+                // If a pickup delay modification is present for this street mode, egressStopDelaysSeconds is
+                // initialized and filled with the default value in the constructor. Here, we override the default
+                // values with any stop-specific values.
+                if (egressStopDelaysSeconds != null) {
+                    // TODO handle case where stopsForZone is not specified in the modification, implying the main
+                    //  polygon can be used for both access and egress service.
+                    PickupWaitTimes.EgressService egressService = pickupWaitTimes.getEgressService(stopIndex);
+                    if (egressService == null) {
+                        if (pickupWaitTimes.getDefaultWaitInSeconds() < 0) {
+                            // Bail out early if egress from this stop is not specified and the default is no available
+                            // on-demand mode
+                            LOG.debug("{} egress from stop {} unavailable in pickup delay modification", streetMode, stopIndex);
+                            return null;
+                        }
+                    } else {
+                        egressArea = egressService.serviceArea;
+                        egressStopDelaysSeconds[stopIndex] = egressService.waitTimeSeconds;
+                    }
                 }
+
                 StreetRouter sr = new StreetRouter(transitLayer.parentNetwork.streetLayer);
                 sr.streetMode = streetMode;
                 int vertexId = transitLayer.streetVertexForStop.get(stopIndex);
@@ -285,19 +304,6 @@ public class EgressCostTable implements Serializable {
                 // sr.setOrigin(vertexId);
                 VertexStore.Vertex vertex = linkedPointSet.streetLayer.vertexStore.getCursor(vertexId);
                 sr.setOrigin(vertex.getLat(), vertex.getLon());
-
-                Geometry egressArea = null;
-
-                // If a pickup delay modification is present for this street mode, egressStopDelaysSeconds is
-                // initialized and filled with the default value in the constructor. Here, we override the default
-                // values with any stop-specific values.
-                if (egressStopDelaysSeconds != null) {
-                    PickupWaitTimes.EgressService egressService = pickupWaitTimes.getEgressService(stopIndex);
-                    if (egressService != null) {
-                        egressArea = egressService.serviceArea;
-                        egressStopDelaysSeconds[stopIndex] = egressService.waitTimeSeconds;
-                    }
-                }
 
                 if (streetMode == StreetMode.BICYCLE) {
                     sr.distanceLimitMeters = linkingDistanceLimitMeters;

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -468,7 +468,8 @@ public class LinkedPointSet implements Serializable {
      * points in this PointSet from the same transit stop. All points outside the distanceTableZone are skipped as an
      * optimization. See JavaDoc on the caller: this is one of the slowest parts of building a network.
      *
-     * This is a pure function i.e. it has no side effects on the state of the LinkedPointSet instance.
+     * This is a pure function i.e. it has no side effects on the state of the LinkedPointSet instance. For the
+     * moment it is used only for walk distance tables, which are computed once and saved when the network is built.
      *
      * @param distanceTableToVertices a map from integer vertex IDs to cumulative distance (in millimeters) accrued
      *                                traversing the network from the stop to the vertices

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -427,7 +427,6 @@ public class LinkedPointSet implements Serializable {
                 Split origin
             ) {
         int[] travelTimes = new int[edges.length];
-        // Iterate over all locations in this temporary vertex list.
         EdgeStore.Edge edge = streetLayer.edgeStore.getCursor();
         for (int i = 0; i < edges.length; i++) {
             if (edges[i] < 0) {

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -534,6 +534,10 @@ public class LinkedPointSet implements Serializable {
             } else if (routingVariable == RoutingVariable.DURATION_SECONDS) {
                 int time0 = costTableToVertices.get(edge.getFromVertex());
                 int time1 = costTableToVertices.get(edge.getFromVertex());
+                if (time0 == 0 && time1 == 0) {
+                    return true; // Edge unreachable, continue iteration. Should we update sr.getReachedVertices to use
+                    // a different noEntryValue?
+                }
                 int onStreetSpeed = (int) edge.getCarSpeedMetersPerSecond() * 1000;
                 cost = timeToPoint(time0, time1, onStreetSpeed, OFF_STREET_SPEED_MILLIMETERS_PER_SECOND, p);
             }

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -21,6 +21,7 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.stream.IntStream;
 
+import static com.conveyal.r5.streets.StreetRouter.State.RoutingVariable;
 import static com.conveyal.r5.streets.VertexStore.floatingDegreesToFixed;
 
 /**
@@ -403,13 +404,16 @@ public class LinkedPointSet implements Serializable {
     }
 
     /**
+     * Calculate time needed to reach points in this pointset (origin split to vertices of destination edge, plus vertex
+     * of destination edge to destination split, plus destination split to destination).
      *
      * @param travelTimeForVertex returning the time required to reach a vertex, in seconds
      * @param onStreetSpeed speed at which the first/last edge is traversed, in millimeters per second. If null, look
      *                     up CAR speed on the edge.
      * @param offStreetSpeed travel speed between the first/last edge and the pointset point, in millimeters per
      *                       second. Generally walking (we don't account for off-street parking not specified in OSM)
-     * @return wrapped int[] of travel times (in seconds) to reach the pointset points
+     * @return wrapped int[] of travel times (in seconds) to reach the pointset points, with Integer.MAX_VALUE for
+     * unreached points.
      */
 
     public PointSetTimes eval (
@@ -427,6 +431,9 @@ public class LinkedPointSet implements Serializable {
                 travelTimes[i] = Integer.MAX_VALUE;
                 continue;
             }
+
+            // TODO consider including time from origin to origin split point. See comments about "length of
+            //  perpendicular" in StreetRouter
             edge.seek(edges[i]);
             int time0 = travelTimeForVertex.getTravelTime(edge.getFromVertex());
             int time1 = travelTimeForVertex.getTravelTime(edge.getToVertex());
@@ -437,9 +444,6 @@ public class LinkedPointSet implements Serializable {
                 continue;
             }
 
-            // Portion of point-to-vertex time spent on component perpendicular to edge
-            int offstreetTime = distancesToEdge_mm[i] / offStreetSpeed;
-
             // Portion of point-to-vertex time spent along edge, between split point and vertex
             // If a null onStreetSpeed is supplied, look up the speed for cars
             if (onStreetSpeed == null) {
@@ -449,19 +453,12 @@ public class LinkedPointSet implements Serializable {
             if (origin != null && origin.edge == edges[i]) {
                 // The target point lies along the same edge as the origin
                 int onStreetDistance_mm = Math.abs(origin.distance0_mm - distances0_mm[i]);
-                offstreetTime += origin.distanceToEdge_mm / offStreetSpeed;
-                travelTimes[i] = onStreetDistance_mm / onStreetSpeed + offstreetTime;
-                continue;
+                travelTimes[i] = // origin.distanceToEdge_mm / offStreetSpeed + TODO origin to origin split point
+                                onStreetDistance_mm / onStreetSpeed + // along street
+                                distancesToEdge_mm[i] / offStreetSpeed; // from destination split point to destination
+            } else {
+                travelTimes[i] = timeToPoint(time0, time1, onStreetSpeed, offStreetSpeed, i);
             }
-
-            if (time0 != Integer.MAX_VALUE) {
-                time0 += distances0_mm[i] / onStreetSpeed + offstreetTime;
-            }
-            if (time1 != Integer.MAX_VALUE) {
-                time1 += distances1_mm[i] / onStreetSpeed + offstreetTime;
-            }
-
-            travelTimes[i] = time0 < time1 ? time0 : time1;
         }
         return new PointSetTimes(pointSet, travelTimes);
     }
@@ -473,14 +470,46 @@ public class LinkedPointSet implements Serializable {
      *
      * This is a pure function i.e. it has no side effects on the state of the LinkedPointSet instance.
      *
-     * TODO clarify that this can use times or distances, depending on units of the table?
-     * @param distanceTableToVertices a map from integer vertex IDs to distances TODO in what units?
-     * @param distanceTableZone TODO clarify: in fixed or floating degrees etc.
-     * @return A packed array of (pointIndex, distanceMillimeters), or null if there are no reachable points.
+     * @param distanceTableToVertices a map from integer vertex IDs to cumulative distance (in millimeters) accrued
+     *                                traversing the network from the stop to the vertices
+     * @param distanceTableZone the envelope in FIXED POINT DEGREES within which we want to find all points.
+     * @return A packed array of (pointIndex, cost), or null if there are no reachable points.
      */
-    public int[] extendDistanceTableToPoints (TIntIntMap distanceTableToVertices, Envelope distanceTableZone) {
+    public int[] extendDistanceTableToPoints(TIntIntMap distanceTableToVertices, Envelope distanceTableZone) {
+        return extendCostsToPoints(distanceTableToVertices,
+                RoutingVariable.DISTANCE_MILLIMETERS,
+                distanceTableZone,
+                null);
+    }
+
+    /**
+     * Given a table of costs (time or distance) to street vertices from a particular transit stop, create a table of
+     * costs to points in this PointSet from the same transit stop. All points outside the distanceTableZone are
+     * skipped as an optimization. See JavaDoc on the caller (EgressCostTable): this is one of the slowest parts of
+     * building a network.
+     *
+     * This is a pure function i.e. it has no side effects on the state of the LinkedPointSet instance.
+     *
+     * @param sr results of an on-street search from the transit stop
+     * @param distanceTableZone the envelope in FIXED POINT DEGREES within which we want to find all points.
+     * @param egressArea area served by on-demand service from this stop. If null, there are no restrictions on which
+     *                  points can be reached in the egress leg from this stop.
+     * @return A packed array of (pointIndex, cost), or null if there are no reachable points. Cost units match
+     * supplied sr.routingVariable
+     */
+    public int[] extendCostsToPoints(StreetRouter sr, Envelope distanceTableZone, Geometry egressArea) {
+        return extendCostsToPoints(sr.getReachedVertices(),
+                sr.quantityToMinimize,
+                distanceTableZone,
+                egressArea);
+    }
+
+    private int[] extendCostsToPoints(TIntIntMap costTableToVertices,
+                                     RoutingVariable routingVariable,
+                                     Envelope distanceTableZone,
+                                     Geometry egressArea) {
         int nPoints = this.size();
-        TIntIntMap distanceToPoint = new TIntIntHashMap(nPoints, 0.5f, Integer.MAX_VALUE, Integer.MAX_VALUE);
+        TIntIntMap costToPoint = new TIntIntHashMap(nPoints, 0.5f, Integer.MAX_VALUE, Integer.MAX_VALUE);
         Edge edge = streetLayer.edgeStore.getCursor();
         // We may not even need a distance table zone: we could just skip all points whose vertices are not in the router result.
         TIntList relevantPoints = pointSet.getPointsInEnvelope(distanceTableZone);
@@ -491,36 +520,84 @@ public class LinkedPointSet implements Serializable {
             if (edges[p] == -1) {
                 return true; // Continue to next iteration.
             }
+
+            if (egressArea != null && !GeometryUtils.containsPoint(egressArea, pointSet.getLon(p), pointSet.getLat(p))) {
+                return true; // Point is outside supplied area, continue to next iteration.
+            }
+
             edge.seek(edges[p]);
-            int t1 = Integer.MAX_VALUE;
-            int t2 = Integer.MAX_VALUE;
-            // TODO this is not strictly correct when there are turn restrictions onto the edge this is linked to
-            if (distanceTableToVertices.containsKey(edge.getFromVertex())) {
-                t1 = distanceTableToVertices.get(edge.getFromVertex()) + distances0_mm[p] + distancesToEdge_mm[p];
+
+            int cost = Integer.MAX_VALUE;
+
+            if (routingVariable == RoutingVariable.DISTANCE_MILLIMETERS) {
+                cost = distanceToPoint(costTableToVertices, edge, p);
+            } else if (routingVariable == RoutingVariable.DURATION_SECONDS) {
+                int time0 = costTableToVertices.get(edge.getFromVertex());
+                int time1 = costTableToVertices.get(edge.getFromVertex());
+                int onStreetSpeed = (int) edge.getCarSpeedMetersPerSecond() * 1000;
+                cost = timeToPoint(time0, time1, onStreetSpeed, OFF_STREET_SPEED_MILLIMETERS_PER_SECOND, p);
             }
-            if (distanceTableToVertices.containsKey(edge.getToVertex())) {
-                t2 = distanceTableToVertices.get(edge.getToVertex()) + distances1_mm[p] + distancesToEdge_mm[p];
-            }
-            int t = Math.min(t1, t2);
-            if (t != Integer.MAX_VALUE) {
-                if (t < distanceToPoint.get(p)) {
-                    distanceToPoint.put(p, t);
+
+            if (cost != Integer.MAX_VALUE) {
+                if (cost < costToPoint.get(p)) { // When is this false?
+                    costToPoint.put(p, cost);
                 }
             }
             return true; // Continue iteration.
         });
-        if (distanceToPoint.size() == 0) {
+        if (costToPoint.size() == 0) {
             return null;
         }
         // Convert a packed array of pairs.
         // TODO don't put in a list and convert to array, just make an array.
-        TIntList packed = new TIntArrayList(distanceToPoint.size() * 2);
-        distanceToPoint.forEachEntry((point, distance) -> {
+        TIntList packed = new TIntArrayList(costToPoint.size() * 2);
+        costToPoint.forEachEntry((point, distance) -> {
             packed.add(point);
             packed.add(distance);
             return true; // Continue iteration.
         });
         return packed.toArray();
+    }
+
+    /**
+     * Given accumulated distances to vertices, add the remaining distance needed to reach a point that is linked to
+     * an edge. This remaining distance consists of a distance along part of the edge (to the "split point"), plus a
+     * perpendicular distance from the split point to the final point.
+     *
+     * @return minimum distance needed to reach point, or Integer.MAX_VALUE if point is not reachable.
+     */
+    private int distanceToPoint(TIntIntMap distancesToVertices, Edge edge, int pointIndex) {
+        int distance0 = Integer.MAX_VALUE;
+        int distance1 = Integer.MAX_VALUE;
+        // TODO this is not strictly correct when there are turn restrictions onto the edge this is linked to
+        if (distancesToVertices.containsKey(edge.getFromVertex())) {
+            distance0 = distancesToVertices.get(edge.getFromVertex()) + distances0_mm[pointIndex] + distancesToEdge_mm[pointIndex];
+        }
+        if (distancesToVertices.containsKey(edge.getToVertex())) {
+            distance1 = distancesToVertices.get(edge.getToVertex()) + distances1_mm[pointIndex] + distancesToEdge_mm[pointIndex];
+        }
+
+        return Math.min(handleOverflow(distance0), handleOverflow(distance1));
+    }
+
+    /**
+     * Given accumulated time to reach vertices, add the remaining time needed to reach a point that is linked to
+     * an edge. This remaining time consists of a time traversing part of the edge (at onStreetSpeed), plus a
+     * time needed to travel the perpendicular distance (at offStreetSpeed) from the split point to the final point.
+     *
+     * @return minimum time needed to reach point, or Integer.MAX_VALUE if point is not reachable.
+     */
+    private int timeToPoint(int time0, int time1, int onStreetSpeed, int offStreetSpeed, int pointIndex) {
+
+        time0 += distances0_mm[pointIndex] / onStreetSpeed + distancesToEdge_mm[pointIndex] / offStreetSpeed;
+        time1 += distances1_mm[pointIndex] / onStreetSpeed + distancesToEdge_mm[pointIndex] / offStreetSpeed;
+
+        return Math.min(handleOverflow(time0), handleOverflow(time1));
+
+    }
+
+    private int handleOverflow (int value) {
+        return value < 0 ? Integer.MAX_VALUE : value;
     }
 
 }

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -91,12 +91,6 @@ public class LinkedPointSet implements Serializable {
     public final int[] distances1_mm;
 
     /**
-     * For each transit stop, extra seconds to wait due to a pickup delay modification (e.g. for autonomoous vehicle,
-     * scooter pickup, etc.)
-     */
-    public int[] egressStopDelaysSeconds;
-
-    /**
      * LinkedPointSets and their EgressCostTables are often copied from existing ones.
      * This field holds a reference to the source linkage from which the copy was made.
      * But there are two different ways linkages and cost tables can be based on existing ones:

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -533,7 +533,7 @@ public class LinkedPointSet implements Serializable {
                 cost = distanceToPoint(costTableToVertices, edge, p);
             } else if (routingVariable == RoutingVariable.DURATION_SECONDS) {
                 int time0 = costTableToVertices.get(edge.getFromVertex());
-                int time1 = costTableToVertices.get(edge.getFromVertex());
+                int time1 = costTableToVertices.get(edge.getToVertex());
                 if (time0 == 0 && time1 == 0) {
                     return true; // Edge unreachable, continue iteration. Should we update sr.getReachedVertices to use
                     // a different noEntryValue?

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -543,9 +543,7 @@ public class LinkedPointSet implements Serializable {
             }
 
             if (cost != Integer.MAX_VALUE) {
-                if (cost < costToPoint.get(p)) { // When is this false?
-                    costToPoint.put(p, cost);
-                }
+                costToPoint.put(p, cost);
             }
             return true; // Continue iteration.
         });

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -585,8 +585,13 @@ public class LinkedPointSet implements Serializable {
     /**
      * Given accumulated time to reach vertices, add the remaining time needed to reach a point that is linked to
      * an edge. This remaining time consists of a time traversing part of the edge (at onStreetSpeed), plus a
-     * time needed to travel the perpendicular distance (at offStreetSpeed) from the split point to the final point.
+     * time needed to travel the perpendicular distance (at offStreetSpeed) from the split point to the linked point.
      *
+     * @param time0 time (seconds) to reach the beginning vertex of the edge
+     * @param time1 time (seconds) to reach the end vertex of the edge
+     * @param onStreetSpeed speed (millimenters per second) at which the edge is traversed
+     * @param offStreetSpeed speed (millimeters per second) traveling from the edge to the linked point
+     * @param pointIndex index of the point in this linked pointset.
      * @return minimum time needed to reach point, or Integer.MAX_VALUE if point is not reachable.
      */
     private int timeToPoint(int time0, int time1, int onStreetSpeed, int offStreetSpeed, int pointIndex) {

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -553,9 +553,9 @@ public class LinkedPointSet implements Serializable {
         // Convert a packed array of pairs.
         // TODO don't put in a list and convert to array, just make an array.
         TIntList packed = new TIntArrayList(costToPoint.size() * 2);
-        costToPoint.forEachEntry((point, distance) -> {
+        costToPoint.forEachEntry((point, cost) -> {
             packed.add(point);
-            packed.add(distance);
+            packed.add(cost);
             return true; // Continue iteration.
         });
         return packed.toArray();

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -491,28 +491,28 @@ public class LinkedPointSet implements Serializable {
      * This is a pure function i.e. it has no side effects on the state of the LinkedPointSet instance.
      *
      * @param sr results of an on-street search from the transit stop
-     * @param distanceTableZone the envelope in FIXED POINT DEGREES within which we want to find all points.
+     * @param envelopeAroundStop the envelope in FIXED POINT DEGREES within which we want to find all points.
      * @param egressArea area served by on-demand service from this stop. If null, there are no restrictions on which
      *                  points can be reached in the egress leg from this stop.
      * @return A packed array of (pointIndex, cost), or null if there are no reachable points. Cost units match
      * supplied sr.routingVariable
      */
-    public int[] extendCostsToPoints(StreetRouter sr, Envelope distanceTableZone, Geometry egressArea) {
+    public int[] extendCostsToPoints(StreetRouter sr, Envelope envelopeAroundStop, Geometry egressArea) {
         return extendCostsToPoints(sr.getReachedVertices(),
                 sr.quantityToMinimize,
-                distanceTableZone,
+                envelopeAroundStop,
                 egressArea);
     }
 
     private int[] extendCostsToPoints(TIntIntMap costTableToVertices,
                                      RoutingVariable routingVariable,
-                                     Envelope distanceTableZone,
+                                     Envelope envelopeAroundStop,
                                      Geometry egressArea) {
         int nPoints = this.size();
         TIntIntMap costToPoint = new TIntIntHashMap(nPoints, 0.5f, Integer.MAX_VALUE, Integer.MAX_VALUE);
         Edge edge = streetLayer.edgeStore.getCursor();
         // We may not even need a distance table zone: we could just skip all points whose vertices are not in the router result.
-        TIntList relevantPoints = pointSet.getPointsInEnvelope(distanceTableZone);
+        TIntList relevantPoints = pointSet.getPointsInEnvelope(envelopeAroundStop);
         // This is not correcting for the fact that the method returns false positives, but that should be harmless.
         // It's returning every point in the bounding box. But it is also sensitive to which vertices are in the map.
         relevantPoints.forEach(p -> {

--- a/src/main/java/com/conveyal/r5/streets/StreetRouter.java
+++ b/src/main/java/com/conveyal/r5/streets/StreetRouter.java
@@ -229,8 +229,12 @@ public class StreetRouter {
     /**
      * Return a map where the keys are all the reached vertices, and the values are the value of the optimization
      * objective variable for the optimal path to that vertex.
+     * @return map from vertices to routing variable (time or distance), with <code>noEntryKey = -1</code> and
+     * <code>noEntryValue = Integer.MAX_VALUE</code>
      */
     public TIntIntMap getReachedVertices () {
+        // TODO use and return a more clearly defined type than this TIntIntMap, such as CostToVertexFunction (which has
+        //  Javadoc stating that MAX_VALUE always means unreachable). See suggestion in R5 #647.
         TIntIntMap result = new TIntIntHashMap(DEFAULT_CAPACITY, DEFAULT_LOAD_FACTOR, -1, Integer.MAX_VALUE);
         EdgeStore.Edge e = streetLayer.edgeStore.getCursor();
         bestStatesAtEdge.forEachEntry((eidx, states) -> {

--- a/src/main/java/com/conveyal/r5/streets/StreetRouter.java
+++ b/src/main/java/com/conveyal/r5/streets/StreetRouter.java
@@ -36,6 +36,8 @@ import java.util.List;
 import java.util.PriorityQueue;
 
 import static com.conveyal.r5.streets.LinkedPointSet.OFF_STREET_SPEED_MILLIMETERS_PER_SECOND;
+import static gnu.trove.impl.Constants.DEFAULT_CAPACITY;
+import static gnu.trove.impl.Constants.DEFAULT_LOAD_FACTOR;
 
 /**
  * This routes over the street layer of a TransitNetwork.
@@ -229,7 +231,7 @@ public class StreetRouter {
      * objective variable for the optimal path to that vertex.
      */
     public TIntIntMap getReachedVertices () {
-        TIntIntMap result = new TIntIntHashMap();
+        TIntIntMap result = new TIntIntHashMap(DEFAULT_CAPACITY, DEFAULT_LOAD_FACTOR, -1, Integer.MAX_VALUE);
         EdgeStore.Edge e = streetLayer.edgeStore.getCursor();
         bestStatesAtEdge.forEachEntry((eidx, states) -> {
             if (eidx < 0) return true;


### PR DESCRIPTION
We implemented support for pickup-delay modifications in https://github.com/conveyal/r5/pull/537, using a couple phases of work. My commits through `2c8a110` focused on on-demand `BICYCLE_RENT`. Subsequent commits were focused on enabling `CAR` with options to specify service between certain "stop" polygons and "zone" polygons.

This PR harmonizes the approaches and addresses a number of outstanding tasks:
* https://github.com/conveyal/r5/commit/e8d5e7d0e4e4999353b0bf8121ddcd474faffe07 includes clarifying comments and a no-op refactor for clarity
* https://github.com/conveyal/r5/commit/aadb689faf9aac0623650ac95b2b5943fe6ac5fa applies `defaultWait` values specified in PickupDelay modifications
* https://github.com/conveyal/r5/commit/aadb689faf9aac0623650ac95b2b5943fe6ac5fa moves tracking of egress stop delays from LinkedPointSet to EgressCostTable, as suggested in a TODO. It also deletes comments about `BICYCLE_RENT` vs. `BICYCLE`. PickupDelay modifications now include a streetMode field, and we should just assume users intend to apply the delays in the modification if it is active in their scenario and its streetMode matches the requested streetMode.
* https://github.com/conveyal/r5/commit/4cd82b15691114989622def03023f7e0f0a23760 is a larger refactor addressing a couple of optimizations previously suggested in TODOs, moving egress stop/area "filtering" and "transforming" (i.e. addition of wait time delays) to shared methods that work for both `BICYCLE` and `CAR`.