### PR TITLE
Add variant index check

### DIFF
--- a/src/main/java/com/conveyal/analysis/models/AnalysisRequest.java
+++ b/src/main/java/com/conveyal/analysis/models/AnalysisRequest.java
@@ -186,6 +186,9 @@ public class AnalysisRequest {
         List<Modification> modifications = new ArrayList<>();
         String scenarioName;
         if (variantIndex > -1) {
+            if (variantIndex >= project.variants.length) {
+                throw AnalysisServerException.badRequest("Scenario does not exist. Please select a new scenario.");
+            }
             modifications = modificationsForProject(project.accessGroup, projectId, variantIndex);
             scenarioName = project.variants[variantIndex];
         } else {


### PR DESCRIPTION
Users are seeing index out of bounds exceptions if they request an analysis using a deleted scenario. This add's a check on the backend to surface a clearer error when this occurs.

A corresponding front end change set will attempt to address the issue on the client side also.