### PR TITLE
Change initialization order for Taui site tasks

### DIFF
--- a/src/main/java/com/conveyal/analysis/controllers/RegionalAnalysisController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/RegionalAnalysisController.java
@@ -439,15 +439,6 @@ public class RegionalAnalysisController implements HttpController {
             task.originPointSet = PointSetCache.readFreeFormFromFileStore(task.originPointSetKey);
         }
 
-        // If our destinations are freeform, pre-load the destination pointset on the backend.
-        // This allows MultiOriginAssembler to know the number of points, and in one-to-one mode to look up their IDs.
-        if (!task.makeTauiSite && task.destinationPointSetKeys[0].endsWith(FileStorageFormat.FREEFORM.extension)) {
-            checkArgument(task.destinationPointSetKeys.length == 1);
-            task.destinationPointSets = new PointSet[] {
-                    PointSetCache.readFreeFormFromFileStore(task.destinationPointSetKeys[0])
-            };
-        }
-
         task.oneToOne = analysisRequest.oneToOne;
         task.recordTimes = analysisRequest.recordTimes;
         // For now, we support calculating paths in regional analyses only for freeform origins.
@@ -458,6 +449,17 @@ public class RegionalAnalysisController implements HttpController {
         if (analysisRequest.makeTauiSite) {
             task.makeTauiSite = true;
             task.recordAccessibility = false;
+        }
+
+        // If our destinations are freeform, pre-load the destination pointset on the backend.
+        // This allows MultiOriginAssembler to know the number of points, and in one-to-one mode to look up their IDs.
+        // Initialization order is important here: task fields makeTauiSite and destinationPointSetKeys must already be
+        // set above.
+        if (!task.makeTauiSite && task.destinationPointSetKeys[0].endsWith(FileStorageFormat.FREEFORM.extension)) {
+            checkArgument(task.destinationPointSetKeys.length == 1);
+            task.destinationPointSets = new PointSet[] {
+                    PointSetCache.readFreeFormFromFileStore(task.destinationPointSetKeys[0])
+            };
         }
 
         // TODO remove duplicate fields from RegionalAnalysis that are already in the nested task.

--- a/src/main/java/com/conveyal/analysis/results/AccessCsvResultWriter.java
+++ b/src/main/java/com/conveyal/analysis/results/AccessCsvResultWriter.java
@@ -49,6 +49,7 @@ public class AccessCsvResultWriter extends CsvResultWriter {
             for (int p = 0; p < task.percentiles.length; p++) {
                 int[] cutoffsForPercentile = percentilesForDestPointset[p];
                 for (int c = 0; c < task.cutoffsMinutes.length; c++) {
+                    // Ideally we'd output the pointset IDs (rather than keys) which we have in the RegionalAnalysis
                     rows.add(new String[] {
                             originId,
                             task.destinationPointSetKeys[d],


### PR DESCRIPTION
This fixes a null pointer reported by @ansoncfit. We were reading a field on the task before it was copied from the incoming analysisRequest.