### PR TITLE
Fix getCsvResults end point

### DIFF
--- a/src/main/java/com/conveyal/analysis/controllers/RegionalAnalysisController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/RegionalAnalysisController.java
@@ -329,7 +329,7 @@ public class RegionalAnalysisController implements HttpController {
         }
     }
 
-    private Object getCsvResults (Request req, Response res) {
+    private String getCsvResults (Request req, Response res) {
         final String regionalAnalysisId = req.params("_id");
         final Result resultType = Result.valueOf(req.params("resultType").toUpperCase());
 
@@ -339,7 +339,7 @@ public class RegionalAnalysisController implements HttpController {
                 req.attribute("accessGroup")
         ).iterator().next();
 
-        if (analysis == null || analysis.deleted || !analysis.complete) {
+        if (analysis == null || analysis.deleted) {
             throw AnalysisServerException.notFound("The specified analysis is unknown, incomplete, or deleted.");
         }
 
@@ -355,11 +355,12 @@ public class RegionalAnalysisController implements HttpController {
             throw AnalysisServerException.notFound("Path results were not recorded for this analysis");
         }
 
-        String key = regionalAnalysisId + resultType + ".csv.gz";
+        // TODO result path is stored in model, use that?
+        String key = regionalAnalysisId + '_' + resultType + ".csv.gz";
         FileStorageKey fileStorageKey = new FileStorageKey(config.resultsBucket(), key);
-        JSONObject json = new JSONObject();
-        json.put("url", fileStorage.getURL(fileStorageKey));
-        return json.toJSONString();
+
+        res.type("text");
+        return fileStorage.getURL(fileStorageKey);
     }
 
     /**
@@ -537,7 +538,7 @@ public class RegionalAnalysisController implements HttpController {
             // For grids, no transformer is supplied: render raw bytes or input stream rather than transforming to JSON.
             sparkService.get("/:_id", this::getRegionalAnalysis);
             sparkService.get("/:_id/grid/:format", this::getRegionalResults);
-            sparkService.get("/:_id/csv/resultType", this::getCsvResults);
+            sparkService.get("/:_id/csv/:resultType", this::getCsvResults);
             sparkService.delete("/:_id", this::deleteRegionalAnalysis, toJson);
             sparkService.post("", this::createRegionalAnalysis, toJson);
             sparkService.put("/:_id", this::updateRegionalAnalysis, toJson);


### PR DESCRIPTION
Notes: 
- `analysis.complete` does not seemed to be set correctly, so until we fix that we shouldn't use it.
- Downloading locally does not currently work due to the `csv.gz` file type. That needs to be fixed in the File package.
- If we are storing the URLs we should be able to use them in the download endpoint right? Either way, what we store should be compatible with the `FileStorageKey` so that we don't need to manually create the URL in the controller and can just do something like `new FileStorageKey(config.resultsBucket(), analysis.resultStorage.get(resultType))`.

