### PR TITLE
Grid cleanup

### DIFF
--- a/src/main/java/com/conveyal/analysis/SelectingGridReducer.java
+++ b/src/main/java/com/conveyal/analysis/SelectingGridReducer.java
@@ -63,7 +63,7 @@ public class SelectingGridReducer {
         // median travel time.
         int nSamples = input.readInt();
 
-        Grid outputGrid = new Grid(zoom, width, height, north, west);
+        Grid outputGrid = new Grid(west, north, width, height, zoom);
 
         int[] valuesThisOrigin = new int[nSamples];
 

--- a/src/main/java/com/conveyal/analysis/SelectingGridReducer.java
+++ b/src/main/java/com/conveyal/analysis/SelectingGridReducer.java
@@ -20,7 +20,6 @@ import java.util.zip.GZIPInputStream;
  * When storing bootstrap replications of travel time, we also store the point estimate (using all Monte Carlo draws
  * equally weighted) as the first value, so a SelectingGridReducer(0) can be used to retrieve the point estimate.
  *
- * This class is not referenced within R5, but is used by the Analysis front end.
  */
 public class SelectingGridReducer {
 

--- a/src/main/java/com/conveyal/analysis/controllers/OpportunityDatasetController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/OpportunityDatasetController.java
@@ -415,6 +415,8 @@ public class OpportunityDatasetController implements HttpController {
     private void verifyBaseNamesSame (List<FileItem> fileItems) {
         String firstBaseName = null;
         for (FileItem fileItem : fileItems) {
+            // Ignore .shp.xml files
+            if (FilenameUtils.getExtension(fileItem.getName()).equals(".xml")) continue;
             String baseName = FilenameUtils.getBaseName(fileItem.getName());
             if (firstBaseName == null) {
                 firstBaseName = baseName;

--- a/src/main/java/com/conveyal/analysis/controllers/OpportunityDatasetController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/OpportunityDatasetController.java
@@ -415,8 +415,8 @@ public class OpportunityDatasetController implements HttpController {
     private void verifyBaseNamesSame (List<FileItem> fileItems) {
         String firstBaseName = null;
         for (FileItem fileItem : fileItems) {
-            // Ignore .shp.xml files
-            if (FilenameUtils.getExtension(fileItem.getName()).equals(".xml")) continue;
+            // Ignore .shp.xml files, which will fail the verifyBaseNamesSame check
+            if ("xml".equalsIgnoreCase(FilenameUtils.getExtension(fileItem.getName()))) continue;
             String baseName = FilenameUtils.getBaseName(fileItem.getName());
             if (firstBaseName == null) {
                 firstBaseName = baseName;

--- a/src/main/java/com/conveyal/analysis/models/AnalysisRequest.java
+++ b/src/main/java/com/conveyal/analysis/models/AnalysisRequest.java
@@ -2,7 +2,6 @@ package com.conveyal.analysis.models;
 
 import com.conveyal.analysis.AnalysisServerException;
 import com.conveyal.analysis.persistence.Persistence;
-import com.conveyal.r5.analyst.Grid;
 import com.conveyal.r5.analyst.WebMercatorExtents;
 import com.conveyal.r5.analyst.cluster.AnalysisWorkerTask;
 import com.conveyal.r5.analyst.decay.DecayFunction;
@@ -229,7 +228,7 @@ public class AnalysisRequest {
         //      Also include getIndex(x, y), getX(index), getY(index), totalTasks()
 
         WebMercatorExtents extents = WebMercatorExtents.forWgsEnvelope(bounds.envelope(), zoom);
-        checkZoom(extents);
+        checkGridSize(extents);
         task.height = extents.height;
         task.north = extents.north;
         task.west = extents.west;
@@ -287,7 +286,7 @@ public class AnalysisRequest {
         return task;
     }
 
-    private static void checkZoom(WebMercatorExtents extents) {
+    private static void checkGridSize (WebMercatorExtents extents) {
         if (extents.zoom < MIN_ZOOM || extents.zoom > MAX_ZOOM) {
             throw AnalysisServerException.badRequest(String.format(
                     "Requested zoom (%s) is outside valid range (%s - %s)", extents.zoom, MIN_ZOOM, MAX_ZOOM

--- a/src/main/java/com/conveyal/analysis/models/AnalysisRequest.java
+++ b/src/main/java/com/conveyal/analysis/models/AnalysisRequest.java
@@ -3,6 +3,7 @@ package com.conveyal.analysis.models;
 import com.conveyal.analysis.AnalysisServerException;
 import com.conveyal.analysis.persistence.Persistence;
 import com.conveyal.r5.analyst.Grid;
+import com.conveyal.r5.analyst.WebMercatorExtents;
 import com.conveyal.r5.analyst.cluster.AnalysisWorkerTask;
 import com.conveyal.r5.analyst.decay.DecayFunction;
 import com.conveyal.r5.analyst.decay.StepDecayFunction;
@@ -227,12 +228,12 @@ public class AnalysisRequest {
         // TODO define class with static factory function WebMercatorGridBounds.fromLatLonBounds().
         //      Also include getIndex(x, y), getX(index), getY(index), totalTasks()
 
-        Grid grid = new Grid(zoom, bounds.envelope());
-        checkZoom(grid);
-        task.height = grid.height;
-        task.north = grid.north;
-        task.west = grid.west;
-        task.width = grid.width;
+        WebMercatorExtents extents = WebMercatorExtents.forWgsEnvelope(bounds.envelope(), zoom);
+        checkZoom(extents);
+        task.height = extents.height;
+        task.north = extents.north;
+        task.west = extents.west;
+        task.width = extents.width;
         task.zoom = zoom;
 
         task.date = date;
@@ -286,17 +287,17 @@ public class AnalysisRequest {
         return task;
     }
 
-    private static void checkZoom(Grid grid) {
-        if (grid.zoom < MIN_ZOOM || grid.zoom > MAX_ZOOM) {
+    private static void checkZoom(WebMercatorExtents extents) {
+        if (extents.zoom < MIN_ZOOM || extents.zoom > MAX_ZOOM) {
             throw AnalysisServerException.badRequest(String.format(
-                    "Requested zoom (%s) is outside valid range (%s - %s)", grid.zoom, MIN_ZOOM, MAX_ZOOM
+                    "Requested zoom (%s) is outside valid range (%s - %s)", extents.zoom, MIN_ZOOM, MAX_ZOOM
             ));
         }
-        if (grid.height * grid.width > MAX_GRID_CELLS) {
+        if (extents.height * extents.width > MAX_GRID_CELLS) {
             throw AnalysisServerException.badRequest(String.format(
                     "Requested number of destinations (%s) exceeds limit (%s). " +
                             "Set smaller custom geographic bounds or a lower zoom level.",
-                            grid.height * grid.width, MAX_GRID_CELLS
+                            extents.height * extents.width, MAX_GRID_CELLS
             ));
         }
     }

--- a/src/main/java/com/conveyal/analysis/persistence/AnalysisCollection.java
+++ b/src/main/java/com/conveyal/analysis/persistence/AnalysisCollection.java
@@ -67,7 +67,7 @@ public class AnalysisCollection<T extends BaseModel> {
         newModel.createdBy = creatorEmail;
         newModel.updatedBy = creatorEmail;
 
-        // This creates the `_id` automatically
+        // This creates the `_id` automatically if it is missing
         collection.insertOne(newModel);
 
         return newModel;

--- a/src/main/java/com/conveyal/analysis/persistence/AnalysisDB.java
+++ b/src/main/java/com/conveyal/analysis/persistence/AnalysisDB.java
@@ -35,7 +35,7 @@ public class AnalysisDB {
 
         database = mongo.getDatabase(config.databaseName()).withCodecRegistry(pojoCodecRegistry);
 
-        // Reqeust that the JVM clean up database connections in all cases - exiting cleanly or by being terminated.
+        // Request that the JVM clean up database connections in all cases - exiting cleanly or by being terminated.
         // We should probably register such hooks for other components to shut down more cleanly.
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             Persistence.mongo.close();

--- a/src/main/java/com/conveyal/analysis/persistence/MongoMap.java
+++ b/src/main/java/com/conveyal/analysis/persistence/MongoMap.java
@@ -170,7 +170,7 @@ public class MongoMap<V extends Model> {
     }
 
     public V put(String key, V value) {
-        if (key != value._id) throw AnalysisServerException.badRequest("ID does not match");
+        if (!key.equals(value._id)) throw AnalysisServerException.badRequest("ID does not match");
         return put(value, null);
     }
 

--- a/src/main/java/com/conveyal/r5/analyst/BootstrappingTravelTimeReducer.java
+++ b/src/main/java/com/conveyal/r5/analyst/BootstrappingTravelTimeReducer.java
@@ -65,8 +65,8 @@ public class BootstrappingTravelTimeReducer {
         // We use the size of the grid to determine the number of destinations used in the linked point set in
         // TravelTimeComputer, therefore the target indices are relative to the grid, not the task.
         // TODO verify that the above is still accurate
-        int gridx = target % grid.width;
-        int gridy = target / grid.width;
+        int gridx = target % grid.extents.width;
+        int gridy = target / grid.extents.width;
         double opportunityCountAtTarget = grid.grid[gridx][gridy];
 
         // As an optimization, don't even bother to check whether cells that contain no opportunities are reachable.

--- a/src/main/java/com/conveyal/r5/analyst/Grid.java
+++ b/src/main/java/com/conveyal/r5/analyst/Grid.java
@@ -101,7 +101,7 @@ public class Grid extends PointSet {
 
     /** Limit on number of pixels, to prevent OOME when multiple large grids are being created (width * height *
      * number of layers/attributes) */
-    private static final int MAX_PIXELS = 100_000_000 * 10;
+    private static final int MAX_PIXELS = 10_000 * 10_000 * 10;
 
     /** Used when reading a saved grid. */
     public Grid (int zoom, int width, int height, int north, int west) {
@@ -504,8 +504,8 @@ public class Grid extends PointSet {
     }
 
     /**
-     * Given a pixel's local coordinates in the supplied WebMercatorExtents, return its geometry in absolute (world)
-     * coordinates
+     * Given a pixel's local grid coordinates within the supplied WebMercatorExtents, return a closed
+     * polygon of that pixel's outline in WGS84 global geographic coordinates.
      * @param localX x pixel number within the given extents.
      * @param localY y pixel number within the given extents.
      * @return a JTS Polygon in WGS84 coordinates for the given pixel.

--- a/src/main/java/com/conveyal/r5/analyst/Grid.java
+++ b/src/main/java/com/conveyal/r5/analyst/Grid.java
@@ -114,9 +114,7 @@ public class Grid extends PointSet {
      * @param wgsEnvelope Envelope of grid, in absolute WGS84 lat/lon coordinates
      */
     public Grid (int zoom, Envelope wgsEnvelope) {
-        WebMercatorExtents extents = WebMercatorExtents.forWgsEnvelope(wgsEnvelope, zoom);
-        this.extents = extents;
-        this.grid = new double[extents.width][extents.height];
+        this(WebMercatorExtents.forWgsEnvelope(wgsEnvelope, zoom));
     }
 
     public static class PixelWeight {

--- a/src/main/java/com/conveyal/r5/analyst/Grid.java
+++ b/src/main/java/com/conveyal/r5/analyst/Grid.java
@@ -34,7 +34,6 @@ import org.locationtech.jts.geom.prep.PreparedPolygon;
 import org.opengis.feature.Property;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
-import org.opengis.feature.type.AttributeDescriptor;
 import org.opengis.parameter.GeneralParameterValue;
 import org.opengis.parameter.ParameterValueGroup;
 import org.opengis.referencing.FactoryException;
@@ -104,7 +103,7 @@ public class Grid extends PointSet {
     private static final int MAX_PIXELS = 10_000 * 10_000 * 10;
 
     /** Used when reading a saved grid. */
-    public Grid (int zoom, int width, int height, int north, int west) {
+    public Grid (int west, int north, int width, int height, int zoom) {
         this(new WebMercatorExtents(west, north, width, height, zoom));
     }
 
@@ -343,7 +342,7 @@ public class Grid extends PointSet {
         int width = data.readInt();
         int height = data.readInt();
 
-        Grid grid = new Grid(zoom, width, height, north, west);
+        Grid grid = new Grid(west, north, width, height, zoom);
 
         // loop in row-major order
         for (int y = 0, value = 0; y < height; y++) {

--- a/src/main/java/com/conveyal/r5/analyst/Grid.java
+++ b/src/main/java/com/conveyal/r5/analyst/Grid.java
@@ -584,11 +584,11 @@ public class Grid extends PointSet {
             for (Iterator<String> it = numericColumns.iterator(); it.hasNext();) {
                 String field = it.next();
                 String value = reader.get(field);
-                if (value == null || "".equals(value)) continue; // allow missing data
+                if (value == null || "".equals(value)) continue; // allow missing data TODO add "N/A" etc.?
                 try {
                     double dv = parseDouble(value);
                     if (!(Double.isFinite(dv) || dv < 0)) {
-                        it.remove();
+                        it.remove(); // TODO track removed columns and report to UI?
                     }
                 } catch (NumberFormatException e) {
                     it.remove();
@@ -599,9 +599,6 @@ public class Grid extends PointSet {
         // This will also close the InputStreams.
         reader.close();
 
-        if (numericColumns.isEmpty()) {
-            throw new IllegalArgumentException("CSV file contained no entirely finite, non-negative numeric columns.");
-        }
         checkWgsEnvelopeSize(envelope);
         WebMercatorExtents extents = WebMercatorExtents.forWgsEnvelope(envelope, zoom);
         checkPixelCount(extents, numericColumns.size());

--- a/src/main/java/com/conveyal/r5/analyst/GridTransformWrapper.java
+++ b/src/main/java/com/conveyal/r5/analyst/GridTransformWrapper.java
@@ -26,7 +26,7 @@ public class GridTransformWrapper extends PointSet {
      * targetGrid cannot be indexed so are effectively zero for the purpose of accessibility calculations.
      */
     public GridTransformWrapper (WebMercatorExtents targetGridExtents, Grid sourceGrid) {
-        checkArgument(targetGridExtents.zoom == sourceGrid.zoom, "Zoom levels must be identical.");
+        checkArgument(targetGridExtents.zoom == sourceGrid.extents.zoom, "Zoom levels must be identical.");
         // Make a pointset for these extents so we can defer to its methods for lat/lon lookup, size, etc.
         this.targetGrid = new WebMercatorGridPointSet(targetGridExtents);
         this.sourceGrid = sourceGrid;
@@ -37,13 +37,13 @@ public class GridTransformWrapper extends PointSet {
     // This could certainly be made more efficient (but complex) by forcing sequential iteration over opportunity counts
     // and disallowing random access, using a new PointSetIterator class that allows reading lat, lon, and counts.
     private int transformIndex (int i) {
-        final int x = (i % targetGrid.width) + targetGrid.west - sourceGrid.west;
-        final int y = (i / targetGrid.width) + targetGrid.north - sourceGrid.north;
-        if (x < 0 || x >= sourceGrid.width || y < 0 || y >= sourceGrid.height) {
+        final int x = (i % targetGrid.width) + targetGrid.west - sourceGrid.extents.west;
+        final int y = (i / targetGrid.width) + targetGrid.north - sourceGrid.extents.north;
+        if (x < 0 || x >= sourceGrid.extents.width || y < 0 || y >= sourceGrid.extents.height) {
             // Point in target grid lies outside source grid, there is no valid index. Return special value.
             return -1;
         }
-        return y * sourceGrid.width + x;
+        return y * sourceGrid.extents.width + x;
     }
 
     @Override

--- a/src/main/java/com/conveyal/r5/analyst/WebMercatorExtents.java
+++ b/src/main/java/com/conveyal/r5/analyst/WebMercatorExtents.java
@@ -26,10 +26,22 @@ import static com.google.common.base.Preconditions.checkState;
  */
 public class WebMercatorExtents {
 
+    /** The pixel number of the westernmost pixel (smallest x value). */
     public final int west;
+
+    /**
+     * The pixel number of the northernmost pixel (smallest y value in web Mercator, because y increases from north to
+     * south in web Mercator).
+     */
     public final int north;
+
+    /** Width in web Mercator pixels */
     public final int width;
+
+    /** Height in web Mercator pixels */
     public final int height;
+
+    /** Web mercator zoom level. */
     public final int zoom;
 
     public WebMercatorExtents (int west, int north, int width, int height, int zoom) {

--- a/src/main/java/com/conveyal/r5/util/ShapefileReader.java
+++ b/src/main/java/com/conveyal/r5/util/ShapefileReader.java
@@ -96,11 +96,8 @@ public class ShapefileReader {
         return features.getSchema()
                 .getAttributeDescriptors()
                 .stream()
-                .filter(d -> {
-                    AttributeType type = d.getType().getSuper();
-                    return type != null && type.getBinding().equals(Number.class);
-                })
-                .map(d -> d.getLocalName())
+                .filter(d -> Number.class.isInstance(d.getType().getBinding()))
+                .map(AttributeDescriptor::getLocalName)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/conveyal/r5/util/ShapefileReader.java
+++ b/src/main/java/com/conveyal/r5/util/ShapefileReader.java
@@ -14,7 +14,6 @@ import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
-import org.opengis.feature.type.AttributeDescriptor;
 import org.opengis.feature.type.AttributeType;
 import org.opengis.filter.Filter;
 import org.opengis.referencing.FactoryException;
@@ -24,7 +23,6 @@ import org.opengis.referencing.operation.TransformException;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;

--- a/src/main/java/com/conveyal/r5/util/ShapefileReader.java
+++ b/src/main/java/com/conveyal/r5/util/ShapefileReader.java
@@ -14,6 +14,8 @@ import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.AttributeDescriptor;
+import org.opengis.feature.type.AttributeType;
 import org.opengis.filter.Filter;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
@@ -22,11 +24,14 @@ import org.opengis.referencing.operation.TransformException;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Spliterator;
 import java.util.Spliterators;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -87,6 +92,18 @@ public class ShapefileReader {
 
     public ReferencedEnvelope getBounds () throws IOException {
         return source.getBounds();
+    }
+
+    public List<String> numericAttributes () {
+        return features.getSchema()
+                .getAttributeDescriptors()
+                .stream()
+                .filter(d -> {
+                    AttributeType type = d.getType().getSuper();
+                    return type != null && type.getBinding().equals(Number.class);
+                })
+                .map(d -> d.getLocalName())
+                .collect(Collectors.toList());
     }
 
     public double getAreaSqKm () throws IOException, TransformException, FactoryException {

--- a/src/main/java/com/conveyal/r5/util/ShapefileReader.java
+++ b/src/main/java/com/conveyal/r5/util/ShapefileReader.java
@@ -14,6 +14,7 @@ import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.AttributeDescriptor;
 import org.opengis.feature.type.AttributeType;
 import org.opengis.filter.Filter;
 import org.opengis.referencing.FactoryException;

--- a/src/test/java/com/conveyal/r5/analyst/GridTest.java
+++ b/src/test/java/com/conveyal/r5/analyst/GridTest.java
@@ -13,6 +13,7 @@ import java.util.Random;
 import java.util.stream.DoubleStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for the Grid class, which holds destination counts in tiled spherical mercator pixels.
@@ -107,8 +108,8 @@ public class GridTest {
         int height = random.nextInt(MAX_GRID_WIDTH_PIXELS) + 1;
 
         Grid grid = new Grid(zoom, width, height, north, west);
-        for (int y = 0; y < grid.height; y++) {
-            for (int x = 0; x < grid.width; x++) {
+        for (int y = 0; y < grid.extents.height; y++) {
+            for (int x = 0; x < grid.extents.width; x++) {
                 double amount = random.nextDouble() * MAX_AMOUNT;
                 if (wholeNumbersOnly) {
                     amount = Math.round(amount);
@@ -121,11 +122,7 @@ public class GridTest {
 
     private static void assertGridSemanticEquals(Grid g1, Grid g2, boolean tolerateRounding) {
         // Note that the name field is excluded because it does not survive serialization.
-        assertEquals(g1.zoom, g2.zoom);
-        assertEquals(g1.north, g2.north);
-        assertEquals(g1.west, g2.west);
-        assertEquals(g1.width, g2.width);
-        assertEquals(g1.height, g2.height);
+        assertTrue(g1.hasEqualExtents(g2));
         assertArrayEquals(g1.grid, g2.grid, tolerateRounding);
     }
 

--- a/src/test/java/com/conveyal/r5/analyst/GridTest.java
+++ b/src/test/java/com/conveyal/r5/analyst/GridTest.java
@@ -7,10 +7,8 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
-import java.util.stream.DoubleStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -32,7 +30,7 @@ public class GridTest {
         int zoom = 4;
         int xTile = 14;
         int yTile = 9;
-        Grid grid = new Grid(zoom, 256, 256, 256 * yTile, 256 * xTile);
+        Grid grid = new Grid(256 * xTile, 256 * yTile, 256, 256, zoom);
         ReferencedEnvelope envelope = grid.getWebMercatorExtents().getMercatorEnvelopeMeters();
         assertEquals(15028131.257091936, envelope.getMinX(), 0.1);
         assertEquals(-5009377.085697312, envelope.getMinY(), 0.1);
@@ -43,7 +41,7 @@ public class GridTest {
         zoom = 5;
         xTile = 16;
         yTile = 11;
-        grid = new Grid(zoom, 256, 256, 256 * yTile, 256 * xTile);
+        grid = new Grid(256 * xTile, 256 * yTile, 256, 256, zoom);
         envelope = grid.getWebMercatorExtents().getMercatorEnvelopeMeters();
         assertEquals(0, envelope.getMinX(), 0.1);
         assertEquals(5009377.085697312, envelope.getMinY(), 0.1);
@@ -107,7 +105,7 @@ public class GridTest {
         int width = random.nextInt(MAX_GRID_WIDTH_PIXELS) + 1;
         int height = random.nextInt(MAX_GRID_WIDTH_PIXELS) + 1;
 
-        Grid grid = new Grid(zoom, width, height, north, west);
+        Grid grid = new Grid(west, north, width, height, zoom);
         for (int y = 0; y < grid.extents.height; y++) {
             for (int x = 0; x < grid.extents.width; x++) {
                 double amount = random.nextDouble() * MAX_AMOUNT;

--- a/src/test/java/com/conveyal/r5/analyst/GridTransformWrapperTest.java
+++ b/src/test/java/com/conveyal/r5/analyst/GridTransformWrapperTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -18,11 +17,11 @@ class GridTransformWrapperTest {
     void testTwoAdjacentGrids () {
 
         // Two grids side by side, right one bigger than than the left, with top 20 pixels lower
-        Grid leftGrid = new Grid(10, 200, 300, 1000, 2000);
-        Grid rightGrid = new Grid(10, 300, 400, 1020, 2200);
+        Grid leftGrid = new Grid(2000, 1000, 200, 300, 10);
+        Grid rightGrid = new Grid(2200, 1020, 300, 400, 10);
 
         // One minimum bounding grid exactly encompassing the other two.
-        Grid superGrid = new Grid(10, 500, 400, 1000, 2000);
+        Grid superGrid = new Grid(2000, 1000, 500, 400, 10);
 
         // Make a column of pixel weights 2 pixels wide and 26 pixels high.
         List<Grid.PixelWeight> weights = new ArrayList<>();

--- a/src/test/java/com/conveyal/r5/analyst/network/GridSinglePointTaskBuilder.java
+++ b/src/test/java/com/conveyal/r5/analyst/network/GridSinglePointTaskBuilder.java
@@ -102,11 +102,11 @@ public class GridSinglePointTaskBuilder {
 
         // In a single point task, the grid of destinations is given with these fields, not from the pointset object.
         // The destination point set (containing the opportunity densities) must then match these same dimensions.
-        task.zoom = grid.zoom;
-        task.north = grid.north;
-        task.west = grid.west;
-        task.width = grid.width;
-        task.height = grid.height;
+        task.zoom = grid.extents.zoom;
+        task.north = grid.extents.north;
+        task.west = grid.extents.west;
+        task.width = grid.extents.width;
+        task.height = grid.extents.height;
 
         return this;
     }


### PR DESCRIPTION
Changes in this PR:
* Store a reference to a `WebMercatorExtents` in grids, instead of inlining the fields
* Impose a limit on (grid size * number of attributes), to avoid exhausting memory (see #727)
* Check for duplicate attributes in shapefile upload
* Allow upload of CSV files with no numeric attributes
* Ignore .xml files in shapefile uploads (because users would occasionally upload .shp.xml files that would cause fail the `verifyBaseNamesSame` check)
* Fix a string equality check
* Clean up a few miscellaneous comments/imports