### PR TITLE
synchronize reads from map to avoid concurrent modification

### DIFF
--- a/src/main/java/com/conveyal/analysis/components/broker/Broker.java
+++ b/src/main/java/com/conveyal/analysis/components/broker/Broker.java
@@ -443,7 +443,6 @@ public class Broker {
             job = findJob(workResult.jobId);
             assembler = resultAssemblers.get(workResult.jobId);
         }
-
         if (assembler == null) {
             LOG.error("Received result for unrecognized job ID {}, discarding.", workResult.jobId);
         } else {
@@ -499,14 +498,14 @@ public class Broker {
         }
     }
 
-    public boolean anyJobsActive () {
+    public synchronized boolean anyJobsActive () {
         for (Job job : jobs.values()) {
             if (!job.isComplete()) return true;
         }
         return false;
     }
 
-    public void logJobStatus() {
+    public synchronized void logJobStatus() {
         for (Job job : jobs.values()) {
             LOG.info(job.toString());
         }


### PR DESCRIPTION
These were previously used only in tests but will be used in auto shutdown checks.