### PR TITLE
Serialize CAR and BICYCLE linkages and egress tables

### DIFF
--- a/src/main/java/com/conveyal/r5/kryo/KryoNetworkSerializer.java
+++ b/src/main/java/com/conveyal/r5/kryo/KryoNetworkSerializer.java
@@ -44,7 +44,7 @@ public abstract class KryoNetworkSerializer {
      * the serialization format itself does not change. This will ensure newer workers will not load cached older files.
      * We considered using an ISO date string as the version but that could get confusing when seen in filenames.
      */
-    public static final String NETWORK_FORMAT_VERSION = "nv1";
+    public static final String NETWORK_FORMAT_VERSION = "361878c3";
 
     public static final byte[] HEADER = "R5NETWORK".getBytes();
 

--- a/src/main/java/com/conveyal/r5/streets/EgressCostTable.java
+++ b/src/main/java/com/conveyal/r5/streets/EgressCostTable.java
@@ -55,7 +55,7 @@ public class EgressCostTable implements Serializable {
 
     public static final int BICYCLE_DISTANCE_LINKING_LIMIT_METERS = 5000;
 
-    public static final int CAR_TIME_LINKING_LIMIT_SECONDS = 30 * 60;
+    public static final int CAR_TIME_LINKING_LIMIT_SECONDS = 20 * 60;
 
     public static final int MAX_CAR_SPEED_METERS_PER_SECOND = 22; // ~80 kilometers per hour
 

--- a/src/main/java/com/conveyal/r5/streets/IntHashGrid.java
+++ b/src/main/java/com/conveyal/r5/streets/IntHashGrid.java
@@ -200,7 +200,7 @@ public class IntHashGrid implements Serializable {
         // Check sanity before iterating
         long dx = (maxXKey - minXKey);
         long dy = (maxYKey - minYKey);
-        if (dx * dy > 10000) {
+        if (dx * dy > 250000) {
             LOG.error("Visiting too many spatial index cells.");
             return;
         }

--- a/src/main/java/com/conveyal/r5/transit/TransportNetworkCache.java
+++ b/src/main/java/com/conveyal/r5/transit/TransportNetworkCache.java
@@ -176,7 +176,7 @@ public class TransportNetworkCache {
         // The linkage we create here will never be used directly, but serves as a basis for scenario linkages, making
         // analysis much faster to start up.
         network.transitLayer.buildDistanceTables(null);
-        network.rebuildLinkedGridPointSet(StreetMode.WALK);
+        network.rebuildLinkedGridPointSet(StreetMode.WALK, StreetMode.BICYCLE, StreetMode.CAR);
 
         // Cache the serialized network on the local filesystem and mirror it to any remote storage.
         try {


### PR DESCRIPTION
I started this branch for a recent batch of static site analyses. The main change, building and storing CAR and BICYCLE egress tables on network build, makes it easier to analyze scenarios with on-demand pickup area modifications. This initial experimental change worked surprisingly well; I still need to consider backward compatibility and the need for a network version update.

Other notes:
https://github.com/conveyal/r5/commit/3941742db0ed9093a8ee09d120e8e0567091b1fa: We should probably revert this before merging to dev.
https://github.com/conveyal/r5/commit/1a28824b027fe24f0eccdd275f0c8095078995ca: The previous limit was too small for a proposed on-demand pickup area in a recent project.