### PR TITLE
Apply egress table preload logic in regional tasks

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalysisWorker.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalysisWorker.java
@@ -462,8 +462,7 @@ public class AnalysisWorker implements Runnable {
         // Note we're completely bypassing the async loader here and relying on the older nested LoadingCaches.
         // If those are ever removed, the async loader will need a synchronous mode with per-path blocking (kind of
         // reinventing the wheel of LoadingCache) or we'll need to make preparation for regional tasks async.
-        TransportNetwork transportNetwork = networkPreloader.transportNetworkCache.getNetworkForScenario(task
-                .graphId, task.scenarioId);
+        TransportNetwork transportNetwork = networkPreloader.synchronousPreload(task);
 
         // Static site tasks do not specify destinations, but all other regional tasks should.
         // Load the PointSets based on the IDs (actually, full storage keys including IDs) in the task.

--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalysisWorker.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalysisWorker.java
@@ -456,13 +456,8 @@ public class AnalysisWorker implements Runnable {
 
         // Get the graph object for the ID given in the task, fetching inputs and building as needed.
         // All requests handled together are for the same graph, and this call is synchronized so the graph will
-        // only be built once.
-        // Record the currently loaded network ID so we "stick" to this same graph on subsequent polls.
+        // only be built once. Record the currently loaded network ID to remain on this same graph on subsequent polls.
         networkId = task.graphId;
-        // Note we're completely bypassing the async loader here and relying on the older nested LoadingCaches.
-        // If those are ever removed, the async loader will need a synchronous mode with per-path blocking (kind of
-        // reinventing the wheel of LoadingCache) or we'll need to make preparation for regional tasks async.
-        TransportNetwork transportNetwork = networkPreloader.synchronousPreload(task);
 
         // Static site tasks do not specify destinations, but all other regional tasks should.
         // Load the PointSets based on the IDs (actually, full storage keys including IDs) in the task.
@@ -470,6 +465,13 @@ public class AnalysisWorker implements Runnable {
         if (!task.makeTauiSite) {
             task.loadAndValidateDestinationPointSets(pointSetCache);
         }
+
+        // Pull all necessary inputs into cache in a blocking fashion, unlike single-point tasks where prep is async.
+        // Avoids auto-shutdown while preloading. Must be done after loading destination pointsets to establish extents.
+        // Note we're completely bypassing the async loader here and relying on the older nested LoadingCaches.
+        // If those are ever removed, the async loader will need a synchronous mode with per-path blocking (kind of
+        // reinventing the wheel of LoadingCache) or we'll need to make preparation for regional tasks async.
+        TransportNetwork transportNetwork = networkPreloader.synchronousPreload(task);
 
         // If we are generating a static site, there must be a single metadata file for an entire batch of results.
         // Arbitrarily we create this metadata as part of the first task in the job.


### PR DESCRIPTION
In common use cases this should cause egress tables to be calculated before we fire the HandleRegionalEvent and begin routing, allowing better tracking of whether workers are still in a slow preparation phase.

This patched version is currently the r5 dependency for the head of cluster. It was necessary to run a TAUI site and a regional analysis for the whole Netherlands using bicycle egress. Without this patch, the workers will all shut down except for the single point worker and regional job progress will be very slow.

Note that some proportion of workers may survive without this patch; the ones that shut down seem to be those that handle at least one task that never reaches transit and therefore wait to build egress tables until after they've handled a few regional tasks and lowered their shutdown timers.
