### PR TITLE
Make CORS headers configurable

### DIFF
--- a/analysis.properties.template
+++ b/analysis.properties.template
@@ -38,7 +38,6 @@ server-port=7070
 # since authentication is not handled through cookies, it does increase the attack surface and better practice is to set
 # this to the actual origin where the UI is hosted. This is different from frontend-url, since frontend-url is just where
 # the frontend code can be retrieved from, and may not even be a valid origin (e.g. if it has a path name).
-# Commenting this property out will result in no Access-Control-Allow-Origin header being sent.
 access-control-allow-origin=http://localhost:3000
 
 # A temporary location to store scratch files. The path can be absolute or relative.

--- a/analysis.properties.template
+++ b/analysis.properties.template
@@ -31,6 +31,16 @@ aws-region=eu-west-1
 # The port on which the server will listen for connections from clients and workers.
 server-port=7070
 
+# The origin where the frontend is hosted. Due to the same-origin policy, cross-origin requests are generally blocked.
+# However, setting this to an origin will add an Access-Control-Allow-Origin header to allow cross-origin requests from
+# that origin. For instance, when running locally, this will generally be http://localhost:3000. It is possible to set
+# this to *, but that allows requests from anywhere. While this should be relatively safe when authentication is enabled
+# since authentication is not handled through cookies, it does increase the attack surface and better practice is to set
+# this to the actual origin where the UI is hosted. This is different from frontend-url, since frontend-url is just where
+# the frontend code can be retrieved from, and may not even be a valid origin (e.g. if it has a path name).
+# Commenting this property out will result in no Access-Control-Allow-Origin header being sent.
+access-control-allow-origin=http://localhost:3000
+
 # A temporary location to store scratch files. The path can be absolute or relative.
 # This allows you to locate temporary storage on an extra drive in case your main drive does not have enough space.
 # local-cache=/home/ec2-user/cache

--- a/src/main/java/com/conveyal/analysis/BackendConfig.java
+++ b/src/main/java/com/conveyal/analysis/BackendConfig.java
@@ -110,7 +110,7 @@ public class BackendConfig implements
         localCacheDirectory = getProperty("local-cache", true);
         serverPort = Integer.parseInt(getProperty("server-port", true));
         offline = Boolean.parseBoolean(getProperty("offline", true));
-        accessControlAllowOrigin = getProperty("access-control-allow-origin", false);
+        accessControlAllowOrigin = getProperty("access-control-allow-origin", true);
         seamlessCensusBucket = getProperty("seamless-census-bucket", true);
         seamlessCensusRegion = getProperty("seamless-census-region", true);
         gridBucket = getProperty("grid-bucket", true);

--- a/src/main/java/com/conveyal/analysis/BackendConfig.java
+++ b/src/main/java/com/conveyal/analysis/BackendConfig.java
@@ -55,6 +55,7 @@ public class BackendConfig implements
     private final String localCacheDirectory;
     private final int serverPort;
     private final boolean offline;
+    private final String accessControlAllowOrigin;
     private final String seamlessCensusBucket;
     private final String seamlessCensusRegion;
     private final String gridBucket;
@@ -109,6 +110,7 @@ public class BackendConfig implements
         localCacheDirectory = getProperty("local-cache", true);
         serverPort = Integer.parseInt(getProperty("server-port", true));
         offline = Boolean.parseBoolean(getProperty("offline", true));
+        accessControlAllowOrigin = getProperty("access-control-allow-origin", false);
         seamlessCensusBucket = getProperty("seamless-census-bucket", true);
         seamlessCensusRegion = getProperty("seamless-census-region", true);
         gridBucket = getProperty("grid-bucket", true);
@@ -171,6 +173,7 @@ public class BackendConfig implements
     @Override public String localCacheDirectory () { return localCacheDirectory;}
     @Override public String bundleBucket () { return bundleBucket; }
     @Override public boolean offline () { return offline; }
+    @Override public String accessControlAllowOrigin () { return accessControlAllowOrigin; }
     @Override public int maxWorkers () { return maxWorkers; }
 
 }

--- a/src/main/java/com/conveyal/analysis/components/HttpApi.java
+++ b/src/main/java/com/conveyal/analysis/components/HttpApi.java
@@ -91,11 +91,9 @@ public class HttpApi implements Component {
             // Set CORS headers, to allow requests to this API server from a frontend hosted on a different domain
             // This used to be hardwired to Access-Control-Allow-Origin: * but that leaves the server open to XSRF
             // attacks when authentication is disabled (e.g. when running locally).
-            if (config.accessControlAllowOrigin() != null) {
-                res.header("Access-Control-Allow-Origin", config.accessControlAllowOrigin());
-                // for caching, signal to the browser that responses may be different based on origin
-                res.header("Vary", "Origin");
-            }
+            res.header("Access-Control-Allow-Origin", config.accessControlAllowOrigin());
+            // for caching, signal to the browser that responses may be different based on origin
+            res.header("Vary", "Origin");
 
             // The default MIME type is JSON. This will be overridden by the few controllers that do not return JSON.
             res.type("application/json");
@@ -128,16 +126,14 @@ public class HttpApi implements Component {
 
         // Handle CORS preflight requests (which are OPTIONS requests).
         // See comment above about Access-Control-Allow-Origin
-        if (config.accessControlAllowOrigin() != null) {
-            sparkService.options("/*", (req, res) -> {
-                res.header("Access-Control-Allow-Methods", "GET,PUT,POST,DELETE,OPTIONS");
-                res.header("Access-Control-Allow-Credentials", "true");
-                res.header("Access-Control-Allow-Headers", "Accept,Authorization,Content-Type,Origin," +
-                        "X-Requested-With,Content-Length,X-Conveyal-Access-Group"
-                );
-                return "OK";
-            });
-        }
+        sparkService.options("/*", (req, res) -> {
+            res.header("Access-Control-Allow-Methods", "GET,PUT,POST,DELETE,OPTIONS");
+            res.header("Access-Control-Allow-Credentials", "true");
+            res.header("Access-Control-Allow-Headers", "Accept,Authorization,Content-Type,Origin," +
+                    "X-Requested-With,Content-Length,X-Conveyal-Access-Group"
+            );
+            return "OK";
+        });
 
         // Allow client to fetch information about the backend build version.
         sparkService.get(

--- a/src/main/java/com/conveyal/analysis/components/HttpApi.java
+++ b/src/main/java/com/conveyal/analysis/components/HttpApi.java
@@ -91,6 +91,12 @@ public class HttpApi implements Component {
             // Set CORS headers, to allow requests to this API server from a frontend hosted on a different domain
             // This used to be hardwired to Access-Control-Allow-Origin: * but that leaves the server open to XSRF
             // attacks when authentication is disabled (e.g. when running locally).
+            if (config.accessControlAllowOrigin() == null || config.accessControlAllowOrigin().equals("null")) {
+                // Access-Control-Allow-Origin: null opens unintended security holes:
+                // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
+                throw new IllegalArgumentException("Access-Control-Allow-Origin should not be null");
+            }
+
             res.header("Access-Control-Allow-Origin", config.accessControlAllowOrigin());
             // for caching, signal to the browser that responses may be different based on origin
             res.header("Vary", "Origin");

--- a/src/main/java/com/conveyal/analysis/components/HttpApi.java
+++ b/src/main/java/com/conveyal/analysis/components/HttpApi.java
@@ -43,6 +43,7 @@ public class HttpApi implements Component {
     public interface Config {
         boolean offline ();
         int serverPort ();
+        String accessControlAllowOrigin ();
     }
 
     private final FileStorage fileStorage;
@@ -87,8 +88,14 @@ public class HttpApi implements Component {
             // FIXME those internal endpoints should be hidden from the outside world by the reverse proxy.
             //       Or now with non-static Spark we can run two HTTP servers on different ports.
 
-            // Set CORS headers, to allow requests to this API server from any page.
-            res.header("Access-Control-Allow-Origin", "*");
+            // Set CORS headers, to allow requests to this API server from a frontend hosted on a different domain
+            // This used to be hardwired to Access-Control-Allow-Origin: * but that leaves the server open to XSRF
+            // attacks when authentication is disabled (e.g. when running locally).
+            if (config.accessControlAllowOrigin() != null) {
+                res.header("Access-Control-Allow-Origin", config.accessControlAllowOrigin());
+                // for caching, signal to the browser that responses may be different based on origin
+                res.header("Vary", "Origin");
+            }
 
             // The default MIME type is JSON. This will be overridden by the few controllers that do not return JSON.
             res.type("application/json");
@@ -120,14 +127,17 @@ public class HttpApi implements Component {
         });
 
         // Handle CORS preflight requests (which are OPTIONS requests).
-        sparkService.options("/*", (req, res) -> {
-            res.header("Access-Control-Allow-Methods", "GET,PUT,POST,DELETE,OPTIONS");
-            res.header("Access-Control-Allow-Credentials", "true");
-            res.header("Access-Control-Allow-Headers", "Accept,Authorization,Content-Type,Origin," +
-                    "X-Requested-With,Content-Length,X-Conveyal-Access-Group"
-            );
-            return "OK";
-        });
+        // See comment above about Access-Control-Allow-Origin
+        if (config.accessControlAllowOrigin() != null) {
+            sparkService.options("/*", (req, res) -> {
+                res.header("Access-Control-Allow-Methods", "GET,PUT,POST,DELETE,OPTIONS");
+                res.header("Access-Control-Allow-Credentials", "true");
+                res.header("Access-Control-Allow-Headers", "Accept,Authorization,Content-Type,Origin," +
+                        "X-Requested-With,Content-Length,X-Conveyal-Access-Group"
+                );
+                return "OK";
+            });
+        }
 
         // Allow client to fetch information about the backend build version.
         sparkService.get(

--- a/src/main/java/com/conveyal/r5/point_to_point/PointToPointRouterServer.java
+++ b/src/main/java/com/conveyal/r5/point_to_point/PointToPointRouterServer.java
@@ -154,26 +154,6 @@ public class PointToPointRouterServer {
         PointToPointQuery pointToPointQuery = new PointToPointQuery(transportNetwork);
         ParetoServer paretoServer = new ParetoServer(transportNetwork);
 
-        // add cors header
-        before((req, res) -> res.header("Access-Control-Allow-Origin", "*"));
-
-        options("/*", (request, response) -> {
-
-            String accessControlRequestHeaders = request
-                .headers("Access-Control-Request-Headers");
-            if (accessControlRequestHeaders != null) {
-                response.header("Access-Control-Allow-Headers", accessControlRequestHeaders);
-            }
-
-            String accessControlRequestMethod = request
-                .headers("Access-Control-Request-Method");
-            if (accessControlRequestMethod != null) {
-                response.header("Access-Control-Allow-Methods", accessControlRequestMethod);
-            }
-
-            return "OK";
-        });
-
         get("/metadata", (request, response) -> {
             response.header("Content-Type", "application/json");
             RouterInfo routerInfo = new RouterInfo();


### PR DESCRIPTION
Per the discussion in #683 and #717, this makes the CORS headers sent by the backend configurable so they can be set to the specific origin where the frontend is hosted, rather than allowing CORS from any (potentially malicious) website to access the backend. The CORS headers are configured by a new `access-control-allow-origin` property in analysis.properties.

To preserve existing behavior, set `access-control-allow-origin=*`, although this isn't best practice and is a particular problem if authentication is disabled.

This supersedes #683 and conveyal/analysis-ui#1457.