### PR TITLE
Fix regional analysis with Grids of different extents

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/WebMercatorExtents.java
+++ b/src/main/java/com/conveyal/r5/analyst/WebMercatorExtents.java
@@ -40,15 +40,23 @@ public class WebMercatorExtents {
         this.zoom = zoom;
     }
 
+    /**
+     * Return the analysis extents embedded in the task object itself.
+     * Sometimes these imply gridded origin points (non-Taui regional tasks without freeform origins specified) and
+     * sometimes these imply gridded destination points (single point tasks and Taui regional tasks).
+     */
     public static WebMercatorExtents forTask (AnalysisWorkerTask task) {
         return new WebMercatorExtents(task.west, task.north, task.width, task.height, task.zoom);
     }
 
-    /** If pointSets are all gridded, return the minimum-sized WebMercatorExtents containing them all. */
+    /**
+     * If pointSets are all gridded, return the minimum bounding WebMercatorExtents containing them all.
+     * Otherwise return null (this null is a hack explained below and should eventually be made more consistent).
+     */
     public static WebMercatorExtents forPointsets (PointSet[] pointSets) {
         checkNotNull(pointSets);
         checkElementIndex(0, pointSets.length, "You must supply at least one destination PointSet.");
-        if (pointSets[0] instanceof Grid) {
+        if (pointSets[0] instanceof Grid || pointSets[0] instanceof GridTransformWrapper) {
             WebMercatorExtents extents = pointSets[0].getWebMercatorExtents();
             for (PointSet pointSet : pointSets) {
                 extents = extents.expandToInclude(pointSet.getWebMercatorExtents());

--- a/src/main/java/com/conveyal/r5/analyst/cluster/RegionalTask.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/RegionalTask.java
@@ -60,7 +60,8 @@ public class RegionalTask extends AnalysisWorkerTask implements Cloneable {
      * the destinations, as this is necessary to compute accessibility. Travel times to any location outside those grids
      * cannot change accessibility results, and we are not displaying travel time isochrones, so we extract the
      * minimal bounds containing all destination opportunity grids. This is not optimal where the full extent of the
-     * road network is smaller than the opportunity data, but that should be rare.
+     * road network is smaller than the opportunity data, but that should be rare. We could intersect with the extents
+     * of the street network, but that probably requires access to the loaded TransportNetwork.
      */
     @Override
     public WebMercatorExtents getWebMercatorExtents() {


### PR DESCRIPTION
This is a fix to be applied on top of the already-merged #684. In addition to that backend change, it turns out we also needed a worker-side change to tolerate GridTransformWrappers in a method that used to only look for Grids. I also revised some comments explaining what's going on when we wrap multiple Grids to give them identical extents.

I ran a manual test against this PR where I took random (2D gaussian) points around Portland and split them into two halves, east and west, overlapping somewhat in the middle. These files were added to the analysis-e2e Fixtures directory alongside others used in manual tests. I ran three regional analyses: one with both east and west pointsets selected, one with only east, and one with only west. The analysis with both pointsets selected will require each pointset to undergo a different transformation to match the minimum bounding extents of the two taken together. The single pointset runs will not undergo any transformation, as the minimum bounding extents are equal to the extents of the single destination pointset.

Results from each of the single-pointset regional runs appear to exactly match those from the two-pointset run, corroborating the passing unit test on GridTransformWrapper. So this should complete the solution to issue #676.
