### PR TITLE
File and logging tweaks

### DIFF
--- a/.github/workflows/cypress-integration.yml
+++ b/.github/workflows/cypress-integration.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: conveyal/analysis-ui
-          ref: a869cd11919343a163e110e812b5d27f3a4ad4c8
+          ref: ed2c18444864e537daeda0d82f208d6a295625b0
           path: ui
       - uses: actions/checkout@v2
         with:

--- a/src/main/java/com/conveyal/analysis/AnalysisServerException.java
+++ b/src/main/java/com/conveyal/analysis/AnalysisServerException.java
@@ -60,6 +60,8 @@ public class AnalysisServerException extends RuntimeException {
         return new AnalysisServerException(Type.NOT_FOUND, message, 404);
     }
 
+    // Note that there is a naming mistake in the HTTP codes. 401 "unauthorized" actually means "unauthenticated".
+    // 403 "forbidden" is what is usually referred to as "unauthorized" in other contexts.
     public static AnalysisServerException unauthorized(String message) {
         return new AnalysisServerException(Type.UNAUTHORIZED, message, 401);
     }

--- a/src/main/java/com/conveyal/analysis/components/HttpApi.java
+++ b/src/main/java/com/conveyal/analysis/components/HttpApi.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import static com.conveyal.analysis.AnalysisServerException.Type.BAD_REQUEST;
 import static com.conveyal.analysis.AnalysisServerException.Type.RUNTIME;
+import static com.conveyal.analysis.AnalysisServerException.Type.UNAUTHORIZED;
 import static com.conveyal.analysis.AnalysisServerException.Type.UNKNOWN;
 
 /**

--- a/src/main/java/com/conveyal/analysis/components/HttpApi.java
+++ b/src/main/java/com/conveyal/analysis/components/HttpApi.java
@@ -163,7 +163,7 @@ public class HttpApi implements Component {
                                     AnalysisServerException.Type type, String message, int code) {
 
         // Stacktrace in ErrorEvent reused below to avoid repeatedly generating String of stacktrace.
-        ErrorEvent errorEvent = new ErrorEvent(e);
+        ErrorEvent errorEvent = new ErrorEvent(e, request.pathInfo());
         eventBus.send(errorEvent.forUser(request.attribute(USER_PERMISSIONS_ATTRIBUTE)));
 
         JSONObject body = new JSONObject();

--- a/src/main/java/com/conveyal/analysis/components/eventbus/ErrorEvent.java
+++ b/src/main/java/com/conveyal/analysis/components/eventbus/ErrorEvent.java
@@ -70,7 +70,7 @@ public class ErrorEvent extends Event {
         String conveyalFrame = stackTrace.lines()
                 .map(String::strip)
                 .filter(s -> s.startsWith("at com.conveyal."))
-                .filter(frame::equals)
+                .filter(s -> !frame.equals(s))
                 .findFirst().orElse("");
         return String.join("\n", error, frame, conveyalFrame);
     }

--- a/src/main/java/com/conveyal/analysis/components/eventbus/ErrorEvent.java
+++ b/src/main/java/com/conveyal/analysis/components/eventbus/ErrorEvent.java
@@ -38,10 +38,14 @@ public class ErrorEvent extends Event {
     /** Return a string intended for logging on Slack or the console. */
     public String traceWithContext (boolean verbose) {
         StringBuilder builder = new StringBuilder();
-        builder.append("User ");
-        builder.append(user);
-        builder.append(" of group ");
-        builder.append(accessGroup);
+        if (user == null && accessGroup == null) {
+            builder.append("Unknown/unauthenticated user");
+        } else {
+            builder.append("User ");
+            builder.append(user);
+            builder.append(" of group ");
+            builder.append(accessGroup);
+        }
         if (httpPath != null) {
             builder.append(" accessing ");
             builder.append(httpPath);

--- a/src/main/java/com/conveyal/analysis/components/eventbus/ErrorEvent.java
+++ b/src/main/java/com/conveyal/analysis/components/eventbus/ErrorEvent.java
@@ -61,7 +61,7 @@ public class ErrorEvent extends Event {
 
     private static String filterStackTrace (String stackTrace) {
         if (stackTrace == null) return null;
-        final String unknownFrame = "at unknown frame";
+        final String unknownFrame = "Unknown stack frame, probably optimized out by JVM.";
         String error = stackTrace.lines().findFirst().get();
         String frame = stackTrace.lines()
                 .map(String::strip)

--- a/src/main/java/com/conveyal/analysis/components/eventbus/ErrorEvent.java
+++ b/src/main/java/com/conveyal/analysis/components/eventbus/ErrorEvent.java
@@ -17,11 +17,58 @@ public class ErrorEvent extends Event {
 
     public final String summary;
 
+    /**
+     * The path portion of the HTTP URL, if the error has occurred while responding to an HTTP request from a user.
+     * May be null if this information is unavailable or unknown (in components where user information is not retained).
+     */
+    public final String httpPath;
+
     public final String stackTrace;
 
-    public ErrorEvent (Throwable throwable) {
+    public ErrorEvent (Throwable throwable, String httpPath) {
         this.summary = ExceptionUtils.shortCauseString(throwable);
         this.stackTrace = ExceptionUtils.stackTraceString(throwable);
+        this.httpPath = httpPath;
+    }
+
+    public ErrorEvent (Throwable throwable) {
+        this(throwable, null);
+    }
+
+    /** Return a string intended for logging on Slack or the console. */
+    public String traceWithContext (boolean verbose) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("User ");
+        builder.append(user);
+        builder.append(" of group ");
+        builder.append(accessGroup);
+        if (httpPath != null) {
+            builder.append(" accessing ");
+            builder.append(httpPath);
+        }
+        builder.append(": ");
+        if (verbose) {
+            builder.append(stackTrace);
+        } else {
+            builder.append(filterStackTrace(stackTrace));
+        }
+        return builder.toString();
+    }
+
+    private static String filterStackTrace (String stackTrace) {
+        if (stackTrace == null) return null;
+        final String unknownFrame = "at unknown frame";
+        String error = stackTrace.lines().findFirst().get();
+        String frame = stackTrace.lines()
+                .map(String::strip)
+                .filter(s -> s.startsWith("at "))
+                .findFirst().orElse(unknownFrame);
+        String conveyalFrame = stackTrace.lines()
+                .map(String::strip)
+                .filter(s -> s.startsWith("at com.conveyal."))
+                .filter(frame::equals)
+                .findFirst().orElse("");
+        return String.join("\n", error, frame, conveyalFrame);
     }
 
 }

--- a/src/main/java/com/conveyal/analysis/components/eventbus/ErrorLogger.java
+++ b/src/main/java/com/conveyal/analysis/components/eventbus/ErrorLogger.java
@@ -15,7 +15,8 @@ public class ErrorLogger implements EventHandler {
     public void handleEvent (Event event) {
         if (event instanceof ErrorEvent) {
             ErrorEvent errorEvent = (ErrorEvent) event;
-            LOG.error("User {} of {}: {}", errorEvent.user, errorEvent.accessGroup, errorEvent.stackTrace);
+            // Verbose message (full stack traces) for console logs.
+            LOG.error(errorEvent.traceWithContext(true));
         }
     }
 

--- a/src/main/java/com/conveyal/analysis/controllers/OpportunityDatasetController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/OpportunityDatasetController.java
@@ -582,6 +582,7 @@ public class OpportunityDatasetController implements HttpController {
         if (dataset == null) {
             throw AnalysisServerException.notFound("Opportunity dataset could not be found.");
         } else {
+            // Several of these files may not exist. FileStorage::delete contract states this will be handled cleanly.
             fileStorage.delete(dataset.getStorageKey(FileStorageFormat.GRID));
             fileStorage.delete(dataset.getStorageKey(FileStorageFormat.PNG));
             fileStorage.delete(dataset.getStorageKey(FileStorageFormat.TIFF));

--- a/src/main/java/com/conveyal/file/FileStorage.java
+++ b/src/main/java/com/conveyal/file/FileStorage.java
@@ -60,6 +60,8 @@ public interface FileStorage {
 
     /**
      * Delete the File identified by the FileStorageKey, in both the local cache and any remote mirror.
+     * Due to some pre-existing code, implementations must tolerate calling this method on files that don't exist
+     * without throwing exceptions.
      */
     void delete(FileStorageKey fileStorageKey);
 

--- a/src/main/java/com/conveyal/file/LocalFileStorage.java
+++ b/src/main/java/com/conveyal/file/LocalFileStorage.java
@@ -9,6 +9,8 @@ import java.io.IOException;
 import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
 
 /**
  * This implementation of FileStorage stores files in a local directory hierarchy and does not mirror anything to
@@ -56,6 +58,8 @@ public class LocalFileStorage implements FileStorage {
                 LOG.info("Could not move {} because of FileSystem restrictions (probably NTFS). Copying instead.",
                         file.getName());
             }
+            // Set the file to be read-only and accessible only by the current user.
+            Files.setPosixFilePermissions(file.toPath(), Set.of(PosixFilePermission.OWNER_READ));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/conveyal/file/LocalFileStorage.java
+++ b/src/main/java/com/conveyal/file/LocalFileStorage.java
@@ -12,6 +12,9 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.Set;
 
+import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
+
 /**
  * This implementation of FileStorage stores files in a local directory hierarchy and does not mirror anything to
  * cloud storage.
@@ -40,7 +43,7 @@ public class LocalFileStorage implements FileStorage {
      * Move the File into the FileStorage by moving the passed in file to the Path represented by the FileStorageKey.
      */
     @Override
-    public void moveIntoStorage(FileStorageKey key, File file) {
+    public void moveIntoStorage(FileStorageKey key, File sourceFile) {
         // Get a pointer to the local file
         File storedFile = getFile(key);
         // Ensure the directories exist
@@ -48,18 +51,18 @@ public class LocalFileStorage implements FileStorage {
         try {
             try {
                 // Move the temporary file to the permanent file location.
-                Files.move(file.toPath(), storedFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                Files.move(sourceFile.toPath(), storedFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
             } catch (FileSystemException e) {
                 // The default Windows filesystem (NTFS) does not unlock memory-mapped files, so certain files (e.g.
                 // mapdb) cannot be moved or deleted. This workaround may cause temporary files to accumulate, but it
                 // should not be triggered for default Linux filesystems (ext).
                 // See https://github.com/jankotek/MapDB/issues/326
-                Files.copy(file.toPath(), storedFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                Files.copy(sourceFile.toPath(), storedFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
                 LOG.info("Could not move {} because of FileSystem restrictions (probably NTFS). Copying instead.",
-                        file.getName());
+                        sourceFile.getName());
             }
             // Set the file to be read-only and accessible only by the current user.
-            Files.setPosixFilePermissions(file.toPath(), Set.of(PosixFilePermission.OWNER_READ));
+            Files.setPosixFilePermissions(storedFile.toPath(), Set.of(OWNER_READ));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -87,7 +90,18 @@ public class LocalFileStorage implements FileStorage {
 
     @Override
     public void delete (FileStorageKey key) {
-        getFile(key).delete();
+        try {
+            File storedFile = getFile(key);
+            if (storedFile.exists()) {
+                // File permissions are set read-only to prevent corruption, so must be changed to allow deletion.
+                Files.setPosixFilePermissions(storedFile.toPath(), Set.of(OWNER_READ, OWNER_WRITE));
+                storedFile.delete();
+            } else {
+                LOG.warn("Attempted to delete non-existing file: " + storedFile);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Exception while deleting stored file.", e);
+        }
     }
 
     @Override


### PR DESCRIPTION
This PR makes two small changes: 
- When files are moved into storage they are set read-only at the filesystem level, precluding accidental corruption or deletion, for example of MapDB files (which after a recent change are also opened in read-only mode for good measure).
- Removes some repetitive code from HTTP server exception handling code, allowing FORBIDDEN and UNAUTHORIZED exceptions to be handled by the same method as all other exceptions, which in turn causes them to fire error events, making it possible to log or otherwise broadcast messages about these errors.
- Before review and merge, we should follow up with other planned changes to respondToException and ErrorEvent, to include the HTTP request path in the ErrorEvent and log it. Authentication code (cluster-specific) can then be changed back to use Type.FORBIDDEN.