### PR TITLE
Return message for AnalysisServerException

### DIFF
--- a/src/main/java/com/conveyal/analysis/AnalysisServerException.java
+++ b/src/main/java/com/conveyal/analysis/AnalysisServerException.java
@@ -86,4 +86,8 @@ public class AnalysisServerException extends RuntimeException {
         message = m;
     }
 
+    @Override
+    public String getMessage() {
+        return message;
+    }
 }


### PR DESCRIPTION
We were seeing `null` instead of more helpful error messages because the default `.getMessage()` returns `detailMessage` of the superclass rather than `message`