### PR TITLE
Further path cleanup

### DIFF
--- a/src/main/java/com/conveyal/analysis/results/MultiOriginAssembler.java
+++ b/src/main/java/com/conveyal/analysis/results/MultiOriginAssembler.java
@@ -255,10 +255,7 @@ public class MultiOriginAssembler {
                     int[] percentileResult = workResult.travelTimeValues[p];
                     for (int d = 0; d < percentileResult.length; d++) {
                         int travelTime = percentileResult[d];
-                        // oneToOne results will perform only one iteration of this loop
-                        // Always writing both origin and destination ID we should alert the user if something is amiss.
-                        int destinationIndex = job.templateTask.oneToOne ? workResult.taskId : d;
-                        String destinationId = destinationPointSet.getId(destinationIndex);
+                        String destinationId = destinationId(workResult.taskId, d);
                         timeCsvWriter.writeOneRow(originId, destinationId, String.valueOf(travelTime));
                     }
                 }
@@ -271,7 +268,7 @@ public class MultiOriginAssembler {
                     ArrayList<String[]> pathsIterations = pathsToPoints[d];
                     for (String[] iterationDetails : pathsIterations) {
                         String originId = originPointSet.getId(workResult.taskId);
-                        String destinationId = destinationPointSet.getId(d);
+                        String destinationId = destinationId(workResult.taskId, d);
                         checkDimension(workResult, "columns", iterationDetails.length, PathResult.DATA_COLUMNS.length);
                         pathCsvWriter.writeOneRow(originId, destinationId, iterationDetails);
                     }
@@ -340,6 +337,16 @@ public class MultiOriginAssembler {
         }
         for (CsvResultWriter writer : csvResultWriters) {
             writer.terminate();
+        }
+    }
+
+    String destinationId(int taskId, int index) {
+        // oneToOne results will have the same origin and destination IDs.
+        // Always writing both should alert the user if something is amiss.
+        if (job.templateTask.oneToOne) {
+            return destinationPointSet.getId(taskId);
+        } else {
+            return destinationPointSet.getId(index);
         }
     }
 

--- a/src/main/java/com/conveyal/r5/analyst/TravelTimeReducer.java
+++ b/src/main/java/com/conveyal/r5/analyst/TravelTimeReducer.java
@@ -278,12 +278,16 @@ public class TravelTimeReducer {
     public void recordPathsForTarget (int target, int[] perIterationTimes, Path[] perIterationPaths,
                                       StreetTimesAndModes.StreetTimeAndMode[] perIterationEgress) {
         Multimap<PatternSequence, PathResult.Iteration> paths = HashMultimap.create();
-        for (int i = 0; i < perIterationPaths.length; i++) {
+        for (int i = 0; i < perIterationTimes.length; i++) {
             Path path = perIterationPaths[i];
             int totalTime = perIterationTimes[i];
             if (path != null) {
                 PatternSequence patternSequence = new PatternSequence(path.patternSequence, perIterationEgress[i]);
                 PathResult.Iteration iteration = new PathResult.Iteration(path, totalTime);
+                paths.put(patternSequence, iteration);
+            } else if (totalTime < UNREACHED){
+                PatternSequence patternSequence = new PatternSequence(null, null, null, null);
+                PathResult.Iteration iteration = new PathResult.Iteration(totalTime);
                 paths.put(patternSequence, iteration);
             }
         }

--- a/src/main/java/com/conveyal/r5/analyst/cluster/PathResult.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/PathResult.java
@@ -7,6 +7,7 @@ import com.conveyal.r5.transit.path.RouteSequence;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import gnu.trove.list.TIntList;
+import gnu.trove.list.array.TIntArrayList;
 import org.apache.commons.lang3.ArrayUtils;
 
 import java.util.ArrayList;
@@ -149,8 +150,8 @@ public class PathResult {
         public Collection<HumanReadableIteration> iterations;
 
         PathIterations(RouteSequence pathTemplate, TransitLayer transitLayer, Collection<Iteration> iterations) {
-            this.access = pathTemplate.stopSequence.access.toString();
-            this.egress = pathTemplate.stopSequence.egress.toString();
+            this.access = pathTemplate.stopSequence.access == null ? null : pathTemplate.stopSequence.access.toString();
+            this.egress = pathTemplate.stopSequence.egress == null ? null : pathTemplate.stopSequence.egress.toString();
             this.transitLegs = pathTemplate.transitLegs(transitLayer);
             this.iterations = iterations.stream().map(HumanReadableIteration::new).collect(Collectors.toList());
         }
@@ -189,6 +190,14 @@ public class PathResult {
             this.waitTimes = path.waitTimes;
             this.totalTime = totalTime;
         }
+
+        /**
+         * Constructor for paths with no transit boardings (and therefore no wait times).
+         */
+        public Iteration(int totalTime) {
+            this.waitTimes = new TIntArrayList();
+            this.totalTime = totalTime;
+        }
     }
 
     /**
@@ -200,6 +209,7 @@ public class PathResult {
         public double totalTime;
 
         HumanReadableIteration(Iteration iteration) {
+            // TODO track departure time for non-transit paths (so direct trips don't show departure time 00:00).
             this.departureTime =
                     String.format("%02d:%02d", Math.floorDiv(iteration.departureTime, 3600),
                             (int) (iteration.departureTime / 60.0 % 60));

--- a/src/main/java/com/conveyal/r5/transit/path/PatternSequence.java
+++ b/src/main/java/com/conveyal/r5/transit/path/PatternSequence.java
@@ -37,9 +37,9 @@ public class PatternSequence {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        PatternSequence path = (PatternSequence) o;
-        return patterns.equals(path.patterns) &&
-               this.stopSequence.equals(path.stopSequence);
+        PatternSequence that = (PatternSequence) o;
+        return Objects.equals(patterns, that.patterns) &&
+                Objects.equals(stopSequence, that.stopSequence);
     }
 
     @Override

--- a/src/main/java/com/conveyal/r5/transit/path/PatternSequence.java
+++ b/src/main/java/com/conveyal/r5/transit/path/PatternSequence.java
@@ -16,7 +16,7 @@ public class PatternSequence {
     /**
      * Create a PatternSequence from transit leg characteristics.
      */
-    PatternSequence(TIntList patterns, TIntList boardStops, TIntList alightStops, TIntList rideTimesSeconds) {
+    public PatternSequence(TIntList patterns, TIntList boardStops, TIntList alightStops, TIntList rideTimesSeconds) {
         this.patterns = patterns;
         this.stopSequence = new StopSequence(boardStops, alightStops, rideTimesSeconds);
     }

--- a/src/main/java/com/conveyal/r5/transit/path/RouteSequence.java
+++ b/src/main/java/com/conveyal/r5/transit/path/RouteSequence.java
@@ -20,7 +20,9 @@ public class RouteSequence {
     public RouteSequence(PatternSequence patternSequence, TransitLayer transitLayer) {
         this.stopSequence = patternSequence.stopSequence;
         this.routes = new TIntArrayList();
-        patternSequence.patterns.forEach(p -> this.routes.add(transitLayer.tripPatterns.get(p).routeIndex));
+        if (patternSequence.patterns != null) {
+            patternSequence.patterns.forEach(p -> this.routes.add(transitLayer.tripPatterns.get(p).routeIndex));
+        }
     }
 
     /** Returns details summarizing this route sequence, using GTFS ids stored in the supplied transitLayer. */
@@ -35,13 +37,15 @@ public class RouteSequence {
             alightStopIds.add(transitLayer.stopString(stopSequence.alightStops.get(i), false));
             rideTimes.add(String.format("%.1f", stopSequence.rideTimesSeconds.get(i) / 60f));
         }
+        String accessTime = stopSequence.access == null ? null : String.format("%.1f", stopSequence.access.time / 60f);
+        String egressTime = stopSequence.egress == null ? null : String.format("%.1f", stopSequence.egress.time / 60f);
         return new String[]{
                 routeIds.toString(),
                 boardStopIds.toString(),
                 alightStopIds.toString(),
                 rideTimes.toString(),
-                String.format("%.1f", stopSequence.access.time / 60f),
-                String.format("%.1f", stopSequence.egress.time / 60f)
+                accessTime,
+                egressTime
         };
     }
 

--- a/src/main/java/com/conveyal/r5/transit/path/StopSequence.java
+++ b/src/main/java/com/conveyal/r5/transit/path/StopSequence.java
@@ -35,9 +35,9 @@ public class StopSequence {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         StopSequence that = (StopSequence) o;
-        return boardStops.equals(that.boardStops) &&
-                alightStops.equals(that.alightStops) &&
-                rideTimesSeconds.equals(that.rideTimesSeconds) &&
+        return Objects.equals(boardStops, that.boardStops) &&
+                Objects.equals(alightStops, that.alightStops) &&
+                Objects.equals(rideTimesSeconds, that.rideTimesSeconds) &&
                 Objects.equals(access, that.access) &&
                 Objects.equals(egress, that.egress);
     }

--- a/src/main/java/com/conveyal/r5/transit/path/StopSequence.java
+++ b/src/main/java/com/conveyal/r5/transit/path/StopSequence.java
@@ -64,10 +64,15 @@ public class StopSequence {
      * calculated by  subtracting the other components of travel time from the total travel time
      */
     public int transferTime(PathResult.Iteration iteration) {
-        int transferTimeSeconds =
-                iteration.totalTime - access.time - egress.time - iteration.waitTimes.sum() - rideTimesSeconds.sum();
-        checkState(transferTimeSeconds >= 0);
-        return transferTimeSeconds;
+        if (access == null && egress == null && iteration.waitTimes.size() == 0 && rideTimesSeconds == null) {
+            // No transit ridden, so transfer time is 0.
+            return 0;
+        } else {
+            int transferTimeSeconds =
+                    iteration.totalTime - access.time - egress.time - iteration.waitTimes.sum() - rideTimesSeconds.sum();
+            checkState(transferTimeSeconds >= 0);
+            return transferTimeSeconds;
+        }
     }
 
 }


### PR DESCRIPTION
- Path results now include rows for direct itineraries (e.g. walking without transit)
- Re-enables oneToOne CSV results (part of #650)