### PR TITLE
Record correct waiting time in path results

### DIFF
--- a/src/main/java/com/conveyal/r5/profile/RaptorState.java
+++ b/src/main/java/com/conveyal/r5/profile/RaptorState.java
@@ -164,7 +164,7 @@ public class RaptorState {
         this.nonTransferWaitTime = Arrays.copyOf(state.nonTransferWaitTime, state.nonTransferWaitTime.length);
         this.nonTransferInVehicleTravelTime =
                 Arrays.copyOf(state.nonTransferInVehicleTravelTime, state.nonTransferInVehicleTravelTime.length);
-        this.previousWaitTime = Arrays.copyOf(state.previousInVehicleTravelTime, state.previousInVehicleTravelTime.length);
+        this.previousWaitTime = Arrays.copyOf(state.previousWaitTime, state.previousWaitTime.length);
         this.previousInVehicleTravelTime = Arrays.copyOf(state.previousInVehicleTravelTime,
                 state.previousInVehicleTravelTime.length);
         this.departureTime = state.departureTime;


### PR DESCRIPTION
In-vehicle times were being copied over to waiting times, probably due to a copy/paste error