### PR TITLE
Add Priority to each GTFSError subclass

### DIFF
--- a/src/main/java/com/conveyal/analysis/models/Bundle.java
+++ b/src/main/java/com/conveyal/analysis/models/Bundle.java
@@ -3,7 +3,6 @@ package com.conveyal.analysis.models;
 import com.conveyal.analysis.AnalysisServerException;
 import com.conveyal.gtfs.GTFSFeed;
 import com.conveyal.gtfs.error.GTFSError;
-import com.conveyal.gtfs.model.Agency;
 import com.conveyal.gtfs.model.FeedInfo;
 import com.conveyal.gtfs.validator.model.Priority;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -83,7 +82,7 @@ public class Bundle extends Model implements Cloneable {
         public Priority priority;
         public GtfsErrorTypeSummary () { /* For deserialization. */ }
         public GtfsErrorTypeSummary (GTFSError error) {
-            this.priority = error.getPriority();
+            this.priority = error.priority;
             this.type = error.errorType;
         }
     }

--- a/src/main/java/com/conveyal/analysis/models/Bundle.java
+++ b/src/main/java/com/conveyal/analysis/models/Bundle.java
@@ -82,7 +82,7 @@ public class Bundle extends Model implements Cloneable {
         public Priority priority;
         public GtfsErrorTypeSummary () { /* For deserialization. */ }
         public GtfsErrorTypeSummary (GTFSError error) {
-            this.priority = error.priority;
+            this.priority = error.getPriority();
             this.type = error.errorType;
         }
     }

--- a/src/main/java/com/conveyal/gtfs/GTFSFeed.java
+++ b/src/main/java/com/conveyal/gtfs/GTFSFeed.java
@@ -512,8 +512,9 @@ public class GTFSFeed implements Cloneable, Closeable {
             for (String stopId : pattern.orderedStops) {
                 Stop stop = stops.get(stopId);
                 if (stop == null) {
-                    // TODO replace with ReferentialIntegrityError during stop_time loading
-                    throw new RuntimeException(String.format("No stop exists with ID '%s'", stopId));
+                    // A ReferentialIntegrityError should have been recorded during stop_time loading and naming should
+                    // be halted.
+                   return;
                 }
                 if (fromName.equals(stop.stop_name) || toName.equals(stop.stop_name)) {
                     continue;

--- a/src/main/java/com/conveyal/gtfs/error/DateParseError.java
+++ b/src/main/java/com/conveyal/gtfs/error/DateParseError.java
@@ -9,10 +9,14 @@ public class DateParseError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public DateParseError(String file, long line, String field) {
-        super(file, line, field, Priority.MEDIUM);
+        super(file, line, field);
     }
 
     @Override public String getMessage() {
         return "Could not parse date (format should be YYYYMMDD).";
+    }
+
+    @Override public Priority getPriority() {
+        return Priority.MEDIUM;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/DateParseError.java
+++ b/src/main/java/com/conveyal/gtfs/error/DateParseError.java
@@ -1,5 +1,7 @@
 package com.conveyal.gtfs.error;
 
+import com.conveyal.gtfs.validator.model.Priority;
+
 import java.io.Serializable;
 
 /** Represents a problem parsing a date field from a GTFS feed. */
@@ -7,11 +9,10 @@ public class DateParseError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public DateParseError(String file, long line, String field) {
-        super(file, line, field);
+        super(file, line, field, Priority.MEDIUM);
     }
 
     @Override public String getMessage() {
         return "Could not parse date (format should be YYYYMMDD).";
     }
-
 }

--- a/src/main/java/com/conveyal/gtfs/error/DuplicateKeyError.java
+++ b/src/main/java/com/conveyal/gtfs/error/DuplicateKeyError.java
@@ -1,5 +1,7 @@
 package com.conveyal.gtfs.error;
 
+import com.conveyal.gtfs.validator.model.Priority;
+
 import java.io.Serializable;
 
 /** Indicates that a GTFS entity was not added to a table because another object already exists with the same primary key. */
@@ -7,11 +9,10 @@ public class DuplicateKeyError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public DuplicateKeyError(String file, long line, String field) {
-        super(file, line, field);
+        super(file, line, field, Priority.MEDIUM);
     }
 
     @Override public String getMessage() {
         return "Duplicate primary key.";
     }
-
 }

--- a/src/main/java/com/conveyal/gtfs/error/DuplicateKeyError.java
+++ b/src/main/java/com/conveyal/gtfs/error/DuplicateKeyError.java
@@ -9,10 +9,14 @@ public class DuplicateKeyError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public DuplicateKeyError(String file, long line, String field) {
-        super(file, line, field, Priority.MEDIUM);
+        super(file, line, field);
     }
 
     @Override public String getMessage() {
         return "Duplicate primary key.";
+    }
+
+    @Override public Priority getPriority() {
+        return Priority.MEDIUM;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/DuplicateStopError.java
+++ b/src/main/java/com/conveyal/gtfs/error/DuplicateStopError.java
@@ -13,12 +13,16 @@ public class DuplicateStopError extends GTFSError implements Serializable {
     public final DuplicateStops duplicateStop;
 
     public DuplicateStopError(DuplicateStops duplicateStop) {
-        super("stop", duplicateStop.getDuplicatedStop().sourceFileLine, "stop_lat,stop_lon", Priority.MEDIUM, duplicateStop.getDuplicatedStop().stop_id);
+        super("stop", duplicateStop.getDuplicatedStop().sourceFileLine, "stop_lat,stop_lon", duplicateStop.getDuplicatedStop().stop_id);
         this.message = duplicateStop.toString();
         this.duplicateStop = duplicateStop;
     }
 
     @Override public String getMessage() {
         return message;
+    }
+
+    @Override public Priority getPriority() {
+        return Priority.MEDIUM;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/DuplicateStopError.java
+++ b/src/main/java/com/conveyal/gtfs/error/DuplicateStopError.java
@@ -1,6 +1,7 @@
 package com.conveyal.gtfs.error;
 
 import com.conveyal.gtfs.validator.model.DuplicateStops;
+import com.conveyal.gtfs.validator.model.Priority;
 
 import java.io.Serializable;
 
@@ -12,7 +13,7 @@ public class DuplicateStopError extends GTFSError implements Serializable {
     public final DuplicateStops duplicateStop;
 
     public DuplicateStopError(DuplicateStops duplicateStop) {
-        super("stop", duplicateStop.getDuplicatedStop().sourceFileLine, "stop_lat,stop_lon", duplicateStop.getDuplicatedStop().stop_id);
+        super("stop", duplicateStop.getDuplicatedStop().sourceFileLine, "stop_lat,stop_lon", Priority.MEDIUM, duplicateStop.getDuplicatedStop().stop_id);
         this.message = duplicateStop.toString();
         this.duplicateStop = duplicateStop;
     }
@@ -20,5 +21,4 @@ public class DuplicateStopError extends GTFSError implements Serializable {
     @Override public String getMessage() {
         return message;
     }
-
 }

--- a/src/main/java/com/conveyal/gtfs/error/DuplicateTripError.java
+++ b/src/main/java/com/conveyal/gtfs/error/DuplicateTripError.java
@@ -20,7 +20,7 @@ public class DuplicateTripError extends GTFSError implements Serializable {
     String lastArrival;
 
     public DuplicateTripError(Trip trip, long line, String duplicateTripId, String patternName, String firstDeparture, String lastArrival) {
-        super("trips", line, "trip_id", Priority.MEDIUM, trip.trip_id);
+        super("trips", line, "trip_id", trip.trip_id);
         this.duplicateTripId = duplicateTripId;
         this.patternName = patternName;
         this.routeId = trip.route_id;
@@ -32,5 +32,9 @@ public class DuplicateTripError extends GTFSError implements Serializable {
 
     @Override public String getMessage() {
         return String.format("Trip Ids %s & %s (route %s) are duplicates (pattern: %s, calendar: %s, from %s to %s)", duplicateTripId, affectedEntityId, routeId, patternName, serviceId, firstDeparture, lastArrival);
+    }
+
+    @Override public Priority getPriority() {
+        return Priority.MEDIUM;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/DuplicateTripError.java
+++ b/src/main/java/com/conveyal/gtfs/error/DuplicateTripError.java
@@ -11,7 +11,6 @@ import java.io.Serializable;
 public class DuplicateTripError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
-    public final Priority priority = Priority.LOW;
     public final String duplicateTripId;
     public final String patternName;
     public final String routeId;
@@ -21,7 +20,7 @@ public class DuplicateTripError extends GTFSError implements Serializable {
     String lastArrival;
 
     public DuplicateTripError(Trip trip, long line, String duplicateTripId, String patternName, String firstDeparture, String lastArrival) {
-        super("trips", line, "trip_id", trip.trip_id);
+        super("trips", line, "trip_id", Priority.MEDIUM, trip.trip_id);
         this.duplicateTripId = duplicateTripId;
         this.patternName = patternName;
         this.routeId = trip.route_id;

--- a/src/main/java/com/conveyal/gtfs/error/EmptyFieldError.java
+++ b/src/main/java/com/conveyal/gtfs/error/EmptyFieldError.java
@@ -9,11 +9,14 @@ public class EmptyFieldError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public EmptyFieldError(String file, long line, String field) {
-        super(file, line, field, Priority.MEDIUM);
+        super(file, line, field);
     }
 
     @Override public String getMessage() {
         return String.format("No value supplied for a required column.");
     }
 
+    @Override public Priority getPriority() {
+        return Priority.MEDIUM;
+    }
 }

--- a/src/main/java/com/conveyal/gtfs/error/EmptyFieldError.java
+++ b/src/main/java/com/conveyal/gtfs/error/EmptyFieldError.java
@@ -1,5 +1,7 @@
 package com.conveyal.gtfs.error;
 
+import com.conveyal.gtfs.validator.model.Priority;
+
 import java.io.Serializable;
 
 /** Indicates that a field marked as required is not present in a GTFS feed on a particular line. */
@@ -7,7 +9,7 @@ public class EmptyFieldError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public EmptyFieldError(String file, long line, String field) {
-        super(file, line, field);
+        super(file, line, field, Priority.MEDIUM);
     }
 
     @Override public String getMessage() {

--- a/src/main/java/com/conveyal/gtfs/error/EmptyTableError.java
+++ b/src/main/java/com/conveyal/gtfs/error/EmptyTableError.java
@@ -1,5 +1,7 @@
 package com.conveyal.gtfs.error;
 
+import com.conveyal.gtfs.validator.model.Priority;
+
 import java.io.Serializable;
 
 /**
@@ -9,7 +11,7 @@ public class EmptyTableError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public EmptyTableError(String file) {
-        super(file, 0, null);
+        super(file, 0, null, Priority.MEDIUM);
     }
 
     @Override public String getMessage() {

--- a/src/main/java/com/conveyal/gtfs/error/EmptyTableError.java
+++ b/src/main/java/com/conveyal/gtfs/error/EmptyTableError.java
@@ -11,10 +11,14 @@ public class EmptyTableError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public EmptyTableError(String file) {
-        super(file, 0, null, Priority.MEDIUM);
+        super(file, 0, null);
     }
 
     @Override public String getMessage() {
         return String.format("Table is present in zip file, but it has no entries.");
+    }
+
+    @Override public Priority getPriority() {
+        return Priority.MEDIUM;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/GTFSError.java
+++ b/src/main/java/com/conveyal/gtfs/error/GTFSError.java
@@ -18,17 +18,19 @@ public abstract class GTFSError implements Comparable<GTFSError>, Serializable {
     public final String field;
     public final String affectedEntityId;
     public final String errorType;
+    public final Priority priority;
 
-    public GTFSError(String file, long line, String field) {
-        this(file, line, field, null);
+    public GTFSError(String file, long line, String field, Priority priority) {
+        this(file, line, field, priority, null);
     }
 
-    public GTFSError(String file, long line, String field, String affectedEntityId) {
+    public GTFSError(String file, long line, String field, Priority priority, String affectedEntityId) {
         this.file  = file;
         this.line  = line;
         this.field = field;
         this.affectedEntityId = affectedEntityId;
         this.errorType = this.getClass().getSimpleName();
+        this.priority = priority;
     }
 
     /**
@@ -40,6 +42,7 @@ public abstract class GTFSError implements Comparable<GTFSError>, Serializable {
         this.field = null;
         this.errorType = null;
         this.affectedEntityId = entityId;
+        this.priority = Priority.UNKNOWN;
     }
 
     /**
@@ -48,10 +51,6 @@ public abstract class GTFSError implements Comparable<GTFSError>, Serializable {
      */
     public final String getErrorCode () {
         return this.getClass().getSimpleName();
-    }
-
-    public Priority getPriority () {
-        return Priority.UNKNOWN;
     }
 
     /**

--- a/src/main/java/com/conveyal/gtfs/error/GTFSError.java
+++ b/src/main/java/com/conveyal/gtfs/error/GTFSError.java
@@ -18,19 +18,17 @@ public abstract class GTFSError implements Comparable<GTFSError>, Serializable {
     public final String field;
     public final String affectedEntityId;
     public final String errorType;
-    public final Priority priority;
 
-    public GTFSError(String file, long line, String field, Priority priority) {
-        this(file, line, field, priority, null);
+    public GTFSError(String file, long line, String field) {
+        this(file, line, field, null);
     }
 
-    public GTFSError(String file, long line, String field, Priority priority, String affectedEntityId) {
+    public GTFSError(String file, long line, String field, String affectedEntityId) {
         this.file  = file;
         this.line  = line;
         this.field = field;
         this.affectedEntityId = affectedEntityId;
         this.errorType = this.getClass().getSimpleName();
-        this.priority = priority;
     }
 
     /**
@@ -42,7 +40,6 @@ public abstract class GTFSError implements Comparable<GTFSError>, Serializable {
         this.field = null;
         this.errorType = null;
         this.affectedEntityId = entityId;
-        this.priority = Priority.UNKNOWN;
     }
 
     /**
@@ -51,6 +48,13 @@ public abstract class GTFSError implements Comparable<GTFSError>, Serializable {
      */
     public final String getErrorCode () {
         return this.getClass().getSimpleName();
+    }
+
+    /**
+     * @return The Error priority level associated with this class.
+     */
+    public Priority getPriority() {
+        return Priority.UNKNOWN;
     }
 
     /**

--- a/src/main/java/com/conveyal/gtfs/error/GeneralError.java
+++ b/src/main/java/com/conveyal/gtfs/error/GeneralError.java
@@ -11,7 +11,7 @@ public class GeneralError extends GTFSError implements Serializable {
     private String message;
 
     public GeneralError(String file, long line, String field, String message) {
-        super(file, line, field, Priority.UNKNOWN);
+        super(file, line, field);
         this.message = message;
     }
 
@@ -19,4 +19,7 @@ public class GeneralError extends GTFSError implements Serializable {
         return message;
     }
 
+    @Override public Priority getPriority() {
+        return Priority.UNKNOWN;
+    }
 }

--- a/src/main/java/com/conveyal/gtfs/error/GeneralError.java
+++ b/src/main/java/com/conveyal/gtfs/error/GeneralError.java
@@ -1,5 +1,7 @@
 package com.conveyal.gtfs.error;
 
+import com.conveyal.gtfs.validator.model.Priority;
+
 import java.io.Serializable;
 
 /** Represents any GTFS loading problem that does not have its own class, with a free-text message. */
@@ -9,7 +11,7 @@ public class GeneralError extends GTFSError implements Serializable {
     private String message;
 
     public GeneralError(String file, long line, String field, String message) {
-        super(file, line, field);
+        super(file, line, field, Priority.UNKNOWN);
         this.message = message;
     }
 

--- a/src/main/java/com/conveyal/gtfs/error/MisplacedStopError.java
+++ b/src/main/java/com/conveyal/gtfs/error/MisplacedStopError.java
@@ -11,16 +11,18 @@ import java.io.Serializable;
 public class MisplacedStopError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
-    public final Priority priority;
     public final Stop stop;
 
     public MisplacedStopError(String affectedEntityId, long line, Stop stop) {
-        super("stops", line, "stop_id", Priority.MEDIUM, affectedEntityId);
-        this.priority = Priority.HIGH;
+        super("stops", line, "stop_id", affectedEntityId);
         this.stop = stop;
     }
 
     @Override public String getMessage() {
         return String.format("Stop Id %s is misplaced.", affectedEntityId);
+    }
+
+    @Override public Priority getPriority() {
+        return Priority.MEDIUM;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/MisplacedStopError.java
+++ b/src/main/java/com/conveyal/gtfs/error/MisplacedStopError.java
@@ -15,7 +15,7 @@ public class MisplacedStopError extends GTFSError implements Serializable {
     public final Stop stop;
 
     public MisplacedStopError(String affectedEntityId, long line, Stop stop) {
-        super("stops", line, "stop_id", affectedEntityId);
+        super("stops", line, "stop_id", Priority.MEDIUM, affectedEntityId);
         this.priority = Priority.HIGH;
         this.stop = stop;
     }

--- a/src/main/java/com/conveyal/gtfs/error/MissingColumnError.java
+++ b/src/main/java/com/conveyal/gtfs/error/MissingColumnError.java
@@ -1,5 +1,7 @@
 package com.conveyal.gtfs.error;
 
+import com.conveyal.gtfs.validator.model.Priority;
+
 import java.io.Serializable;
 
 /** Indicates that a column marked as required is entirely missing from a GTFS feed. */
@@ -7,7 +9,7 @@ public class MissingColumnError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public MissingColumnError(String file, String field) {
-        super(file, 1, field);
+        super(file, 1, field, Priority.MEDIUM);
     }
 
     @Override public String getMessage() {

--- a/src/main/java/com/conveyal/gtfs/error/MissingColumnError.java
+++ b/src/main/java/com/conveyal/gtfs/error/MissingColumnError.java
@@ -9,11 +9,14 @@ public class MissingColumnError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public MissingColumnError(String file, String field) {
-        super(file, 1, field, Priority.MEDIUM);
+        super(file, 1, field);
     }
 
     @Override public String getMessage() {
         return String.format("Missing required column.");
     }
 
+    @Override public Priority getPriority() {
+        return Priority.MEDIUM;
+    }
 }

--- a/src/main/java/com/conveyal/gtfs/error/MissingShapeError.java
+++ b/src/main/java/com/conveyal/gtfs/error/MissingShapeError.java
@@ -12,7 +12,7 @@ public class MissingShapeError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public MissingShapeError(Trip trip) {
-        super("trips", trip.sourceFileLine, "shape_id", Priority.MEDIUM, trip.trip_id);
+        super("trips", trip.sourceFileLine, "shape_id", Priority.LOW, trip.trip_id);
     }
 
     @Override public String getMessage() {

--- a/src/main/java/com/conveyal/gtfs/error/MissingShapeError.java
+++ b/src/main/java/com/conveyal/gtfs/error/MissingShapeError.java
@@ -11,10 +11,8 @@ import java.io.Serializable;
 public class MissingShapeError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
-    public final Priority priority = Priority.MEDIUM;
-
     public MissingShapeError(Trip trip) {
-        super("trips", trip.sourceFileLine, "shape_id", trip.trip_id);
+        super("trips", trip.sourceFileLine, "shape_id", Priority.MEDIUM, trip.trip_id);
     }
 
     @Override public String getMessage() {

--- a/src/main/java/com/conveyal/gtfs/error/MissingShapeError.java
+++ b/src/main/java/com/conveyal/gtfs/error/MissingShapeError.java
@@ -12,10 +12,14 @@ public class MissingShapeError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public MissingShapeError(Trip trip) {
-        super("trips", trip.sourceFileLine, "shape_id", Priority.LOW, trip.trip_id);
+        super("trips", trip.sourceFileLine, "shape_id", trip.trip_id);
     }
 
     @Override public String getMessage() {
         return "Trip " + affectedEntityId + " is missing a shape";
+    }
+
+    @Override public Priority getPriority() {
+        return Priority.LOW;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/MissingTableError.java
+++ b/src/main/java/com/conveyal/gtfs/error/MissingTableError.java
@@ -9,11 +9,14 @@ public class MissingTableError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public MissingTableError(String file) {
-        super(file, 0, null, Priority.MEDIUM);
+        super(file, 0, null);
     }
 
     @Override public String getMessage() {
         return String.format("This table is required by the GTFS specification but is missing.");
     }
 
+    @Override public Priority getPriority() {
+        return Priority.MEDIUM;
+    }
 }

--- a/src/main/java/com/conveyal/gtfs/error/MissingTableError.java
+++ b/src/main/java/com/conveyal/gtfs/error/MissingTableError.java
@@ -1,5 +1,7 @@
 package com.conveyal.gtfs.error;
 
+import com.conveyal.gtfs.validator.model.Priority;
+
 import java.io.Serializable;
 
 /** Indicates that a table marked as required is not present in a GTFS feed. */
@@ -7,7 +9,7 @@ public class MissingTableError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public MissingTableError(String file) {
-        super(file, 0, null);
+        super(file, 0, null, Priority.MEDIUM);
     }
 
     @Override public String getMessage() {

--- a/src/main/java/com/conveyal/gtfs/error/NoAgencyInFeedError.java
+++ b/src/main/java/com/conveyal/gtfs/error/NoAgencyInFeedError.java
@@ -6,10 +6,8 @@ import com.conveyal.gtfs.validator.model.Priority;
  * Created by landon on 5/2/17.
  */
 public class NoAgencyInFeedError extends GTFSError {
-    public final Priority priority = Priority.HIGH;
-
     public NoAgencyInFeedError() {
-        super("agency", 0, "agency_id");
+        super("agency", 0, "agency_id", Priority.HIGH);
     }
 
     @Override public String getMessage() {

--- a/src/main/java/com/conveyal/gtfs/error/NoAgencyInFeedError.java
+++ b/src/main/java/com/conveyal/gtfs/error/NoAgencyInFeedError.java
@@ -7,10 +7,14 @@ import com.conveyal.gtfs.validator.model.Priority;
  */
 public class NoAgencyInFeedError extends GTFSError {
     public NoAgencyInFeedError() {
-        super("agency", 0, "agency_id", Priority.HIGH);
+        super("agency", 0, "agency_id");
     }
 
     @Override public String getMessage() {
         return String.format("No agency listed in feed (must have at least one).");
+    }
+
+    @Override public Priority getPriority() {
+        return Priority.HIGH;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/NumberParseError.java
+++ b/src/main/java/com/conveyal/gtfs/error/NumberParseError.java
@@ -9,11 +9,14 @@ public class NumberParseError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public NumberParseError(String file, long line, String field) {
-        super(file, line, field, Priority.HIGH);
+        super(file, line, field);
     }
 
     @Override public String getMessage() {
         return String.format("Error parsing a number from a string.");
     }
 
+    @Override public Priority getPriority() {
+        return Priority.HIGH;
+    }
 }

--- a/src/main/java/com/conveyal/gtfs/error/NumberParseError.java
+++ b/src/main/java/com/conveyal/gtfs/error/NumberParseError.java
@@ -1,5 +1,7 @@
 package com.conveyal.gtfs.error;
 
+import com.conveyal.gtfs.validator.model.Priority;
+
 import java.io.Serializable;
 
 /** Represents a problem parsing an integer field of GTFS feed. */
@@ -7,7 +9,7 @@ public class NumberParseError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public NumberParseError(String file, long line, String field) {
-        super(file, line, field);
+        super(file, line, field, Priority.HIGH);
     }
 
     @Override public String getMessage() {

--- a/src/main/java/com/conveyal/gtfs/error/OverlappingTripsInBlockError.java
+++ b/src/main/java/com/conveyal/gtfs/error/OverlappingTripsInBlockError.java
@@ -15,7 +15,7 @@ public class OverlappingTripsInBlockError extends GTFSError implements Serializa
     public final String routeId;
 
     public OverlappingTripsInBlockError(long line, String field, String affectedEntityId, String routeId, String[] tripIds) {
-        super("trips", line, field, affectedEntityId);
+        super("trips", line, field, Priority.MEDIUM, affectedEntityId);
         this.tripIds = tripIds;
         this.routeId = routeId;
     }

--- a/src/main/java/com/conveyal/gtfs/error/OverlappingTripsInBlockError.java
+++ b/src/main/java/com/conveyal/gtfs/error/OverlappingTripsInBlockError.java
@@ -15,12 +15,16 @@ public class OverlappingTripsInBlockError extends GTFSError implements Serializa
     public final String routeId;
 
     public OverlappingTripsInBlockError(long line, String field, String affectedEntityId, String routeId, String[] tripIds) {
-        super("trips", line, field, Priority.MEDIUM, affectedEntityId);
+        super("trips", line, field, affectedEntityId);
         this.tripIds = tripIds;
         this.routeId = routeId;
     }
 
     @Override public String getMessage() {
         return String.format("Trip Ids %s overlap (route: %s) and share block ID %s", String.join(" & ", tripIds), routeId, affectedEntityId);
+    }
+
+    @Override public Priority getPriority() {
+        return Priority.MEDIUM;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/RangeError.java
+++ b/src/main/java/com/conveyal/gtfs/error/RangeError.java
@@ -11,7 +11,7 @@ public class RangeError extends GTFSError implements Serializable {
     final double min, max, actual;
 
     public RangeError(String file, long line, String field, double min, double max, double actual) {
-        super(file, line, field, Priority.MEDIUM);
+        super(file, line, field, Priority.LOW);
         this.min = min;
         this.max = max;
         this.actual = actual;

--- a/src/main/java/com/conveyal/gtfs/error/RangeError.java
+++ b/src/main/java/com/conveyal/gtfs/error/RangeError.java
@@ -1,5 +1,7 @@
 package com.conveyal.gtfs.error;
 
+import com.conveyal.gtfs.validator.model.Priority;
+
 import java.io.Serializable;
 
 /** Indicates that a number is out of the acceptable range. */
@@ -9,7 +11,7 @@ public class RangeError extends GTFSError implements Serializable {
     final double min, max, actual;
 
     public RangeError(String file, long line, String field, double min, double max, double actual) {
-        super(file, line, field);
+        super(file, line, field, Priority.MEDIUM);
         this.min = min;
         this.max = max;
         this.actual = actual;

--- a/src/main/java/com/conveyal/gtfs/error/RangeError.java
+++ b/src/main/java/com/conveyal/gtfs/error/RangeError.java
@@ -11,7 +11,7 @@ public class RangeError extends GTFSError implements Serializable {
     final double min, max, actual;
 
     public RangeError(String file, long line, String field, double min, double max, double actual) {
-        super(file, line, field, Priority.LOW);
+        super(file, line, field);
         this.min = min;
         this.max = max;
         this.actual = actual;
@@ -21,4 +21,7 @@ public class RangeError extends GTFSError implements Serializable {
         return String.format("Number %s outside of acceptable range [%s,%s].", actual, min, max);
     }
 
+    @Override public Priority getPriority() {
+        return Priority.LOW;
+    }
 }

--- a/src/main/java/com/conveyal/gtfs/error/ReferentialIntegrityError.java
+++ b/src/main/java/com/conveyal/gtfs/error/ReferentialIntegrityError.java
@@ -1,5 +1,7 @@
 package com.conveyal.gtfs.error;
 
+import com.conveyal.gtfs.validator.model.Priority;
+
 import java.io.Serializable;
 
 /** Indicates that an entity referenced another entity that does not exist. */
@@ -10,7 +12,7 @@ public class ReferentialIntegrityError extends GTFSError implements Serializable
     public final String badReference;
 
     public ReferentialIntegrityError(String tableName, long row, String field, String badReference) {
-        super(tableName, row, field);
+        super(tableName, row, field, Priority.HIGH);
         this.badReference = badReference;
     }
 
@@ -25,5 +27,4 @@ public class ReferentialIntegrityError extends GTFSError implements Serializable
     @Override public String getMessage() {
         return String.format(badReference);
     }
-
 }

--- a/src/main/java/com/conveyal/gtfs/error/ReferentialIntegrityError.java
+++ b/src/main/java/com/conveyal/gtfs/error/ReferentialIntegrityError.java
@@ -12,7 +12,7 @@ public class ReferentialIntegrityError extends GTFSError implements Serializable
     public final String badReference;
 
     public ReferentialIntegrityError(String tableName, long row, String field, String badReference) {
-        super(tableName, row, field, Priority.HIGH);
+        super(tableName, row, field);
         this.badReference = badReference;
     }
 
@@ -26,5 +26,9 @@ public class ReferentialIntegrityError extends GTFSError implements Serializable
 
     @Override public String getMessage() {
         return String.format(badReference);
+    }
+
+    @Override public Priority getPriority() {
+        return Priority.HIGH;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/ReversedTripShapeError.java
+++ b/src/main/java/com/conveyal/gtfs/error/ReversedTripShapeError.java
@@ -11,11 +11,10 @@ import java.io.Serializable;
 public class ReversedTripShapeError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
-    public final Priority priority = Priority.HIGH;
     public final String shapeId;
 
     public ReversedTripShapeError(Trip trip) {
-        super("trips", trip.sourceFileLine, "shape_id", trip.trip_id);
+        super("trips", trip.sourceFileLine, "shape_id", Priority.HIGH, trip.trip_id);
         this.shapeId = trip.shape_id;
     }
 

--- a/src/main/java/com/conveyal/gtfs/error/ReversedTripShapeError.java
+++ b/src/main/java/com/conveyal/gtfs/error/ReversedTripShapeError.java
@@ -14,11 +14,15 @@ public class ReversedTripShapeError extends GTFSError implements Serializable {
     public final String shapeId;
 
     public ReversedTripShapeError(Trip trip) {
-        super("trips", trip.sourceFileLine, "shape_id", Priority.HIGH, trip.trip_id);
+        super("trips", trip.sourceFileLine, "shape_id", trip.trip_id);
         this.shapeId = trip.shape_id;
     }
 
     @Override public String getMessage() {
         return "Trip " + affectedEntityId + " references reversed shape " + shapeId;
+    }
+
+    @Override public Priority getPriority() {
+        return Priority.HIGH;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/ShapeMissingCoordinatesError.java
+++ b/src/main/java/com/conveyal/gtfs/error/ShapeMissingCoordinatesError.java
@@ -11,11 +11,10 @@ import java.io.Serializable;
 public class ShapeMissingCoordinatesError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
-    public final Priority priority = Priority.MEDIUM;
     public final String[] tripIds;
 
     public ShapeMissingCoordinatesError(ShapePoint shapePoint, String[] tripIds) {
-        super("shapes", shapePoint.sourceFileLine, "shape_id", shapePoint.shape_id);
+        super("shapes", shapePoint.sourceFileLine, "shape_id", Priority.MEDIUM, shapePoint.shape_id);
         this.tripIds = tripIds;
     }
 

--- a/src/main/java/com/conveyal/gtfs/error/ShapeMissingCoordinatesError.java
+++ b/src/main/java/com/conveyal/gtfs/error/ShapeMissingCoordinatesError.java
@@ -14,11 +14,15 @@ public class ShapeMissingCoordinatesError extends GTFSError implements Serializa
     public final String[] tripIds;
 
     public ShapeMissingCoordinatesError(ShapePoint shapePoint, String[] tripIds) {
-        super("shapes", shapePoint.sourceFileLine, "shape_id", Priority.MEDIUM, shapePoint.shape_id);
+        super("shapes", shapePoint.sourceFileLine, "shape_id", shapePoint.shape_id);
         this.tripIds = tripIds;
     }
 
     @Override public String getMessage() {
         return "Shape " + affectedEntityId + " is missing coordinates (affects " + tripIds.length + " trips)";
+    }
+
+    @Override public Priority getPriority() {
+        return Priority.MEDIUM;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/TableInSubdirectoryError.java
+++ b/src/main/java/com/conveyal/gtfs/error/TableInSubdirectoryError.java
@@ -13,11 +13,15 @@ public class TableInSubdirectoryError extends GTFSError implements Serializable 
     public final String directory;
 
     public TableInSubdirectoryError(String file, String directory) {
-        super(file, 0, null, Priority.HIGH);
+        super(file, 0, null);
         this.directory = directory;
     }
 
     @Override public String getMessage() {
         return String.format("All GTFS files (including %s.txt) should be at root of zipfile, not nested in subdirectory (%s)", file, directory);
+    }
+
+    @Override public Priority getPriority() {
+        return Priority.HIGH;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/TableInSubdirectoryError.java
+++ b/src/main/java/com/conveyal/gtfs/error/TableInSubdirectoryError.java
@@ -11,10 +11,9 @@ public class TableInSubdirectoryError extends GTFSError implements Serializable 
     public static final long serialVersionUID = 1L;
 
     public final String directory;
-    public final Priority priority = Priority.HIGH;
 
     public TableInSubdirectoryError(String file, String directory) {
-        super(file, 0, null);
+        super(file, 0, null, Priority.HIGH);
         this.directory = directory;
     }
 

--- a/src/main/java/com/conveyal/gtfs/error/TimeParseError.java
+++ b/src/main/java/com/conveyal/gtfs/error/TimeParseError.java
@@ -1,5 +1,7 @@
 package com.conveyal.gtfs.error;
 
+import com.conveyal.gtfs.validator.model.Priority;
+
 import java.io.Serializable;
 
 /** Represents a problem parsing a time of day field of GTFS feed. */
@@ -7,7 +9,7 @@ public class TimeParseError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public TimeParseError(String file, long line, String field) {
-        super(file, line, field);
+        super(file, line, field, Priority.MEDIUM);
     }
 
     @Override public String getMessage() {

--- a/src/main/java/com/conveyal/gtfs/error/TimeParseError.java
+++ b/src/main/java/com/conveyal/gtfs/error/TimeParseError.java
@@ -9,11 +9,14 @@ public class TimeParseError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public TimeParseError(String file, long line, String field) {
-        super(file, line, field, Priority.MEDIUM);
+        super(file, line, field);
     }
 
     @Override public String getMessage() {
         return "Could not parse time (format should be HH:MM:SS).";
     }
 
+    @Override public Priority getPriority() {
+        return Priority.MEDIUM;
+    }
 }

--- a/src/main/java/com/conveyal/gtfs/error/TimeZoneError.java
+++ b/src/main/java/com/conveyal/gtfs/error/TimeZoneError.java
@@ -1,5 +1,7 @@
 package com.conveyal.gtfs.error;
 
+import com.conveyal.gtfs.validator.model.Priority;
+
 import java.io.Serializable;
 
 /**
@@ -20,7 +22,7 @@ public class TimeZoneError extends GTFSError implements Serializable {
      * @param message description of issue with timezone reference
      */
     public TimeZoneError(String tableName, long line, String field, String affectedEntityId, String message) {
-        super(tableName, line, field, affectedEntityId);
+        super(tableName, line, field, Priority.MEDIUM, affectedEntityId);
         this.message = message;
     }
 

--- a/src/main/java/com/conveyal/gtfs/error/TimeZoneError.java
+++ b/src/main/java/com/conveyal/gtfs/error/TimeZoneError.java
@@ -22,11 +22,15 @@ public class TimeZoneError extends GTFSError implements Serializable {
      * @param message description of issue with timezone reference
      */
     public TimeZoneError(String tableName, long line, String field, String affectedEntityId, String message) {
-        super(tableName, line, field, Priority.MEDIUM, affectedEntityId);
+        super(tableName, line, field, affectedEntityId);
         this.message = message;
     }
 
     @Override public String getMessage() {
         return message + ". (" + field + ": " + affectedEntityId + ")";
+    }
+
+    @Override public Priority getPriority() {
+        return Priority.MEDIUM;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/URLParseError.java
+++ b/src/main/java/com/conveyal/gtfs/error/URLParseError.java
@@ -9,7 +9,7 @@ public class URLParseError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public URLParseError(String file, long line, String field) {
-        super(file, line, field, Priority.MEDIUM);
+        super(file, line, field, Priority.LOW);
     }
 
     @Override public String getMessage() {

--- a/src/main/java/com/conveyal/gtfs/error/URLParseError.java
+++ b/src/main/java/com/conveyal/gtfs/error/URLParseError.java
@@ -9,11 +9,14 @@ public class URLParseError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public URLParseError(String file, long line, String field) {
-        super(file, line, field, Priority.LOW);
+        super(file, line, field);
     }
 
     @Override public String getMessage() {
         return "Could not parse URL (format should be <scheme>://<authority><path>?<query>#<fragment>).";
     }
 
+    @Override public Priority getPriority() {
+        return Priority.LOW;
+    }
 }

--- a/src/main/java/com/conveyal/gtfs/error/URLParseError.java
+++ b/src/main/java/com/conveyal/gtfs/error/URLParseError.java
@@ -1,5 +1,7 @@
 package com.conveyal.gtfs.error;
 
+import com.conveyal.gtfs.validator.model.Priority;
+
 import java.io.Serializable;
 
 /** Represents a problem parsing a URL field from a GTFS feed. */
@@ -7,7 +9,7 @@ public class URLParseError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public URLParseError(String file, long line, String field) {
-        super(file, line, field);
+        super(file, line, field, Priority.MEDIUM);
     }
 
     @Override public String getMessage() {

--- a/src/main/java/com/conveyal/gtfs/error/UnusedStopError.java
+++ b/src/main/java/com/conveyal/gtfs/error/UnusedStopError.java
@@ -12,11 +12,15 @@ public class UnusedStopError extends GTFSError implements Serializable {
     public final Stop stop;
 
     public UnusedStopError(Stop stop) {
-        super("stops", stop.sourceFileLine, "stop_id", Priority.LOW, stop.stop_id);
+        super("stops", stop.sourceFileLine, "stop_id", stop.stop_id);
         this.stop = stop;
     }
 
     @Override public String getMessage() {
         return String.format("Stop Id %s is not used in any trips.", affectedEntityId);
+    }
+
+    @Override public Priority getPriority() {
+        return Priority.LOW;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/UnusedStopError.java
+++ b/src/main/java/com/conveyal/gtfs/error/UnusedStopError.java
@@ -9,12 +9,10 @@ import java.io.Serializable;
 public class UnusedStopError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
-    public final Priority priority;
     public final Stop stop;
 
     public UnusedStopError(Stop stop) {
-        super("stops", stop.sourceFileLine, "stop_id", stop.stop_id);
-        this.priority = Priority.LOW;
+        super("stops", stop.sourceFileLine, "stop_id", Priority.LOW, stop.stop_id);
         this.stop = stop;
     }
 


### PR DESCRIPTION
Add a specific `Priority` to each `GTFSError` subclass enforced through the constructor. This affects all of the "old" GTFS errors. I selected each error's `Priority` from the files themselves or from the `NewGTFSErrorType` enum that looked most closely related to it. 

If there are desired changes to the priority levels used, please feel free to change directly or to submit a suggested change inline.

Additionally, I've removed a thrown exception during pattern naming for when pattern has a stop that doesn't exist. A error will have already been recorded, so removing that exception allows the feed creation to complete and for those recorded errors to be displayed. If there's an alternative way of achieving the same behavior, I'm open to suggestions.