### PR TITLE
Fault Injection ("Chaos Engineering")

### DIFF
--- a/src/main/java/com/conveyal/analysis/WorkerConfig.java
+++ b/src/main/java/com/conveyal/analysis/WorkerConfig.java
@@ -18,7 +18,6 @@ public abstract class WorkerConfig extends ConfigBase implements TaskScheduler.C
     private final String  brokerPort;
     private final int     lightThreads;
     private final int     heavyThreads;
-    private final boolean testTaskRedelivery;
     private final boolean listenForSinglePoint;
 
     // CONSTRUCTORS
@@ -34,7 +33,6 @@ public abstract class WorkerConfig extends ConfigBase implements TaskScheduler.C
             lightThreads = availableProcessors;
             heavyThreads = availableProcessors;
         }
-        testTaskRedelivery = boolProp("test-task-redelivery");
         listenForSinglePoint = boolProp("listen-for-single-point");
         // No call to exitIfErrors() here, that should be done in concrete subclasses.
     }
@@ -47,7 +45,6 @@ public abstract class WorkerConfig extends ConfigBase implements TaskScheduler.C
     @Override public String  brokerPort()      { return brokerPort; }
     @Override public int     lightThreads ()   { return lightThreads; }
     @Override public int     heavyThreads ()   { return heavyThreads; }
-    @Override public boolean testTaskRedelivery()   { return testTaskRedelivery; }
     @Override public boolean listenForSinglePoint() { return listenForSinglePoint; }
 
 }

--- a/src/main/java/com/conveyal/analysis/components/LocalWorkerLauncher.java
+++ b/src/main/java/com/conveyal/analysis/components/LocalWorkerLauncher.java
@@ -23,12 +23,10 @@ public class LocalWorkerLauncher implements WorkerLauncher {
 
     private static final Logger LOG = LoggerFactory.getLogger(LocalWorkerLauncher.class);
     private static final int N_WORKERS_LOCAL = 1;
-    private static final int N_WORKERS_LOCAL_TESTING = 4;
 
     public interface Config {
         int serverPort ();
         String localCacheDirectory ();
-        boolean testTaskRedelivery();
     }
 
     private final TransportNetworkCache transportNetworkCache;
@@ -47,22 +45,11 @@ public class LocalWorkerLauncher implements WorkerLauncher {
         workerConfig.setProperty("broker-address", "localhost");
         workerConfig.setProperty("broker-port", Integer.toString(config.serverPort()));
         workerConfig.setProperty("cache-dir", config.localCacheDirectory());
-        workerConfig.setProperty("test-task-redelivery", "false");
-
 
         // From a throughput perspective there is no point in running more than one worker locally, since each worker
         // has at least as many threads as there are processor cores. But for testing purposes (e.g. testing that task
         // redelivery works right) we may want to start more workers to simulate running on a cluster.
-        if (config.testTaskRedelivery()) {
-            // When testing we want multiple workers. Below, all but one will have single point listening disabled
-            // to allow them to run on the same machine without port conflicts.
-            nWorkers = N_WORKERS_LOCAL_TESTING;
-            // Tell the workers to return fake results, but fail part of the time.
-            workerConfig.setProperty("test-task-redelivery", "true");
-        } else {
-            nWorkers = N_WORKERS_LOCAL;
-        }
-
+        nWorkers = N_WORKERS_LOCAL;
     }
 
     @Override

--- a/src/main/java/com/conveyal/analysis/models/AnalysisRequest.java
+++ b/src/main/java/com/conveyal/analysis/models/AnalysisRequest.java
@@ -5,6 +5,7 @@ import com.conveyal.analysis.UserPermissions;
 import com.conveyal.analysis.persistence.Persistence;
 import com.conveyal.r5.analyst.WebMercatorExtents;
 import com.conveyal.r5.analyst.cluster.AnalysisWorkerTask;
+import com.conveyal.r5.analyst.cluster.ChaosParameters;
 import com.conveyal.r5.analyst.decay.DecayFunction;
 import com.conveyal.r5.analyst.decay.StepDecayFunction;
 import com.conveyal.r5.analyst.fare.InRoutingFareCalculator;
@@ -158,6 +159,12 @@ public class AnalysisRequest {
     public DecayFunction decayFunction;
 
     /**
+     * If this field is non-null, it will intentionally cause failures on workers handling the task. This is done on
+     * testing or even production systems in order to observe and improve their robustness to failure.
+     */
+    public ChaosParameters injectFault;
+
+    /**
      * Create the R5 `Scenario` from this request.
      */
     public Scenario createScenario (UserPermissions userPermissions) {
@@ -253,6 +260,8 @@ public class AnalysisRequest {
         if (task.decayFunction == null) {
             task.decayFunction = new StepDecayFunction();
         }
+        // Intentionally introduce errors for testing purposes.
+        task.injectFault = injectFault;
     }
 
     private static void checkGridSize (WebMercatorExtents extents) {

--- a/src/main/java/com/conveyal/analysis/models/AnalysisRequest.java
+++ b/src/main/java/com/conveyal/analysis/models/AnalysisRequest.java
@@ -260,8 +260,10 @@ public class AnalysisRequest {
         if (task.decayFunction == null) {
             task.decayFunction = new StepDecayFunction();
         }
-        // Intentionally introduce errors for testing purposes.
-        task.injectFault = injectFault;
+        // Intentionally introduce errors for testing purposes, but only for admin users.
+        if (userPermissions.admin) {
+            task.injectFault = injectFault;
+        }
     }
 
     private static void checkGridSize (WebMercatorExtents extents) {

--- a/src/main/java/com/conveyal/analysis/models/AnalysisRequest.java
+++ b/src/main/java/com/conveyal/analysis/models/AnalysisRequest.java
@@ -261,8 +261,12 @@ public class AnalysisRequest {
             task.decayFunction = new StepDecayFunction();
         }
         // Intentionally introduce errors for testing purposes, but only for admin users.
-        if (userPermissions.admin) {
-            task.injectFault = injectFault;
+        if (injectFault != null) {
+            if (userPermissions.admin) {
+                task.injectFault = injectFault;
+            } else {
+                throw new IllegalArgumentException("Must be admin user to inject faults.");
+            }
         }
     }
 

--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalysisWorkerTask.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalysisWorkerTask.java
@@ -158,6 +158,12 @@ public abstract class AnalysisWorkerTask extends ProfileRequest {
     public transient PointSet[] destinationPointSets;
 
     /**
+     * If this field is non-null, it will intentionally cause failures on workers handling the task. This is done on
+     * testing or even production systems in order to observe and improve their robustness to failure.
+     */
+    public ChaosParameters injectFault;
+
+    /**
      * Is this a single point or regional request? Needed to encode types in JSON serialization. Can that type field be
      * added automatically with a serializer annotation instead of by defining a getter method and two dummy methods?
      */

--- a/src/main/java/com/conveyal/r5/analyst/cluster/ChaosParameters.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/ChaosParameters.java
@@ -1,0 +1,93 @@
+package com.conveyal.r5.analyst.cluster;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Random;
+
+import static com.conveyal.r5.analyst.cluster.ChaosParameters.FailureMode.*;
+
+/**
+ * If these parameters are included in an AnalysisWorkerTask, they will cause intentional failures and disruptions on
+ * the workers processing them. This is used in testing the robustness of the system against unexpected failures,
+ * particularly worker shutdown when using lower priced spot instances. This is a simple form of "fault injection" or
+ * "chaos engineering".
+ *
+ * For testing redelivery of tasks, we cannot simply designate specific task IDs to fail, either explicitly or
+ * parametrically, or even through deterministic pseudo-random number sequences, because these same tasks would keep
+ * failing on each redelivery. Whether the tasks are skipped over or they cause a more complete worker shutdown, no
+ * number of retries could solve the problem.
+ *
+ * The alternative (currently in use) is to fail randomly a certain percentage of the time. Here there is some chance
+ * the actual number of failures will deviate far below the target percentage, and may even be zero. In this case a
+ * full regional analysis would complete without ever triggering the error, so it's not ideal for automated testing.
+ * The probability of an ineffective test run is like the probability of getting a run of all heads in a coin toss:
+ * (1-p)^N.
+ *
+ * I believe that in a distributed system like ours, the only practical way to ensure a specific number of failures on
+ * a set of tasks that do not recur identically at each retry / redistribution of tasks is for the backend to
+ * orchestrate (perhaps precompute) which failures will happen, checking them off as they are distributed to workers to
+ * ensure certain constraints are respected.
+ *
+ * An imperative, non-probabilistic instruction to fail would be attached to certain individual tasks.
+ * Failing only on the initial round of task delivery would not be sufficient. We want to test that we can recover from
+ * multiple redelivery rounds of faulty processing.
+ *
+ * One particular case could be tested by setting a flag on a single task that would shut down the whole worker
+ * processing it. But this is still essentially orchestrating the test from the backend rather than at the workers.
+ */
+public class ChaosParameters {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ChaosParameters.class);
+
+    private static final Random random = new Random();
+
+    public FailureMode failureMode;
+
+    public int startingAtTask = 0;
+
+    public int failurePercent;
+
+    /** This message will be logged when the failure is injected, and will be included in any exception thrown. */
+    public String message = "Intentional failure for testing purposes.";
+
+    private boolean shouldFail (int taskIndex) {
+        return taskIndex >= startingAtTask && random.nextInt(100) < failurePercent;
+    }
+
+    public boolean shouldDropTaskBeforeCompute (int taskIndex) {
+        boolean shouldDrop = failureMode == DROP_TASK && shouldFail(taskIndex);
+        if (shouldDrop) {
+            LOG.warn("Intentionally dropping task for testing purposes.");
+        }
+        return shouldDrop;
+    }
+
+    public void considerShutdownOrException (int taskIndex) {
+        if (shouldFail(taskIndex)) {
+            if (failureMode == THROW_EXCEPTION) {
+                LOG.warn("Intentionally throwing runtime exception for testing purposes.");
+                throw new RuntimeException(message);
+            } else if (failureMode == EXIT_JVM) {
+                // This exits cleanly - also allow other nonzero return codes?
+                LOG.warn("Intentionally exiting JVM for testing purposes.");
+                System.exit(0);
+            }
+        }
+    }
+
+    /**
+     * Our worker scripts do not contain a loop to restart the JVM. They shut down whenever the JVM exits.
+     * If for some reason we want another mode to directly shut down the machine, this can be done with something like:
+     * Runtime.getRuntime().exec("sudo shutdown -h now");
+     * But this is operating system specific and requires more checks for exceptions and process completion.
+     * A NO_FAILURE value could be added for an implementation that does not depend on null checks.
+     * We may also want to add a failure mode that makes some tasks very slow to process (sleep for N seconds).
+     */
+    public enum FailureMode {
+        DROP_TASK,
+        THROW_EXCEPTION,
+        EXIT_JVM
+    }
+
+}


### PR DESCRIPTION
This is motivated by testing #517 and #768.  This allows intentionally requesting workers to fail during regional processing by throwing exceptions, dropping tasks, or completely exiting the JVM. It would benefit from some refinements described in the Javadoc, but is definitely useable as-is. For now this only applies to regional analyses but would also make sense for testing single point analysis (with the difference that the starting task and failure percent should probably be ignored).

For example, to test reporting of exceptions on workers, in the request JSON you can add:
```
{
  "injectFault": {
    "failureMode": "THROW_EXCEPTION",
    "message": "This is an exception.",
    "failurePercent": 50,
    "startingAtTask": 100
  }
```
After handling 100 tasks the job should fail, reporting an exception with the supplied message.

The failureMode can be DROP_TASK, THROW_EXCEPTION, or EXIT_JVM. To test job redelivery:
```
{
  "injectFault": {
    "failureMode": "DROP_TASK",
    "failurePercent": 10,
    "startingAtTask": 200
  }
```

This should cause 10% of tasks above task 200 to be dropped, leading to several retries before all results are returned.

Unfortunately these tests are not deterministic and may (with low probability) not even trigger any faults. Reasons and possible refinements are described in the Javadoc.
