### PR TITLE
Clarify travel time CSV errors

### DIFF
--- a/src/main/java/com/conveyal/analysis/controllers/RegionalAnalysisController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/RegionalAnalysisController.java
@@ -16,6 +16,7 @@ import com.conveyal.file.FileStorage;
 import com.conveyal.file.FileStorageFormat;
 import com.conveyal.file.FileStorageKey;
 import com.conveyal.file.FileUtils;
+import com.conveyal.r5.analyst.FreeFormPointSet;
 import com.conveyal.r5.analyst.Grid;
 import com.conveyal.r5.analyst.PointSet;
 import com.conveyal.r5.analyst.PointSetCache;
@@ -455,6 +456,14 @@ public class RegionalAnalysisController implements HttpController {
             task.destinationPointSets = new PointSet[] {
                     PointSetCache.readFreeFormFromFileStore(task.destinationPointSetKeys[0])
             };
+        }
+        if (task.recordTimes) {
+            checkArgument(
+                task.destinationPointSets != null &&
+                task.destinationPointSets.length == 1 &&
+                task.destinationPointSets[0] instanceof FreeFormPointSet,
+                "recordTimes can only be used with a single destination pointset, which must be freeform (non-grid)."
+            );
         }
 
         // TODO remove duplicate fields from RegionalAnalysis that are already in the nested task.

--- a/src/main/java/com/conveyal/analysis/results/TimeCsvResultWriter.java
+++ b/src/main/java/com/conveyal/analysis/results/TimeCsvResultWriter.java
@@ -1,6 +1,7 @@
 package com.conveyal.analysis.results;
 
 import com.conveyal.file.FileStorage;
+import com.conveyal.r5.analyst.FreeFormPointSet;
 import com.conveyal.r5.analyst.cluster.RegionalTask;
 import com.conveyal.r5.analyst.cluster.RegionalWorkResult;
 
@@ -8,6 +9,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 public class TimeCsvResultWriter extends CsvResultWriter {
@@ -31,9 +33,13 @@ public class TimeCsvResultWriter extends CsvResultWriter {
      */
     @Override
     protected void checkDimension (RegionalWorkResult workResult) {
-        // This CSV writer expects only a single freeform destination pointset.
         // TODO handle multiple destination pointsets at once?
-        checkState(task.destinationPointSets.length == 1);
+        checkState(
+           task.destinationPointSets != null &&
+           task.destinationPointSets.length == 1 &&
+           task.destinationPointSets[0] instanceof FreeFormPointSet,
+           "Time CSV writer expects only a single freeform destination pointset."
+        );
         // In one-to-one mode, we expect only one value per origin, the destination point at the same pointset index as
         // the origin point. Otherwise, for each origin, we expect one value per destination.
         final int nDestinations = task.oneToOne ? 1 : task.destinationPointSets[0].featureCount();


### PR DESCRIPTION
Recently we saw dozens of messages from our production system like this:
```
[production] User null of null: Optional[java.lang.NullPointerException]
at unknown frame
```

The "at unknown frame" text is from our implementation, handling a case where Java just does not provide a stacktrace. It sometimes removes the stacktrace when it's already been provided: https://stackoverflow.com/a/3010106/778449. The true error was:

```
[production] User null of null: Optional[java.lang.NullPointerException]
at com.conveyal.analysis.results.TimeCsvResultWriter.checkDimension(TimeCsvResultWriter.java:36)
```

This error message is confusing because: 
1. No username and group are currently available in the CsvResultWriter where the error occurs.
2. The checkState call assumes that task.destinationPointSets is non-null and checks its length, but it can be null. In fact it’s transient and usually null on the backend (filled in on workers only). See RegionalAnalysisController where the field is initialized only if we have a single freeform pointset.
3. The error repeats many times (about 27 times in an analysis with 3181 origins). All N outstanding tasks fetched in the first batch by the single active worker yield errors, which are all reported to the backend. Once an error has been reported the job stops distributing tasks to workers and stalls. This is intentional, to let workers shut down and the user see the task is stalled (errored). We should also stop the job from receiving any more results so it doesn’t hit the same error N times, just once.
4. We don’t bubble the error up to the end user. This is just a presentation issue. The error message is stored on the regional job and returned to the UI on the `errors` field of the JSON response from `/api/region/X/regional/running`. The UI side of this is tracked at conveyal/analysis-ui#1584.

This PR adds a null check and adds descriptive strings to checkArgument calls to ensure error messages are clearer. It also drops any incoming results for jobs that are inactive (have already received an error). Finally, the whole checkArgument call is replicated in RegionalAnalysisController so we catch the problem before the regional job is even created. This gives immediate feedback to the user about how to correct the parameters they supplied.