### PR TITLE
Revised Activity API

### DIFF
--- a/.github/workflows/cypress-integration.yml
+++ b/.github/workflows/cypress-integration.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: conveyal/analysis-ui
-          ref: dev
+          ref: 62dfe5b8d8e76a095b8f923b6458b75d3e10c2c8
           path: ui
       - uses: actions/checkout@v2
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,8 @@ version gitVersion()
 
 jib.to.image = 'ghcr.io/conveyal/r5:' + version
 
+
+
 java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11

--- a/build.gradle
+++ b/build.gradle
@@ -174,7 +174,7 @@ dependencies {
     // Provides the EPSG coordinate reference system catalog as an HSQL database.
     implementation group: 'org.geotools', version: geotoolsVersion, name: 'gt-epsg-hsql'
 
-    compile 'com.wdtinc:mapbox-vector-tile:3.1.0'
+    implementation 'com.wdtinc:mapbox-vector-tile:3.1.0'
 
     // Legacy JTS with com.vividsolutions package name. Newer Geotools compatible with Java 11 uses a newer version of
     // JTS with the org.locationtech package name. But our MapDB format includes serialized JTS geometries with the

--- a/src/main/java/com/conveyal/analysis/components/Component.java
+++ b/src/main/java/com/conveyal/analysis/components/Component.java
@@ -8,6 +8,9 @@ package com.conveyal.analysis.components;
  * Each component should encapsulate a distinct, well-defined set of functionality. Different implementations of
  * components allow running locally or in other environments like AWS or potentially other cloud service providers.
  * Currently this is a marker interface with no methods, just to indicate the role of certain classes in the project.
+ *
+ * All Components should be threadsafe: they must not fail when concurrently used by multiple HTTP handler threads.
  */
 public interface Component {
+
 }

--- a/src/main/java/com/conveyal/analysis/components/TaskScheduler.java
+++ b/src/main/java/com/conveyal/analysis/components/TaskScheduler.java
@@ -1,22 +1,18 @@
 package com.conveyal.analysis.components;
 
 import com.conveyal.analysis.UserPermissions;
-import com.conveyal.analysis.controllers.UserActivityController;
-import com.conveyal.analysis.controllers.UserActivityController.ApiTask;
+import com.conveyal.r5.analyst.progress.ApiTask;
 import com.conveyal.r5.analyst.progress.Task;
 import com.conveyal.r5.analyst.progress.TaskAction;
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.SetMultimap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;

--- a/src/main/java/com/conveyal/analysis/components/TaskScheduler.java
+++ b/src/main/java/com/conveyal/analysis/components/TaskScheduler.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -201,6 +202,11 @@ public class TaskScheduler implements Component {
                 }
             }))
        );
+    }
+
+    /** Get the number of slower "heavy" tasks that are queued for execution and not yet being processed. */
+    public int getBacklog() {
+        return ((ThreadPoolExecutor) heavyExecutor).getQueue().size();
     }
 
 }

--- a/src/main/java/com/conveyal/analysis/components/TaskScheduler.java
+++ b/src/main/java/com/conveyal/analysis/components/TaskScheduler.java
@@ -1,6 +1,8 @@
 package com.conveyal.analysis.components;
 
 import com.conveyal.analysis.UserPermissions;
+import com.conveyal.analysis.controllers.UserActivityController;
+import com.conveyal.analysis.controllers.UserActivityController.ApiTask;
 import com.conveyal.r5.analyst.progress.Task;
 import com.conveyal.r5.analyst.progress.TaskAction;
 import com.google.common.collect.HashMultimap;
@@ -10,8 +12,11 @@ import com.google.common.collect.SetMultimap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -19,6 +24,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 /**
  * This provides application-wide queues of one-off or repeating tasks. It ensures that some tasks repeat regularly
@@ -31,13 +37,9 @@ import java.util.concurrent.TimeUnit;
  * However with the workStealingPool we have no guarantees it will create more than one queue, or on execution order.
  * The implementation with ExecutorServices also seems to allow more control over tasks causing exceptions.
  *
- * ===
- *
  * This also serves to report active tasks for a given user.
  * That could be considered a separate function, but it ended up having a bidirectional dependency on this
  * TaskScheduler so they've been merged.
- *
- * ===
  *
  * This is moving in the direction of having a single unified task management and reporting system across the backend
  * and workers. It could be interesting to gather task status from the whole cluster of workers and merge them together
@@ -46,7 +48,6 @@ import java.util.concurrent.TimeUnit;
  * workers to the UI in the same data structures.
  *
  * So we're moving toward a programming API where you submit Tasks with attached Actions.
- * TODO state that all Components should be threadsafe, i.e. should not fail if used by multiple HTTP handler threads.
  *
  * Eventually every asynchronous task should be handled by this one mechanism, to ensure every Throwable is caught and
  * cannot kill threads, as well as standardized reporting and tracking of backend and worker activity.
@@ -62,13 +63,20 @@ public class TaskScheduler implements Component {
     private final ExecutorService lightExecutor;
     private final ExecutorService heavyExecutor;
 
-    // Keep the futures returned when tasks are scheduled, which give access to status information and exceptions.
+    // Keep the futures returned when periodic tasks are scheduled, giving access to status information and exceptions.
     // This should facilitate debugging. We may want to do the same thing for one-off tasks.
-    // Note this will need to be synchronized if we ever allow canceling periodic tasks.
+    // This will need to be synchronized if we ever allow canceling periodic tasks.
     private final List<ScheduledFuture> periodicTaskFutures = new ArrayList<>();
 
-    // Keep track of tasks submitted by each user, for reporting on their progress over the HTTP API.
-    // Synchronized because multiple users may add things to this map from multiple HTTP server threads.
+    // Keep track of tasks submitted by each user, for reporting on their progress over the HTTP API. The collection is
+    // synchronized because multiple users may add to and read this map from different HTTP server threads. When
+    // reading be aware of the synchronization requirements described on Guava Multimaps.synchronizedMultimap.
+    // As a Guava SynchronizedMultimap, certain compound operations such as forEach do properly lock the entire multimap.
+    // Calls to get() return a Guava SynchronizedSet (a subtype of SynchronizedCollection) which also properly locks the
+    // entire parent multimap for the duration of compound operations such as forEach and removeIf. However it appears
+    // that stream operations must be manually synchronized. And it seems like there is a potential for another thread
+    // to alter the map between a call to get() and a subsequent synchronized call like forEach(). When in doubt it
+    // usually can't hurt to wrap a series of operations in synchronized(tasksForUser).
     private final SetMultimap<String, Task> tasksForUser = Multimaps.synchronizedSetMultimap(HashMultimap.create());
 
     public interface Config {
@@ -76,11 +84,15 @@ public class TaskScheduler implements Component {
         int heavyThreads ();
     }
 
-    /** Interface for all actions that we want to repeat at regular intervals. */
-    // TODO this could be merged with all other tasks - getPeriodSeconds returns -1 for non-periodic.
-    //      However there are advantages to single method interfaces.
-    //      Heavy/light/periodic should be indicated on the Task rather than the TaskAction passed in.
-    //      ProgressListener needs methods to markComplete() and reportError(Throwable)
+    /**
+     * Interface for all actions that we want to repeat at regular intervals.
+     * This could be merged with all other task actions, using a getPeriodSeconds method returning -1 for non-periodic.
+     * However this would yield interfaces with more than one method, and single-method interfaces provide for some
+     * syntactic flexibility (lambdas and method references).
+     * TODO use PeriodicTasks to handle worker record scavenging and cluster stats reporting.
+     * TODO Heavy/light/periodic should be indicated on the Task rather than the TaskAction passed in.
+     * TODO ProgressListener might benefit from methods to markComplete() and reportError(Throwable)
+     */
     public interface PeriodicTask extends Runnable {
         int getPeriodSeconds();
     }
@@ -91,9 +103,6 @@ public class TaskScheduler implements Component {
         heavyExecutor = Executors.newFixedThreadPool(config.heavyThreads());
     }
 
-    /** TODO handle worker record scavenging and cluster stats reporting with this. */
-    // Require an interface extending runnable to pass something to the TaskScheduler constructor?
-    // Perhaps start periodic tasks automatically on TaskScheduler construction.
     public void repeatRegularly (PeriodicTask periodicTask) {
         String className = periodicTask.getClass().getSimpleName();
         int periodSeconds = periodicTask.getPeriodSeconds();
@@ -104,13 +113,8 @@ public class TaskScheduler implements Component {
         );
     }
 
-    public void repeatRegularly (PeriodicTask... periodicTasks) {
-        for (PeriodicTask periodicTask : periodicTasks) {
-            repeatRegularly(periodicTask);
-        }
-    }
-
-    // TODO these can be eliminated in favor of the single enqueue(Task) method that gets heavy/light/periodic from the Task.
+    // TODO these methods can be eliminated in favor of the single enqueue method that gets information about
+    //      heavy/light/periodic from its Task parameter.
 
     public void enqueueLightTask (Runnable runnable) {
         lightExecutor.submit(new ErrorTrap(runnable));
@@ -143,17 +147,44 @@ public class TaskScheduler implements Component {
         }
     }
 
-    ////// Methods for reporting active tasks for each user
-
-    /** Return an empty list even when no tasks have been recorded for the user (return is always non-null). */
-    public List<Task> getTasksForUser (String userEmail) {
-        Set<Task> tasks = tasksForUser.get(userEmail);
-        return tasks == null ? Collections.emptyList() : List.copyOf(tasks);
+    /**
+     * Return the status of all background tasks for the given user, as API model objects for serialization to JSON.
+     * Completed tasks that finished over a minute ago will be purged after returning them. This ensures they're sent
+     * at least once to the UI and gives any other tabs a chance to poll for them.
+     * Conversion to the API model is done here to allow synchronization without copying the list of internal tasks.
+     * The task scheduler collections are being updated by worker threads. The fields of the individual Tasks may also
+     * be updated at any time. So there is a risk of sending a partially updated Task out to the UI. If this ever causes
+     * problems we'll need to lock each Task independently.
+     * Returns an empty list even when no tasks have been recorded for the user (return is always non-null).
+     */
+    public @Nonnull List<ApiTask> getTasksForUser (String userEmail) {
+        synchronized (tasksForUser) {
+            Set<Task> tasks = tasksForUser.get(userEmail);
+            if (tasks == null) return Collections.emptyList();
+            List<ApiTask> apiTaskList = tasks.stream()
+                    .map(TaskScheduler::toApiTask)
+                    .collect(Collectors.toUnmodifiableList());
+            tasks.removeIf(t -> t.durationComplete().getSeconds() > 60);
+            return apiTaskList;
+        }
     }
 
-    // This raises the question of whether calling code should ever create its own Tasks, or if those are always
-    // created here inside the TaskScheduler from other raw information. The caller creating a Task seems like a good
-    // way to configure execution details like heavy/light/periodic, and submit user information without passing it in.
+    /** Convert a single internal Task object to its representation for JSON serialization and return to the UI. */
+    private static ApiTask toApiTask (Task task) {
+        ApiTask apiTask = new ApiTask();
+        apiTask.id = task.id; // This can be the same as the workProduct ID except for cases with no Mongo document
+        apiTask.title = task.description;
+        apiTask.detail = task.description;
+        apiTask.state = task.state;
+        apiTask.percentComplete = (int)(task.getPercentComplete());
+        apiTask.workProduct = null;
+        return apiTask;
+    }
+
+    // Q: Should the caller ever create its own Tasks, or if are tasks created here inside the TaskScheduler from
+    // other raw information? Having the caller creating a Task seems like a good way to configure execution details
+    // like heavy/light/periodic, and submit user information without passing it in. That task request could be separate
+    // from the internal Task object it creates, but that seems like overkill for an internal mechanism.
     public void newTaskForUser (UserPermissions user, TaskAction taskAction) {
         Task task = Task.forUser(user).withAction(taskAction);
         enqueue(task);
@@ -170,9 +201,7 @@ public class TaskScheduler implements Component {
         }
     }
 
-    /**
-     * Just demonstrating how this would be used.
-     */
+    /** Just demonstrating how this can be used. */
     public void example () {
         this.enqueue(Task.forUser(new UserPermissions("abyrd@conveyal.com", true, "conveyal"))
             .withDescription("Process some complicated things")

--- a/src/main/java/com/conveyal/analysis/controllers/BundleController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/BundleController.java
@@ -4,12 +4,11 @@ import com.conveyal.analysis.AnalysisServerException;
 import com.conveyal.analysis.UserPermissions;
 import com.conveyal.analysis.components.Components;
 import com.conveyal.analysis.components.TaskScheduler;
-import com.conveyal.analysis.controllers.UserActivityController.WorkProduct;
 import com.conveyal.analysis.models.Bundle;
 import com.conveyal.analysis.persistence.Persistence;
 import com.conveyal.analysis.util.HttpUtils;
 import com.conveyal.analysis.util.JsonUtil;
-import com.conveyal.analysis.util.ProgressInputStream;
+import com.conveyal.r5.analyst.progress.ProgressInputStream;
 import com.conveyal.file.FileStorage;
 import com.conveyal.file.FileStorageKey;
 import com.conveyal.file.FileUtils;
@@ -21,7 +20,6 @@ import com.conveyal.r5.analyst.cluster.BundleManifest;
 import com.conveyal.r5.analyst.progress.Task;
 import com.conveyal.r5.streets.OSMCache;
 import com.conveyal.r5.util.ExceptionUtils;
-import com.google.common.io.CountingInputStream;
 import com.mongodb.QueryBuilder;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.disk.DiskFileItem;
@@ -33,10 +31,8 @@ import spark.Request;
 import spark.Response;
 import spark.Service;
 
-import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -46,7 +42,7 @@ import java.util.stream.Collectors;
 import java.util.zip.ZipFile;
 
 import static com.conveyal.analysis.components.HttpApi.USER_PERMISSIONS_ATTRIBUTE;
-import static com.conveyal.analysis.controllers.UserActivityController.WorkProductType.BUNDLE;
+import static com.conveyal.r5.analyst.progress.WorkProductType.BUNDLE;
 import static com.conveyal.analysis.util.JsonUtil.toJson;
 
 /**
@@ -174,9 +170,7 @@ public class BundleController implements HttpController {
 
                 if (bundle.feedGroupId == null) {
                     // Process uploaded GTFS files
-                    bundle.status = Bundle.Status.PROCESSING_GTFS;
                     bundle.feedGroupId = new ObjectId().toString();
-                    Persistence.bundles.modifiyWithoutUpdatingLock(bundle);
 
                     Envelope bundleBounds = new Envelope();
                     bundle.serviceStart = LocalDate.MAX;

--- a/src/main/java/com/conveyal/analysis/controllers/UserActivityController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/UserActivityController.java
@@ -2,12 +2,8 @@ package com.conveyal.analysis.controllers;
 
 import com.conveyal.analysis.UserPermissions;
 import com.conveyal.analysis.components.TaskScheduler;
-import com.conveyal.analysis.models.BaseModel;
-import com.conveyal.analysis.models.Bundle;
-import com.conveyal.analysis.models.Model;
-import com.conveyal.analysis.models.OpportunityDataset;
-import com.conveyal.analysis.models.RegionalAnalysis;
 import com.conveyal.r5.analyst.progress.Task;
+import com.conveyal.r5.analyst.progress.WorkProduct;
 import spark.Request;
 import spark.Response;
 import spark.Service;
@@ -71,46 +67,9 @@ public class UserActivityController implements HttpController {
         public String detail;
         public Task.State state;
         public int percentComplete;
-        public Long timeBegan;
-        public Long timeCompleted;
+        public int secondsActive;
+        public int secondsComplete;
         public WorkProduct workProduct;
-    }
-
-    /** API model providing a unique identifier for the final product of a single task in an activity response. */
-    // ID is unique within type so region is redundant information, but facilitates prefectch on API.
-
-    public static class WorkProduct {
-        public WorkProductType type;
-        public String id;
-        public String region;
-
-        public WorkProduct (WorkProductType type, String id, String region) {
-            this.type = type;
-            this.id = id;
-            this.region = region;
-        }
-
-        public static WorkProduct forModel (Model model) {
-            // FIXME Not all Models have a regionId. Rather than pass that in as a String, refine the programming API.
-            WorkProduct product = new WorkProduct(WorkProductType.forModel(model), model._id, null);
-            return product;
-        }
-    }
-
-    /**
-     * There is some implicit and unenforced correspondence between these values and those in FileCategory, as well
-     * as the tables in Mongo. We should probably clearly state and enforce this parallelism. No background work is
-     * done creating regions, projects, or modifications so they don't need to be represented here.
-     */
-    public static enum WorkProductType {
-        BUNDLE, REGIONAL_ANALYSIS, AGGREGATION_AREA, OPPORTUNITY_DATASET;
-        // Currently we have two base classes for db objects so may need to use Object instead of BaseModel parameter
-        public static WorkProductType forModel (Model model) {
-            if (model instanceof Bundle) return BUNDLE;
-            if (model instanceof OpportunityDataset) return OPPORTUNITY_DATASET;
-            if (model instanceof RegionalAnalysis) return REGIONAL_ANALYSIS;
-            throw new IllegalArgumentException("Unrecognized work product type.");
-        }
     }
 
 }

--- a/src/main/java/com/conveyal/analysis/controllers/UserActivityController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/UserActivityController.java
@@ -46,6 +46,8 @@ public class UserActivityController implements HttpController {
     private ResponseModel getActivity (Request req, Response res) {
         UserPermissions userPermissions = req.attribute(USER_PERMISSIONS_ATTRIBUTE);
         ResponseModel responseModel = new ResponseModel();
+        responseModel.systemStatusMessages = List.of();
+        responseModel.taskBacklog = taskScheduler.getBacklog();
         responseModel.taskProgress = taskScheduler.getTasksForUser(userPermissions.email);
         return responseModel;
     }
@@ -53,14 +55,14 @@ public class UserActivityController implements HttpController {
     /** API model used only to structure activity JSON messages sent back to UI. */
     public static class ResponseModel {
         /** For example: "Server going down at 17:00 GMT for maintenance" or "Working to resolve known issue [link]." */
-        public List<String> systemStatusMessages = new ArrayList<>();
+        public List<String> systemStatusMessages;
         /** Number of tasks in the queue until this user's start processing. Just a rough indicator of progress. */
         public int taskBacklog;
         /** List of tasks with percentage complete, current stage of progress, and any failures or error messages. */
         public List<ApiTask> taskProgress;
     }
 
-    /** API model for tasks in an activity response. Times are in epoch milliseconds and may be null until relevant. */
+    /** API model for tasks in an activity response. Times are durations rather than absolute to counter clock drift. */
     public static class ApiTask {
         public UUID id;
         public String title;

--- a/src/main/java/com/conveyal/analysis/controllers/UserActivityController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/UserActivityController.java
@@ -2,15 +2,12 @@ package com.conveyal.analysis.controllers;
 
 import com.conveyal.analysis.UserPermissions;
 import com.conveyal.analysis.components.TaskScheduler;
-import com.conveyal.r5.analyst.progress.Task;
-import com.conveyal.r5.analyst.progress.WorkProduct;
+import com.conveyal.r5.analyst.progress.ApiTask;
 import spark.Request;
 import spark.Response;
 import spark.Service;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 import static com.conveyal.analysis.components.HttpApi.USER_PERMISSIONS_ATTRIBUTE;
 import static com.conveyal.analysis.util.JsonUtil.toJson;
@@ -60,18 +57,6 @@ public class UserActivityController implements HttpController {
         public int taskBacklog;
         /** List of tasks with percentage complete, current stage of progress, and any failures or error messages. */
         public List<ApiTask> taskProgress;
-    }
-
-    /** API model for tasks in an activity response. Times are durations rather than absolute to counter clock drift. */
-    public static class ApiTask {
-        public UUID id;
-        public String title;
-        public String detail;
-        public Task.State state;
-        public int percentComplete;
-        public int secondsActive;
-        public int secondsComplete;
-        public WorkProduct workProduct;
     }
 
 }

--- a/src/main/java/com/conveyal/analysis/controllers/UserActivityController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/UserActivityController.java
@@ -9,6 +9,7 @@ import spark.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import static com.conveyal.analysis.components.HttpApi.USER_PERMISSIONS_ATTRIBUTE;
 import static com.conveyal.analysis.util.JsonUtil.toJson;
@@ -48,14 +49,39 @@ public class UserActivityController implements HttpController {
         return responseModel;
     }
 
-    /** Only used to structure JSON messages sent back to UI. */
+    /** API model used only to structure activity JSON messages sent back to UI. */
     public static class ResponseModel {
         /** For example: "Server going down at 17:00 GMT for maintenance" or "Working to resolve known issue [link]." */
         public List<String> systemStatusMessages = new ArrayList<>();
         /** Number of tasks in the queue until this user's start processing. Just a rough indicator of progress. */
         public int taskBacklog;
-        /** Nested list of tasks with percentage complete and any failures or error messages. */
-        public List<Task> taskProgress;
+        /** List of tasks with percentage complete, current stage of progress, and any failures or error messages. */
+        public List<ApiTask> taskProgress;
+    }
+
+    /** API model for tasks in an activity response. */
+    public static class ApiTask {
+        public UUID id;
+        public String title;
+        public String detail;
+        public Task.State state;
+        public int percentComplete;
+        public WorkProduct workProduct;
+    }
+
+    /** API model providing a unique identifier for the final product of a single task in an activity response. */
+    public static class WorkProduct {
+        public WorkProductType type;
+        public String id;
+    }
+
+    /**
+     * There is some implicit and unenforced correspondence between these values and those in FileCategory, as well
+     * as the tables in Mongo. We should probably clearly state and enforce this parallelism. No background work is
+     * done creating regions, projects, or modifications so they don't need to be represented here.
+     */
+    public static enum WorkProductType {
+        BUNDLE, REGIONAL_ANALYSIS, AGGREGATION_AREA, OPPORTUNITY_DATASET
     }
 
 }

--- a/src/main/java/com/conveyal/analysis/models/Bundle.java
+++ b/src/main/java/com/conveyal/analysis/models/Bundle.java
@@ -104,6 +104,7 @@ public class Bundle extends Model implements Cloneable {
         }
     }
 
+    // The first two PROCESSING_* values are essentially deprecated in favor of Task. Consider eliminating this field.
     public enum Status {
         PROCESSING_OSM,
         PROCESSING_GTFS,

--- a/src/main/java/com/conveyal/analysis/util/ProgressInputStream.java
+++ b/src/main/java/com/conveyal/analysis/util/ProgressInputStream.java
@@ -1,0 +1,57 @@
+package com.conveyal.analysis.util;
+
+import com.conveyal.r5.analyst.progress.ProgressListener;
+import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.io.input.ProxyInputStream;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.commons.io.IOUtils.EOF;
+
+/**
+ * This will report the total number of bytes that have passed through the stream, which can exceed 100% of the file
+ * size if the caller uses mark and reset. Based on CountingInputStream. The progressListener should be pre-configured
+ * with the total number of bytes expected and a detail message using ProgressListener::beginTask.
+ */
+public class ProgressInputStream extends ProxyInputStream {
+
+    private final ProgressListener progressListener;
+
+    public ProgressInputStream (ProgressListener progressListener, InputStream proxy) {
+        super(proxy);
+        this.progressListener = progressListener;
+    }
+
+    @Override
+    protected synchronized void afterRead (final int n) {
+        if (n != EOF) {
+            progressListener.increment(n);
+        }
+    }
+
+    @Override
+    public synchronized long skip (final long length) throws IOException {
+        final long skippedBytes = super.skip(length);
+        progressListener.increment((int) skippedBytes);
+        return skippedBytes;
+    }
+
+    /**
+     * Given an uploaded file, report progress on reading it.
+     * Incrementing the progress seems to introduce some inefficiency when performing unbuffered small reads, such as
+     * calls to InputStream.read() which are used by DataInputStream to read numbers.
+     * TODO wrap in buffered input stream to reduce small read calls? Or make tune progress reporting?
+     */
+    public static ProgressInputStream forFileItem (FileItem fileItem, ProgressListener progressListener) {
+        try {
+            checkArgument(fileItem.getSize() < Integer.MAX_VALUE);
+            progressListener.beginTask("Reading file " + fileItem.getName(), (int)(fileItem.getSize()));
+            return new ProgressInputStream(progressListener, fileItem.getInputStream());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/main/java/com/conveyal/gtfs/GTFSFeed.java
+++ b/src/main/java/com/conveyal/gtfs/GTFSFeed.java
@@ -1,6 +1,7 @@
 package com.conveyal.gtfs;
 
 import com.conveyal.gtfs.error.GTFSError;
+import com.conveyal.gtfs.error.ReferentialIntegrityError;
 import com.conveyal.gtfs.model.Agency;
 import com.conveyal.gtfs.model.Calendar;
 import com.conveyal.gtfs.model.CalendarDate;
@@ -20,6 +21,8 @@ import com.conveyal.gtfs.model.StopTime;
 import com.conveyal.gtfs.model.Transfer;
 import com.conveyal.gtfs.model.Trip;
 import com.conveyal.gtfs.validator.service.GeoUtils;
+import com.conveyal.r5.analyst.progress.NoopProgressListener;
+import com.conveyal.r5.analyst.progress.ProgressListener;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -166,6 +169,14 @@ public class GTFSFeed implements Cloneable, Closeable {
 
     /** Once a GTFSFeed has one feed loaded into it, we set this to true to block loading any additional feeds. */
     private boolean loaded = false;
+
+    /**
+     * Set this to a ProgressListener to receive updates while loading GTFS. Like OSM files we have no idea how many
+     * entities are in the GTFS before we begin, so can only report progress based on the number of bytes read.
+     * Unlike OSM, GTFS is a zip file and will usually require random access to read the tables so we report progress
+     * on each table separately. This does give nice fine-grained reporting for the larger tables like stop_times.
+     */
+    public ProgressListener progressListener = null;
 
     /**
      * The order in which we load the tables is important for two reasons.
@@ -435,7 +446,6 @@ public class GTFSFeed implements Cloneable, Closeable {
         int n = 0;
 
         Multimap<TripPatternKey, String> tripsForPattern = HashMultimap.create();
-
         for (String trip_id : trips.keySet()) {
             if (++n % 100000 == 0) {
                 LOG.info("trip {}", human(n));
@@ -499,12 +509,17 @@ public class GTFSFeed implements Cloneable, Closeable {
             namingInfo.fromStops.put(fromName, pattern);
             namingInfo.toStops.put(toName, pattern);
 
-            pattern.orderedStops.stream().map(stops::get).forEach(stop -> {
-               if (fromName.equals(stop.stop_name) || toName.equals(stop.stop_name)) return;
-
+            for (String stopId : pattern.orderedStops) {
+                Stop stop = stops.get(stopId);
+                if (stop == null) {
+                    // TODO replace with ReferentialIntegrityError during stop_time loading
+                    throw new RuntimeException(String.format("No stop exists with ID '%s'", stopId));
+                }
+                if (fromName.equals(stop.stop_name) || toName.equals(stop.stop_name)) {
+                    continue;
+                }
                 namingInfo.vias.put(stop.stop_name, pattern);
-            });
-
+            }
             namingInfo.patternsOnRoute.add(pattern);
         }
 
@@ -793,8 +808,7 @@ public class GTFSFeed implements Cloneable, Closeable {
                     .closeOnJvmShutdown()
                     .make();
         } catch (ExecutionError | IOError | Exception e) {
-            LOG.error("Could not construct db from file.", e);
-            return null;
+            throw new GtfsLibException("Could not construct db from file.", e);
         }
     }
 

--- a/src/main/java/com/conveyal/gtfs/model/Entity.java
+++ b/src/main/java/com/conveyal/gtfs/model/Entity.java
@@ -1,6 +1,7 @@
 package com.conveyal.gtfs.model;
 
 import com.beust.jcommander.internal.Sets;
+import com.conveyal.analysis.util.ProgressInputStream;
 import com.conveyal.gtfs.GTFSFeed;
 import com.conveyal.gtfs.error.DateParseError;
 import com.conveyal.gtfs.error.EmptyFieldError;
@@ -246,12 +247,12 @@ public abstract class Entity implements Serializable {
         protected abstract void loadOneRow() throws IOException;
 
         /**
-         * The main entry point into an Entity.Loader. Interprets each row of a CSV file within a zip file as a sinle
+         * The main entry point into an Entity.Loader. Interprets each row of a CSV file within a zip file as a single
          * GTFS entity, and loads them into a table.
          *
          * @param zip the zip file from which to read a table
          */
-        public void loadTable(ZipFile zip) throws IOException {
+        public void loadTable (ZipFile zip) throws IOException {
             ZipEntry entry = zip.getEntry(tableName + ".txt");
             if (entry == null) {
                 Enumeration<? extends ZipEntry> entries = zip.entries();
@@ -269,15 +270,19 @@ public abstract class Entity implements Serializable {
                 } else {
                     LOG.info("Table {} was missing but it is not required.", tableName);
                 }
-
                 if (entry == null) return;
             }
             LOG.info("Loading GTFS table {} from {}", tableName, entry);
-            InputStream zis = zip.getInputStream(entry);
+            InputStream inStream = zip.getInputStream(entry);
             // skip any byte order mark that may be present. Files must be UTF-8,
             // but the GTFS spec says that "files that include the UTF byte order mark are acceptable"
-            InputStream bis = new BOMInputStream(zis);
-            CsvReader reader = new CsvReader(bis, ',', Charset.forName("UTF8"));
+            inStream = new BOMInputStream(inStream);
+            // TODO Would this benefit from buffering,especially considering progress reporting? Try and measure speed.
+            if (feed.progressListener != null) {
+                inStream = new ProgressInputStream(feed.progressListener, inStream);
+                feed.progressListener.beginTask("Loading GTFS table " + entry.getName(), (int)(entry.getSize()));
+            }
+            CsvReader reader = new CsvReader(inStream, ',', Charset.forName("UTF8"));
             this.reader = reader;
             boolean hasHeaders = reader.readHeaders();
             if (!hasHeaders) {

--- a/src/main/java/com/conveyal/gtfs/model/Entity.java
+++ b/src/main/java/com/conveyal/gtfs/model/Entity.java
@@ -1,7 +1,7 @@
 package com.conveyal.gtfs.model;
 
 import com.beust.jcommander.internal.Sets;
-import com.conveyal.analysis.util.ProgressInputStream;
+import com.conveyal.r5.analyst.progress.ProgressInputStream;
 import com.conveyal.gtfs.GTFSFeed;
 import com.conveyal.gtfs.error.DateParseError;
 import com.conveyal.gtfs.error.EmptyFieldError;

--- a/src/main/java/com/conveyal/r5/analyst/progress/ApiTask.java
+++ b/src/main/java/com/conveyal/r5/analyst/progress/ApiTask.java
@@ -1,0 +1,15 @@
+package com.conveyal.r5.analyst.progress;
+
+import java.util.UUID;
+
+/** API model for tasks in an activity response. Times are durations rather than absolute to counter clock drift. */
+public class ApiTask {
+    public UUID id;
+    public String title;
+    public String detail;
+    public Task.State state;
+    public int percentComplete;
+    public int secondsActive;
+    public int secondsComplete;
+    public WorkProduct workProduct;
+}

--- a/src/main/java/com/conveyal/r5/analyst/progress/NetworkPreloaderProgressListener.java
+++ b/src/main/java/com/conveyal/r5/analyst/progress/NetworkPreloaderProgressListener.java
@@ -60,6 +60,12 @@ public class NetworkPreloaderProgressListener implements ProgressListener {
         }
     }
 
+    @Override
+    public synchronized void increment (int n) {
+        throw new UnsupportedOperationException();
+        // TODO combined progress updating with case where n == 1
+    }
+
     private int getPercentComplete () {
         return (currentElement * 100) / totalElements;
     }

--- a/src/main/java/com/conveyal/r5/analyst/progress/NoopProgressListener.java
+++ b/src/main/java/com/conveyal/r5/analyst/progress/NoopProgressListener.java
@@ -1,15 +1,18 @@
 package com.conveyal.r5.analyst.progress;
 
+/**
+ * For classes that support progress listeners but may not always use one, to avoid littering the code with null checks
+ * we have this trivial ProgressListener implementation that does nothing.
+ */
 public class NoopProgressListener implements ProgressListener {
 
     @Override
-    public void beginTask(String description, int totalElements) {
-
-    }
+    public void beginTask(String description, int totalElements) { }
 
     @Override
-    public void increment() {
+    public void increment() { }
 
-    }
+    @Override
+    public void increment (int n) { }
 
 }

--- a/src/main/java/com/conveyal/r5/analyst/progress/ProgressInputStream.java
+++ b/src/main/java/com/conveyal/r5/analyst/progress/ProgressInputStream.java
@@ -1,6 +1,5 @@
-package com.conveyal.analysis.util;
+package com.conveyal.r5.analyst.progress;
 
-import com.conveyal.r5.analyst.progress.ProgressListener;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.io.input.ProxyInputStream;
 
@@ -11,9 +10,10 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.commons.io.IOUtils.EOF;
 
 /**
- * This will report the total number of bytes that have passed through the stream, which can exceed 100% of the file
- * size if the caller uses mark and reset. Based on CountingInputStream. The progressListener should be pre-configured
- * with the total number of bytes expected and a detail message using ProgressListener::beginTask.
+ * This will report progress as the total number of bytes that have passed through the stream, like CountingInputStream.
+ * This can exceed 100% of the file size if the caller uses mark and reset. The progressListener should be
+ * pre-configured with the total number of bytes expected and a detail message using ProgressListener::beginTask.
+ * The static method forFileItem() demonstrates usage when reading from a file of known length.
  */
 public class ProgressInputStream extends ProxyInputStream {
 
@@ -42,7 +42,7 @@ public class ProgressInputStream extends ProxyInputStream {
      * Given an uploaded file, report progress on reading it.
      * Incrementing the progress seems to introduce some inefficiency when performing unbuffered small reads, such as
      * calls to InputStream.read() which are used by DataInputStream to read numbers.
-     * TODO wrap in buffered input stream to reduce small read calls? Or make tune progress reporting?
+     * TODO wrap in buffered input stream to reduce small read calls, or tune to only report once per percentage?
      */
     public static ProgressInputStream forFileItem (FileItem fileItem, ProgressListener progressListener) {
         try {

--- a/src/main/java/com/conveyal/r5/analyst/progress/ProgressListener.java
+++ b/src/main/java/com/conveyal/r5/analyst/progress/ProgressListener.java
@@ -2,6 +2,7 @@ package com.conveyal.r5.analyst.progress;
 
 /**
  * This interface provides simple callbacks to allow long running, asynchronous operations to report on their progress.
+ * Take care that all method implementations are very fast as the increment methods might be called in tight loops.
  */
 public interface ProgressListener {
 
@@ -16,9 +17,12 @@ public interface ProgressListener {
      */
     void beginTask(String description, int totalElements);
 
-    /**
-     * Call this method to report that one unit of work has been performed.
-     */
-    void increment();
+    /** Call this method to report that N units of work have been performed. */
+    void increment(int n);
+
+    /** Call this method to report that one unit of work has been performed. */
+    default void increment () {
+        increment(1);
+    }
 
 }

--- a/src/main/java/com/conveyal/r5/analyst/progress/Task.java
+++ b/src/main/java/com/conveyal/r5/analyst/progress/Task.java
@@ -1,7 +1,6 @@
 package com.conveyal.r5.analyst.progress;
 
 import com.conveyal.analysis.UserPermissions;
-import com.conveyal.analysis.controllers.UserActivityController.ApiTask;
 import com.conveyal.analysis.models.Model;
 import com.conveyal.r5.util.ExceptionUtils;
 

--- a/src/main/java/com/conveyal/r5/analyst/progress/Task.java
+++ b/src/main/java/com/conveyal/r5/analyst/progress/Task.java
@@ -217,6 +217,11 @@ public class Task implements Runnable, ProgressListener {
         return Duration.between(began, endTime);
     }
 
+    public Duration durationComplete () {
+        if (completed == null) return Duration.ZERO;
+        return Duration.between(completed, Instant.now());
+    }
+
     // FLUENT METHODS FOR CONFIGURING
 
     /** Call this static factory to begin building a task. */

--- a/src/main/java/com/conveyal/r5/analyst/progress/Task.java
+++ b/src/main/java/com/conveyal/r5/analyst/progress/Task.java
@@ -275,7 +275,7 @@ public class Task implements Runnable, ProgressListener {
         apiTask.state = state;
         apiTask.percentComplete = (int) getPercentComplete();
         apiTask.secondsActive = (int) durationExecuting().getSeconds();
-        apiTask.secondsComplete = (int) durationExecuting().getSeconds();
+        apiTask.secondsComplete = (int) durationComplete().getSeconds();
         apiTask.workProduct = workProduct;
         return apiTask;
     }

--- a/src/main/java/com/conveyal/r5/analyst/progress/Task.java
+++ b/src/main/java/com/conveyal/r5/analyst/progress/Task.java
@@ -1,13 +1,9 @@
 package com.conveyal.r5.analyst.progress;
 
 import com.conveyal.analysis.UserPermissions;
-import com.conveyal.analysis.controllers.UserActivityController;
 import com.conveyal.analysis.controllers.UserActivityController.ApiTask;
-import com.conveyal.analysis.controllers.UserActivityController.WorkProduct;
-import com.conveyal.analysis.controllers.UserActivityController.WorkProductType;
 import com.conveyal.analysis.models.Model;
 import com.conveyal.r5.util.ExceptionUtils;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -277,9 +273,9 @@ public class Task implements Runnable, ProgressListener {
         apiTask.title = title;
         apiTask.detail = description;
         apiTask.state = state;
-        apiTask.percentComplete = (int)(getPercentComplete());
-        apiTask.timeBegan = began == null ? null : began.toEpochMilli();
-        apiTask.timeCompleted = completed == null ? null : completed.toEpochMilli();
+        apiTask.percentComplete = (int) getPercentComplete();
+        apiTask.secondsActive = (int) durationExecuting().getSeconds();
+        apiTask.secondsComplete = (int) durationExecuting().getSeconds();
         apiTask.workProduct = workProduct;
         return apiTask;
     }

--- a/src/main/java/com/conveyal/r5/analyst/progress/TaskAction.java
+++ b/src/main/java/com/conveyal/r5/analyst/progress/TaskAction.java
@@ -13,6 +13,6 @@ public interface TaskAction {
      * The parameter is a simpler interface of Task that only allows progress reporting, to encapsulate actions and
      * prevent them from seeing or modifying the task hierarchy that triggers and manages them.
      */
-    public void action (ProgressListener progressListener);
+    public void action (ProgressListener progressListener) throws Exception;
 
 }

--- a/src/main/java/com/conveyal/r5/analyst/progress/TaskAction.java
+++ b/src/main/java/com/conveyal/r5/analyst/progress/TaskAction.java
@@ -1,8 +1,5 @@
 package com.conveyal.r5.analyst.progress;
 
-import com.conveyal.analysis.controllers.UserActivityController;
-import com.conveyal.analysis.controllers.UserActivityController.WorkProduct;
-
 /**
  * This represents the work actually carried out by a Task.
  * It's a single-method interface so it can be defined with lambda functions, or other objects can implement it.

--- a/src/main/java/com/conveyal/r5/analyst/progress/TaskAction.java
+++ b/src/main/java/com/conveyal/r5/analyst/progress/TaskAction.java
@@ -1,5 +1,8 @@
 package com.conveyal.r5.analyst.progress;
 
+import com.conveyal.analysis.controllers.UserActivityController;
+import com.conveyal.analysis.controllers.UserActivityController.WorkProduct;
+
 /**
  * This represents the work actually carried out by a Task.
  * It's a single-method interface so it can be defined with lambda functions, or other objects can implement it.

--- a/src/main/java/com/conveyal/r5/analyst/progress/WorkProduct.java
+++ b/src/main/java/com/conveyal/r5/analyst/progress/WorkProduct.java
@@ -1,0 +1,29 @@
+package com.conveyal.r5.analyst.progress;
+
+import com.conveyal.analysis.controllers.UserActivityController;
+import com.conveyal.analysis.models.Model;
+
+/**
+ * A unique identifier for the final product of a single task action. Currently this serves as both an
+ * internal data structure and an API model class, which should be harmless as it's an immutable data class.
+ * The id is unique within the type, so the regionId is redundant information, but facilitates prefectches on the UI.
+ */
+public class WorkProduct {
+
+    public final WorkProductType type;
+    public final String id;
+    public final String regionId;
+
+    public WorkProduct (WorkProductType type, String id, String regionId) {
+        this.type = type;
+        this.id = id;
+        this.regionId = regionId;
+    }
+
+    // FIXME Not all Models have a regionId. Rather than pass that in as a String, refine the programming API.
+    public static WorkProduct forModel (Model model) {
+        WorkProduct product = new WorkProduct(WorkProductType.forModel(model), model._id, null);
+        return product;
+    }
+
+}

--- a/src/main/java/com/conveyal/r5/analyst/progress/WorkProductType.java
+++ b/src/main/java/com/conveyal/r5/analyst/progress/WorkProductType.java
@@ -1,0 +1,25 @@
+package com.conveyal.r5.analyst.progress;
+
+import com.conveyal.analysis.controllers.UserActivityController;
+import com.conveyal.analysis.models.Bundle;
+import com.conveyal.analysis.models.Model;
+import com.conveyal.analysis.models.OpportunityDataset;
+import com.conveyal.analysis.models.RegionalAnalysis;
+
+/**
+ * There is some implicit and unenforced correspondence between these values and those in FileCategory, as well
+ * as the tables in Mongo. We should probably clearly state and enforce this parallelism. No background work is
+ * done creating regions, projects, or modifications so they don't need to be represented here.
+ */
+public enum WorkProductType {
+
+    BUNDLE, REGIONAL_ANALYSIS, AGGREGATION_AREA, OPPORTUNITY_DATASET;
+
+    // Currently we have two base classes for db objects so may need to use Object instead of BaseModel parameter
+    public static WorkProductType forModel (Model model) {
+        if (model instanceof Bundle) return BUNDLE;
+        if (model instanceof OpportunityDataset) return OPPORTUNITY_DATASET;
+        if (model instanceof RegionalAnalysis) return REGIONAL_ANALYSIS;
+        throw new IllegalArgumentException("Unrecognized work product type.");
+    }
+}

--- a/src/main/java/com/conveyal/r5/util/ExceptionUtils.java
+++ b/src/main/java/com/conveyal/r5/util/ExceptionUtils.java
@@ -45,7 +45,7 @@ public abstract class ExceptionUtils {
             throwable = throwable.getCause();
         }
         Collections.reverse(items);
-        return String.join(" Caused ", items);
+        return String.join(", caused ", items);
     }
 
     public static String shortAndLongString (Throwable throwable) {


### PR DESCRIPTION
This is a revised version of the new user activity API created in #706. This takes in to account the discussion on #716 and in subsequent meetings. The API is now more clearly defined via model classes within `UserActivityController.java`. The title of tasks is now separate from their description, with the latter changing as work is done. Fine grained progress reporting on OSM and GTFS will be shown separately, reporting the percentage of each file that's been loaded.

The endpoint will now stop reporting on tasks after their DONE or ERROR state has been delivered to a UI at least once, and one minute has passed.

Any exceptions will be attached to the Task as well as the Mongo. A common code path will be factored out for this purpose (tied in with the workProduct information), but it works in the current form.

Work product API model classes are present but not yet set. I can take care of that tomorrow, probably during the work session.

This should also be integrated with #715 so we don't give the illusion of successful GTFS loading by not showing feed validation errors. I just tried merging them and the only conflicts were imports.