### PR TITLE
Minor fixes for bugs found when modifying Freeform pointset upload

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/FreeFormPointSet.java
+++ b/src/main/java/com/conveyal/r5/analyst/FreeFormPointSet.java
@@ -81,7 +81,7 @@ public class FreeFormPointSet extends PointSet {
             if (idField != null && idCol < 0) {
                 throw new ParameterException("CSV file did not contain the specified ID column.");
             }
-            if (idField != null && idCol < 0) {
+            if (countField != null && countCol < 0) {
                 throw new ParameterException("CSV file did not contain the specified opportunity count column.");
             }
             while (reader.readRecord()) {


### PR DESCRIPTION
Count field was not being checked during freeform upload. It appears like it was meant to be, but the id field was instead checked twice.

During form upload, if the name field did not exist it would throw an `AnalysisServerException` that was then caught and re-thrown but with a new message that was less specific and harder to decipher. This refactors the form to allow those exceptions to get thrown to the appropriate handler.