### PR TITLE
Add "Access-Control-Max-Age" header

### DIFF
--- a/src/main/java/com/conveyal/analysis/components/HttpApi.java
+++ b/src/main/java/com/conveyal/analysis/components/HttpApi.java
@@ -121,7 +121,10 @@ public class HttpApi implements Component {
         // Handle CORS preflight requests (which are OPTIONS requests).
         // See comment above about Access-Control-Allow-Origin
         sparkService.options("/*", (req, res) -> {
+            // Cache the preflight response for up to one day (the maximum allowed by browsers)
+            res.header("Access-Control-Max-Age", "86400");
             res.header("Access-Control-Allow-Methods", "GET,PUT,POST,DELETE,OPTIONS");
+            // Allowing credentials is necessary to send an Authorization header
             res.header("Access-Control-Allow-Credentials", "true");
             res.header("Access-Control-Allow-Headers", "Accept,Authorization,Content-Type,Origin," +
                     "X-Requested-With,Content-Length,X-Conveyal-Access-Group"


### PR DESCRIPTION
Our preflight request response does not change. If we add "Access-Control-Max-Age" header set to one day to all preflight requests it will allow browsers to cache the "Options" preflight request instead of sending it for each HTTP request. 

Note: I am uncertain if this caches preflight request for the entire origin (https://api.conveyal.com) or for each individual request (/api/region/1 vs /api/region/2). Obviously, the former would be ideal for our situation.

closes #754 