### PR TITLE
Preserve stop order in hops

### DIFF
--- a/src/main/java/com/conveyal/analysis/models/AdjustDwellTime.java
+++ b/src/main/java/com/conveyal/analysis/models/AdjustDwellTime.java
@@ -28,12 +28,12 @@ public class AdjustDwellTime extends Modification {
         adt.comment = name;
 
         if (trips == null) {
-            adt.routes = feedScopeIds(feed, routes);
+            adt.routes = feedScopedIdSet(feed, routes);
         } else {
-            adt.patterns = feedScopeIds(feed, trips);
+            adt.patterns = feedScopedIdSet(feed, trips);
         }
 
-        adt.stops = feedScopeIds(feed, stops);
+        adt.stops = feedScopedIdSet(feed, stops);
 
         if (scale) {
             adt.scale = value;

--- a/src/main/java/com/conveyal/analysis/models/AdjustSpeed.java
+++ b/src/main/java/com/conveyal/analysis/models/AdjustSpeed.java
@@ -1,5 +1,6 @@
 package com.conveyal.analysis.models;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
@@ -28,21 +29,17 @@ public class AdjustSpeed extends Modification {
         as.comment = name;
 
         if (trips == null) {
-            as.routes = feedScopeIds(feed, routes);
+            as.routes = feedScopedIdSet(feed, routes);
         } else {
-            as.patterns = feedScopeIds(feed, trips);
+            as.patterns = feedScopedIdSet(feed, trips);
         }
 
         if (hops != null) {
-            as.hops = Arrays.stream(hops)
-                    .map(h -> feedScopeIds(feed, h))
-                    .map(s -> {
-                        Object[] oa = s.toArray();
-                        return Arrays.copyOf(oa, oa.length, String[].class);
-                    })
-                    .collect(Collectors.toList());
+            as.hops = new ArrayList<>(hops.length);
+            for (String[] hopStops : hops) {
+                as.hops.add(feedScopedIdArray(feed, hopStops));
+            }
         }
-
         as.scale = scale;
 
         return as;

--- a/src/main/java/com/conveyal/analysis/models/Modification.java
+++ b/src/main/java/com/conveyal/analysis/models/Modification.java
@@ -2,6 +2,7 @@ package com.conveyal.analysis.models;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.google.common.collect.Sets;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -59,11 +60,7 @@ public abstract class Modification extends Model implements Cloneable {
         if (ids == null) {
             return null;
         } else {
-            Set<String> feedScopedIdSet = new HashSet<>(ids.length);
-            for (String id : ids) {
-                feedScopedIdSet.add(feedScopeId(feed, id));
-            }
-            return feedScopedIdSet;
+            return Sets.newHashSet(feedScopedIdArray(feed, ids));
         }
     }
 

--- a/src/main/java/com/conveyal/analysis/models/RemoveStops.java
+++ b/src/main/java/com/conveyal/analysis/models/RemoveStops.java
@@ -21,12 +21,12 @@ public class RemoveStops extends Modification {
     public com.conveyal.r5.analyst.scenario.RemoveStops toR5 () {
         com.conveyal.r5.analyst.scenario.RemoveStops rs = new com.conveyal.r5.analyst.scenario.RemoveStops();
         rs.comment = name;
-        rs.stops = feedScopeIds(feed, stops);
+        rs.stops = feedScopedIdSet(feed, stops);
 
         if (trips == null) {
-            rs.routes = feedScopeIds(feed, routes);
+            rs.routes = feedScopedIdSet(feed, routes);
         } else {
-            rs.patterns = feedScopeIds(feed, trips);
+            rs.patterns = feedScopedIdSet(feed, trips);
         }
 
         rs.secondsSavedAtEachStop = secondsSavedAtEachStop;

--- a/src/main/java/com/conveyal/analysis/models/RemoveTrips.java
+++ b/src/main/java/com/conveyal/analysis/models/RemoveTrips.java
@@ -21,9 +21,9 @@ public class RemoveTrips extends Modification {
         rt.comment = name;
 
         if (trips == null) {
-            rt.routes = feedScopeIds(feed, routes);
+            rt.routes = feedScopedIdSet(feed, routes);
         } else {
-            rt.patterns = feedScopeIds(feed, trips);
+            rt.patterns = feedScopedIdSet(feed, trips);
         }
 
         return rt;

--- a/src/main/java/com/conveyal/analysis/models/Reroute.java
+++ b/src/main/java/com/conveyal/analysis/models/Reroute.java
@@ -39,9 +39,9 @@ public class Reroute extends Modification {
         rr.stops = ModificationStop.toStopSpecs(stops);
 
         if (this.trips == null) {
-            rr.routes = feedScopeIds(feed, routes);
+            rr.routes = feedScopedIdSet(feed, routes);
         } else {
-            rr.patterns = feedScopeIds(feed, trips);
+            rr.patterns = feedScopedIdSet(feed, trips);
         }
 
         if (fromStop != null) {


### PR DESCRIPTION
This should fix  #687.

Currently marked as draft PR, a few tasks remain: 

- [x] add warnings during scenario application based on number of patterns affected by each hop
- [x] test on some newly created modifications to make sure the conversions still happen smoothly

@ansoncfit indicated that the failing case described in #687 is nondeterministic (as expected) and hard to reproduce on production. So we will keep an eye on the new warning output from adjust speed modifications during our next round of manual testing.