### PR TITLE
Restore priority field

### DIFF
--- a/src/main/java/com/conveyal/analysis/models/Bundle.java
+++ b/src/main/java/com/conveyal/analysis/models/Bundle.java
@@ -82,7 +82,7 @@ public class Bundle extends Model implements Cloneable {
         public Priority priority;
         public GtfsErrorTypeSummary () { /* For deserialization. */ }
         public GtfsErrorTypeSummary (GTFSError error) {
-            this.priority = error.getPriority();
+            this.priority = error.priority;
             this.type = error.errorType;
         }
     }

--- a/src/main/java/com/conveyal/gtfs/error/DateParseError.java
+++ b/src/main/java/com/conveyal/gtfs/error/DateParseError.java
@@ -9,14 +9,10 @@ public class DateParseError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public DateParseError(String file, long line, String field) {
-        super(file, line, field);
+        super(file, line, field, Priority.MEDIUM);
     }
 
     @Override public String getMessage() {
         return "Could not parse date (format should be YYYYMMDD).";
-    }
-
-    @Override public Priority getPriority() {
-        return Priority.MEDIUM;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/DuplicateKeyError.java
+++ b/src/main/java/com/conveyal/gtfs/error/DuplicateKeyError.java
@@ -9,14 +9,10 @@ public class DuplicateKeyError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public DuplicateKeyError(String file, long line, String field) {
-        super(file, line, field);
+        super(file, line, field, Priority.MEDIUM);
     }
 
     @Override public String getMessage() {
         return "Duplicate primary key.";
-    }
-
-    @Override public Priority getPriority() {
-        return Priority.MEDIUM;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/DuplicateStopError.java
+++ b/src/main/java/com/conveyal/gtfs/error/DuplicateStopError.java
@@ -13,16 +13,12 @@ public class DuplicateStopError extends GTFSError implements Serializable {
     public final DuplicateStops duplicateStop;
 
     public DuplicateStopError(DuplicateStops duplicateStop) {
-        super("stop", duplicateStop.getDuplicatedStop().sourceFileLine, "stop_lat,stop_lon", duplicateStop.getDuplicatedStop().stop_id);
+        super("stop", duplicateStop.getDuplicatedStop().sourceFileLine, "stop_lat,stop_lon", Priority.MEDIUM, duplicateStop.getDuplicatedStop().stop_id);
         this.message = duplicateStop.toString();
         this.duplicateStop = duplicateStop;
     }
 
     @Override public String getMessage() {
         return message;
-    }
-
-    @Override public Priority getPriority() {
-        return Priority.MEDIUM;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/DuplicateTripError.java
+++ b/src/main/java/com/conveyal/gtfs/error/DuplicateTripError.java
@@ -20,7 +20,7 @@ public class DuplicateTripError extends GTFSError implements Serializable {
     String lastArrival;
 
     public DuplicateTripError(Trip trip, long line, String duplicateTripId, String patternName, String firstDeparture, String lastArrival) {
-        super("trips", line, "trip_id", trip.trip_id);
+        super("trips", line, "trip_id", Priority.MEDIUM, trip.trip_id);
         this.duplicateTripId = duplicateTripId;
         this.patternName = patternName;
         this.routeId = trip.route_id;
@@ -32,9 +32,5 @@ public class DuplicateTripError extends GTFSError implements Serializable {
 
     @Override public String getMessage() {
         return String.format("Trip Ids %s & %s (route %s) are duplicates (pattern: %s, calendar: %s, from %s to %s)", duplicateTripId, affectedEntityId, routeId, patternName, serviceId, firstDeparture, lastArrival);
-    }
-
-    @Override public Priority getPriority() {
-        return Priority.MEDIUM;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/EmptyFieldError.java
+++ b/src/main/java/com/conveyal/gtfs/error/EmptyFieldError.java
@@ -9,14 +9,11 @@ public class EmptyFieldError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public EmptyFieldError(String file, long line, String field) {
-        super(file, line, field);
+        super(file, line, field, Priority.MEDIUM);
     }
 
     @Override public String getMessage() {
         return String.format("No value supplied for a required column.");
     }
 
-    @Override public Priority getPriority() {
-        return Priority.MEDIUM;
-    }
 }

--- a/src/main/java/com/conveyal/gtfs/error/EmptyTableError.java
+++ b/src/main/java/com/conveyal/gtfs/error/EmptyTableError.java
@@ -11,14 +11,10 @@ public class EmptyTableError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public EmptyTableError(String file) {
-        super(file, 0, null);
+        super(file, 0, null, Priority.MEDIUM);
     }
 
     @Override public String getMessage() {
         return String.format("Table is present in zip file, but it has no entries.");
-    }
-
-    @Override public Priority getPriority() {
-        return Priority.MEDIUM;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/GTFSError.java
+++ b/src/main/java/com/conveyal/gtfs/error/GTFSError.java
@@ -18,17 +18,19 @@ public abstract class GTFSError implements Comparable<GTFSError>, Serializable {
     public final String field;
     public final String affectedEntityId;
     public final String errorType;
+    public final Priority priority;
 
-    public GTFSError(String file, long line, String field) {
-        this(file, line, field, null);
+    public GTFSError(String file, long line, String field, Priority priority) {
+        this(file, line, field, priority, null);
     }
 
-    public GTFSError(String file, long line, String field, String affectedEntityId) {
+    public GTFSError(String file, long line, String field, Priority priority, String affectedEntityId) {
         this.file  = file;
         this.line  = line;
         this.field = field;
         this.affectedEntityId = affectedEntityId;
         this.errorType = this.getClass().getSimpleName();
+        this.priority = priority;
     }
 
     /**
@@ -40,6 +42,7 @@ public abstract class GTFSError implements Comparable<GTFSError>, Serializable {
         this.field = null;
         this.errorType = null;
         this.affectedEntityId = entityId;
+        this.priority = Priority.UNKNOWN;
     }
 
     /**
@@ -48,13 +51,6 @@ public abstract class GTFSError implements Comparable<GTFSError>, Serializable {
      */
     public final String getErrorCode () {
         return this.getClass().getSimpleName();
-    }
-
-    /**
-     * @return The Error priority level associated with this class.
-     */
-    public Priority getPriority() {
-        return Priority.UNKNOWN;
     }
 
     /**

--- a/src/main/java/com/conveyal/gtfs/error/GTFSError.java
+++ b/src/main/java/com/conveyal/gtfs/error/GTFSError.java
@@ -18,6 +18,8 @@ public abstract class GTFSError implements Comparable<GTFSError>, Serializable {
     public final String field;
     public final String affectedEntityId;
     public final String errorType;
+    // NOTE: Do not remove this field. Though this field is somewhat redundant (since every instance of each class has
+    // the same priority) we have old MapDB files around that contain serialized errors. They would all break.
     public final Priority priority;
 
     public GTFSError(String file, long line, String field, Priority priority) {

--- a/src/main/java/com/conveyal/gtfs/error/GeneralError.java
+++ b/src/main/java/com/conveyal/gtfs/error/GeneralError.java
@@ -11,7 +11,7 @@ public class GeneralError extends GTFSError implements Serializable {
     private String message;
 
     public GeneralError(String file, long line, String field, String message) {
-        super(file, line, field);
+        super(file, line, field, Priority.UNKNOWN);
         this.message = message;
     }
 
@@ -19,7 +19,4 @@ public class GeneralError extends GTFSError implements Serializable {
         return message;
     }
 
-    @Override public Priority getPriority() {
-        return Priority.UNKNOWN;
-    }
 }

--- a/src/main/java/com/conveyal/gtfs/error/MisplacedStopError.java
+++ b/src/main/java/com/conveyal/gtfs/error/MisplacedStopError.java
@@ -11,18 +11,16 @@ import java.io.Serializable;
 public class MisplacedStopError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
+    public final Priority priority;
     public final Stop stop;
 
     public MisplacedStopError(String affectedEntityId, long line, Stop stop) {
-        super("stops", line, "stop_id", affectedEntityId);
+        super("stops", line, "stop_id", Priority.MEDIUM, affectedEntityId);
+        this.priority = Priority.HIGH;
         this.stop = stop;
     }
 
     @Override public String getMessage() {
         return String.format("Stop Id %s is misplaced.", affectedEntityId);
-    }
-
-    @Override public Priority getPriority() {
-        return Priority.MEDIUM;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/MissingColumnError.java
+++ b/src/main/java/com/conveyal/gtfs/error/MissingColumnError.java
@@ -9,14 +9,11 @@ public class MissingColumnError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public MissingColumnError(String file, String field) {
-        super(file, 1, field);
+        super(file, 1, field, Priority.MEDIUM);
     }
 
     @Override public String getMessage() {
         return String.format("Missing required column.");
     }
 
-    @Override public Priority getPriority() {
-        return Priority.MEDIUM;
-    }
 }

--- a/src/main/java/com/conveyal/gtfs/error/MissingShapeError.java
+++ b/src/main/java/com/conveyal/gtfs/error/MissingShapeError.java
@@ -12,14 +12,10 @@ public class MissingShapeError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public MissingShapeError(Trip trip) {
-        super("trips", trip.sourceFileLine, "shape_id", trip.trip_id);
+        super("trips", trip.sourceFileLine, "shape_id", Priority.LOW, trip.trip_id);
     }
 
     @Override public String getMessage() {
         return "Trip " + affectedEntityId + " is missing a shape";
-    }
-
-    @Override public Priority getPriority() {
-        return Priority.LOW;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/MissingTableError.java
+++ b/src/main/java/com/conveyal/gtfs/error/MissingTableError.java
@@ -9,14 +9,11 @@ public class MissingTableError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public MissingTableError(String file) {
-        super(file, 0, null);
+        super(file, 0, null, Priority.MEDIUM);
     }
 
     @Override public String getMessage() {
         return String.format("This table is required by the GTFS specification but is missing.");
     }
 
-    @Override public Priority getPriority() {
-        return Priority.MEDIUM;
-    }
 }

--- a/src/main/java/com/conveyal/gtfs/error/NoAgencyInFeedError.java
+++ b/src/main/java/com/conveyal/gtfs/error/NoAgencyInFeedError.java
@@ -7,14 +7,10 @@ import com.conveyal.gtfs.validator.model.Priority;
  */
 public class NoAgencyInFeedError extends GTFSError {
     public NoAgencyInFeedError() {
-        super("agency", 0, "agency_id");
+        super("agency", 0, "agency_id", Priority.HIGH);
     }
 
     @Override public String getMessage() {
         return String.format("No agency listed in feed (must have at least one).");
-    }
-
-    @Override public Priority getPriority() {
-        return Priority.HIGH;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/NumberParseError.java
+++ b/src/main/java/com/conveyal/gtfs/error/NumberParseError.java
@@ -9,14 +9,11 @@ public class NumberParseError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public NumberParseError(String file, long line, String field) {
-        super(file, line, field);
+        super(file, line, field, Priority.HIGH);
     }
 
     @Override public String getMessage() {
         return String.format("Error parsing a number from a string.");
     }
 
-    @Override public Priority getPriority() {
-        return Priority.HIGH;
-    }
 }

--- a/src/main/java/com/conveyal/gtfs/error/OverlappingTripsInBlockError.java
+++ b/src/main/java/com/conveyal/gtfs/error/OverlappingTripsInBlockError.java
@@ -15,16 +15,12 @@ public class OverlappingTripsInBlockError extends GTFSError implements Serializa
     public final String routeId;
 
     public OverlappingTripsInBlockError(long line, String field, String affectedEntityId, String routeId, String[] tripIds) {
-        super("trips", line, field, affectedEntityId);
+        super("trips", line, field, Priority.MEDIUM, affectedEntityId);
         this.tripIds = tripIds;
         this.routeId = routeId;
     }
 
     @Override public String getMessage() {
         return String.format("Trip Ids %s overlap (route: %s) and share block ID %s", String.join(" & ", tripIds), routeId, affectedEntityId);
-    }
-
-    @Override public Priority getPriority() {
-        return Priority.MEDIUM;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/RangeError.java
+++ b/src/main/java/com/conveyal/gtfs/error/RangeError.java
@@ -11,7 +11,7 @@ public class RangeError extends GTFSError implements Serializable {
     final double min, max, actual;
 
     public RangeError(String file, long line, String field, double min, double max, double actual) {
-        super(file, line, field);
+        super(file, line, field, Priority.LOW);
         this.min = min;
         this.max = max;
         this.actual = actual;
@@ -21,7 +21,4 @@ public class RangeError extends GTFSError implements Serializable {
         return String.format("Number %s outside of acceptable range [%s,%s].", actual, min, max);
     }
 
-    @Override public Priority getPriority() {
-        return Priority.LOW;
-    }
 }

--- a/src/main/java/com/conveyal/gtfs/error/ReferentialIntegrityError.java
+++ b/src/main/java/com/conveyal/gtfs/error/ReferentialIntegrityError.java
@@ -12,7 +12,7 @@ public class ReferentialIntegrityError extends GTFSError implements Serializable
     public final String badReference;
 
     public ReferentialIntegrityError(String tableName, long row, String field, String badReference) {
-        super(tableName, row, field);
+        super(tableName, row, field, Priority.HIGH);
         this.badReference = badReference;
     }
 
@@ -26,9 +26,5 @@ public class ReferentialIntegrityError extends GTFSError implements Serializable
 
     @Override public String getMessage() {
         return String.format(badReference);
-    }
-
-    @Override public Priority getPriority() {
-        return Priority.HIGH;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/ReversedTripShapeError.java
+++ b/src/main/java/com/conveyal/gtfs/error/ReversedTripShapeError.java
@@ -14,15 +14,11 @@ public class ReversedTripShapeError extends GTFSError implements Serializable {
     public final String shapeId;
 
     public ReversedTripShapeError(Trip trip) {
-        super("trips", trip.sourceFileLine, "shape_id", trip.trip_id);
+        super("trips", trip.sourceFileLine, "shape_id", Priority.HIGH, trip.trip_id);
         this.shapeId = trip.shape_id;
     }
 
     @Override public String getMessage() {
         return "Trip " + affectedEntityId + " references reversed shape " + shapeId;
-    }
-
-    @Override public Priority getPriority() {
-        return Priority.HIGH;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/ShapeMissingCoordinatesError.java
+++ b/src/main/java/com/conveyal/gtfs/error/ShapeMissingCoordinatesError.java
@@ -14,15 +14,11 @@ public class ShapeMissingCoordinatesError extends GTFSError implements Serializa
     public final String[] tripIds;
 
     public ShapeMissingCoordinatesError(ShapePoint shapePoint, String[] tripIds) {
-        super("shapes", shapePoint.sourceFileLine, "shape_id", shapePoint.shape_id);
+        super("shapes", shapePoint.sourceFileLine, "shape_id", Priority.MEDIUM, shapePoint.shape_id);
         this.tripIds = tripIds;
     }
 
     @Override public String getMessage() {
         return "Shape " + affectedEntityId + " is missing coordinates (affects " + tripIds.length + " trips)";
-    }
-
-    @Override public Priority getPriority() {
-        return Priority.MEDIUM;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/TableInSubdirectoryError.java
+++ b/src/main/java/com/conveyal/gtfs/error/TableInSubdirectoryError.java
@@ -13,15 +13,11 @@ public class TableInSubdirectoryError extends GTFSError implements Serializable 
     public final String directory;
 
     public TableInSubdirectoryError(String file, String directory) {
-        super(file, 0, null);
+        super(file, 0, null, Priority.HIGH);
         this.directory = directory;
     }
 
     @Override public String getMessage() {
         return String.format("All GTFS files (including %s.txt) should be at root of zipfile, not nested in subdirectory (%s)", file, directory);
-    }
-
-    @Override public Priority getPriority() {
-        return Priority.HIGH;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/TimeParseError.java
+++ b/src/main/java/com/conveyal/gtfs/error/TimeParseError.java
@@ -9,14 +9,11 @@ public class TimeParseError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public TimeParseError(String file, long line, String field) {
-        super(file, line, field);
+        super(file, line, field, Priority.MEDIUM);
     }
 
     @Override public String getMessage() {
         return "Could not parse time (format should be HH:MM:SS).";
     }
 
-    @Override public Priority getPriority() {
-        return Priority.MEDIUM;
-    }
 }

--- a/src/main/java/com/conveyal/gtfs/error/TimeZoneError.java
+++ b/src/main/java/com/conveyal/gtfs/error/TimeZoneError.java
@@ -22,15 +22,11 @@ public class TimeZoneError extends GTFSError implements Serializable {
      * @param message description of issue with timezone reference
      */
     public TimeZoneError(String tableName, long line, String field, String affectedEntityId, String message) {
-        super(tableName, line, field, affectedEntityId);
+        super(tableName, line, field, Priority.MEDIUM, affectedEntityId);
         this.message = message;
     }
 
     @Override public String getMessage() {
         return message + ". (" + field + ": " + affectedEntityId + ")";
-    }
-
-    @Override public Priority getPriority() {
-        return Priority.MEDIUM;
     }
 }

--- a/src/main/java/com/conveyal/gtfs/error/URLParseError.java
+++ b/src/main/java/com/conveyal/gtfs/error/URLParseError.java
@@ -9,14 +9,11 @@ public class URLParseError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public URLParseError(String file, long line, String field) {
-        super(file, line, field);
+        super(file, line, field, Priority.LOW);
     }
 
     @Override public String getMessage() {
         return "Could not parse URL (format should be <scheme>://<authority><path>?<query>#<fragment>).";
     }
 
-    @Override public Priority getPriority() {
-        return Priority.LOW;
-    }
 }

--- a/src/main/java/com/conveyal/gtfs/error/UnusedStopError.java
+++ b/src/main/java/com/conveyal/gtfs/error/UnusedStopError.java
@@ -12,15 +12,11 @@ public class UnusedStopError extends GTFSError implements Serializable {
     public final Stop stop;
 
     public UnusedStopError(Stop stop) {
-        super("stops", stop.sourceFileLine, "stop_id", stop.stop_id);
+        super("stops", stop.sourceFileLine, "stop_id", Priority.LOW, stop.stop_id);
         this.stop = stop;
     }
 
     @Override public String getMessage() {
         return String.format("Stop Id %s is not used in any trips.", affectedEntityId);
-    }
-
-    @Override public Priority getPriority() {
-        return Priority.LOW;
     }
 }


### PR DESCRIPTION
This fixes a bug where pre-existing gtfs MapDB files could not be read, because they contained serialized errors with a priority field. The changed class did not have this field, causing a failure. We could have deleted and rebuilt all these database files, but then they'd be unreadable by older workers. We could also save new and old formats under different file names, but introducing multiple file format versions doesn't seem worthwhile for such a trivial difference. In any case, all new GTFS MapDB files will have an empty errors table.