### PR TITLE
Remove Kodiak

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -1,2 +1,0 @@
-# Minimal config. version is the only required field.
-version = 1


### PR DESCRIPTION
The Kodiak check stalled on a recent PR, maybe because of configuration changes elsewhere. I turned off that status check on our r5 dev branch. Anyway we always expected this to become a standard Github feature, and indeed automerge now exists and is seamlessly integrated.