### PR TITLE
No local CORS

### DIFF
--- a/src/main/java/com/conveyal/analysis/components/HttpApi.java
+++ b/src/main/java/com/conveyal/analysis/components/HttpApi.java
@@ -88,7 +88,11 @@ public class HttpApi implements Component {
             //       Or now with non-static Spark we can run two HTTP servers on different ports.
 
             // Set CORS headers, to allow requests to this API server from any page.
-            res.header("Access-Control-Allow-Origin", "*");
+            // but do not do this when running offline with no auth, as this may allow a malicious website to use a local
+            // browser to access the analysis server.
+            if (!config.offline()) {
+                res.header("Access-Control-Allow-Origin", "*");
+            }
 
             // The default MIME type is JSON. This will be overridden by the few controllers that do not return JSON.
             res.type("application/json");
@@ -120,14 +124,17 @@ public class HttpApi implements Component {
         });
 
         // Handle CORS preflight requests (which are OPTIONS requests).
-        sparkService.options("/*", (req, res) -> {
-            res.header("Access-Control-Allow-Methods", "GET,PUT,POST,DELETE,OPTIONS");
-            res.header("Access-Control-Allow-Credentials", "true");
-            res.header("Access-Control-Allow-Headers", "Accept,Authorization,Content-Type,Origin," +
-                    "X-Requested-With,Content-Length,X-Conveyal-Access-Group"
-            );
-            return "OK";
-        });
+        // except when running in offline mode (see above comment about auth and CORS)
+        if (!config.offline()) {
+            sparkService.options("/*", (req, res) -> {
+                res.header("Access-Control-Allow-Methods", "GET,PUT,POST,DELETE,OPTIONS");
+                res.header("Access-Control-Allow-Credentials", "true");
+                res.header("Access-Control-Allow-Headers", "Accept,Authorization,Content-Type,Origin," +
+                        "X-Requested-With,Content-Length,X-Conveyal-Access-Group"
+                );
+                return "OK";
+            });
+        }
 
         // Allow client to fetch information about the backend build version.
         sparkService.get(

--- a/src/main/java/com/conveyal/analysis/components/LocalComponents.java
+++ b/src/main/java/com/conveyal/analysis/components/LocalComponents.java
@@ -33,7 +33,7 @@ public class LocalComponents extends Components {
         taskScheduler = new TaskScheduler(config);
         fileStorage = new LocalFileStorage(
                 config.localCacheDirectory(),
-                String.format("http://localhost:%s/files", config.serverPort())
+                "/api/backend/files" // proxied by analysis-ui
         );
         gtfsCache = new GTFSCache(fileStorage, config);
         osmCache = new OSMCache(fileStorage, config);


### PR DESCRIPTION
This disables CORS when running without authentication locally, and requires conveyal/analysis-ui#1457 to proxy to the backend. It makes no changes in production.