### PR TITLE
Fix Download Scenario JSON

### DIFF
--- a/src/main/java/com/conveyal/analysis/models/AnalysisRequest.java
+++ b/src/main/java/com/conveyal/analysis/models/AnalysisRequest.java
@@ -191,6 +191,7 @@ public class AnalysisRequest {
         if (bounds == null) throw AnalysisServerException.badRequest("Analysis bounds must be set.");
 
         task.scenario = createScenario(userPermissions);
+        task.scenarioId = task.scenario.id;
         task.graphId = bundleId;
         task.workerVersion = workerVersion;
         task.maxFare = maxFare;

--- a/src/main/java/com/conveyal/analysis/models/RegionalAnalysis.java
+++ b/src/main/java/com/conveyal/analysis/models/RegionalAnalysis.java
@@ -27,6 +27,14 @@ public class RegionalAnalysis extends Model implements Cloneable {
     public int height;
     public int north;
     public int west;
+
+    /**
+     * TODO: Fix confusing naming. An `AnalysisRequest` is used to create a `AnalysisWorkerTask` (which `RegionalTask`
+     *       extends) but is not the same as a task. Naming this parameter `request` can create confusion that it refers
+     *       to that incoming `AnalysisRequest` object and not the `RegionalTask` itself. Either 1) rename this parameter
+     *       "task" (which would require a migration) or 2) rename `AnalysisRequest` something more unique to
+     *       differentiate or 3) ?.
+     */
     public RegionalTask request;
 
     /**

--- a/src/main/java/com/conveyal/file/FileStorageFormat.java
+++ b/src/main/java/com/conveyal/file/FileStorageFormat.java
@@ -15,12 +15,11 @@ public enum FileStorageFormat {
     // SHP implies .dbf and .prj, and optionally .shx
     SHP("shp", "application/octet-stream"),
 
-    // Some of these are not yet used.
+    // Some of these are not yet used. Any file type that can be downloaded through `FileStorage` is required here.
     // In our internal storage, we may want to force less ambiguous .gtfs.zip .osm.pbf and .geojson.
     GTFS("zip", "application/zip"),
     OSMPBF("pbf", "application/octet-stream"),
     // Also can be application/geo+json, see https://www.iana.org/assignments/media-types/application/geo+json
-    // The extension used to be defined as .json TODO ensure that changing it to .geojson hasn't broken anything.
     GEOJSON("geojson", "application/json"),
     JSON("json", "application/json"),
     // See requirement 3 http://www.geopackage.org/spec130/#_file_extension_name

--- a/src/main/java/com/conveyal/file/FileStorageFormat.java
+++ b/src/main/java/com/conveyal/file/FileStorageFormat.java
@@ -1,7 +1,5 @@
 package com.conveyal.file;
 
-import org.bson.codecs.pojo.annotations.BsonIgnore;
-
 /**
  * An enumeration of all the file types we handle as uploads, derived internal data, or work products.
  * Really this should be a union of several enumerated types (upload/internal/product) but Java does not allow this.
@@ -24,6 +22,7 @@ public enum FileStorageFormat {
     // Also can be application/geo+json, see https://www.iana.org/assignments/media-types/application/geo+json
     // The extension used to be defined as .json TODO ensure that changing it to .geojson hasn't broken anything.
     GEOJSON("geojson", "application/json"),
+    JSON("json", "application/json"),
     // See requirement 3 http://www.geopackage.org/spec130/#_file_extension_name
     GEOPACKAGE("gpkg", "application/geopackage+sqlite3");
 


### PR DESCRIPTION
Set the `task.scenarioId` properly. The immediate bug this fixes is that regional analysis scenario JSON files can be downloaded again. The details about why we went with this change can be found here: #765 

Also:
1. Add back the FileStorageFormat JSON.
2. Add suggestion about renaming the `RegionalAnalysis#request` parameter in the subsequent change.