### PR TITLE
Build with NEXT_PUBLIC_CYPRESS: true

### DIFF
--- a/.github/workflows/cypress-integration.yml
+++ b/.github/workflows/cypress-integration.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: cypress-io/github-action@v2
         env:
           NEXT_PUBLIC_BASEMAP_DISABLED: true
+          NEXT_PUBLIC_CYPRESS: true
           NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
         with:
           build: yarn build


### PR DESCRIPTION
This disables deduping UI requests that come from multiple components (the tests run faster than real world usage).

Specifically, Cypress tests failing with a "button still exists but expected not to" type error should now pass. On the region page it would load the regions, delete the region, confirm deletion, and reload the regions page very fast. If it was less than 2 seconds, the request would be deduplicated and the region would still appear.