### PR TITLE
Additive cost rasters, elevation cost bugfix

### DIFF
--- a/src/main/java/com/conveyal/analysis/controllers/NetworkTileController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/NetworkTileController.java
@@ -147,9 +147,8 @@ public class NetworkTileController implements HttpController {
             JtsMvt mvt = new JtsMvt(edgeLayer);
             MvtLayerParams mvtLayerParams = new MvtLayerParams(256, tileExtent);
             byte[] pbfMessage = MvtEncoder.encode(mvt, mvtLayerParams, new UserDataKeyValueMapConverter());
-
-            LOG.info("getTile({}, {}, {}, {}) in {}", network.scenarioId, zTile, xTile, yTile, Duration.ofMillis(System.currentTimeMillis() - startTimeMs));
-
+            LOG.debug("getTile({}, {}, {}, {}) in {}", network.scenarioId, zTile, xTile, yTile,
+                    Duration.ofMillis(System.currentTimeMillis() - startTimeMs));
             return pbfMessage;
         } else {
             return new byte[]{};

--- a/src/main/java/com/conveyal/r5/analyst/scenario/RasterCost.java
+++ b/src/main/java/com/conveyal/r5/analyst/scenario/RasterCost.java
@@ -69,15 +69,17 @@ public class RasterCost extends Modification {
             loader = new ElevationLoader(dataSourceId, new MinettiCalculator());
         } else if (costFunction == SUN) {
             loader = new SunLoader(dataSourceId);
-        } else {
-            errors.add("Unrecognized cost function: " + costFunction);
         }
-        loader.setNorthShiftMeters(northShiftMeters);
-        loader.setEastShiftMeters(eastShiftMeters);
-        checkScaleRange(inputScale);
-        checkScaleRange(outputScale);
-        loader.setInputScale(inputScale);
-        loader.setOutputScale(outputScale);
+        if (loader == null) {
+            errors.add("Unrecognized cost function: " + costFunction);
+        } else {
+            loader.setNorthShiftMeters(northShiftMeters);
+            loader.setEastShiftMeters(eastShiftMeters);
+            checkScaleRange(inputScale);
+            checkScaleRange(outputScale);
+            loader.setInputScale(inputScale);
+            loader.setOutputScale(outputScale);
+        }
         return errors.size() > 0;
     }
 

--- a/src/main/java/com/conveyal/r5/kryo/KryoNetworkSerializer.java
+++ b/src/main/java/com/conveyal/r5/kryo/KryoNetworkSerializer.java
@@ -44,7 +44,7 @@ public abstract class KryoNetworkSerializer {
      * the serialization format itself does not change. This will ensure newer workers will not load cached older files.
      * We considered using an ISO date string as the version but that could get confusing when seen in filenames.
      */
-    public static final String NETWORK_FORMAT_VERSION = "DEBUG202203B";
+    public static final String NETWORK_FORMAT_VERSION = "DEBUG202203E";
 
     public static final byte[] HEADER = "R5NETWORK".getBytes();
 

--- a/src/main/java/com/conveyal/r5/kryo/KryoNetworkSerializer.java
+++ b/src/main/java/com/conveyal/r5/kryo/KryoNetworkSerializer.java
@@ -44,7 +44,7 @@ public abstract class KryoNetworkSerializer {
      * the serialization format itself does not change. This will ensure newer workers will not load cached older files.
      * We considered using an ISO date string as the version but that could get confusing when seen in filenames.
      */
-    public static final String NETWORK_FORMAT_VERSION = "DEBUG202203A";
+    public static final String NETWORK_FORMAT_VERSION = "DEBUG202203B";
 
     public static final byte[] HEADER = "R5NETWORK".getBytes();
 

--- a/src/main/java/com/conveyal/r5/rastercost/CostField.java
+++ b/src/main/java/com/conveyal/r5/rastercost/CostField.java
@@ -19,15 +19,20 @@ import java.util.List;
  * cost. So TraversalTimeCalculator is like a special case of CostField that is always called first with a
  * parameter of zero, and has the added ability to calculate turn costs.
  *
- * TODO rename to TraversalTimeTransformer or TraversalCost
+ * This could be renamed to something like TraversalTimeAdjustment but something more concise would be better.
  */
 public interface CostField {
 
     /**
-     * TODO perhaps this and the base traversal time function should all return doubles, which are rounded only
-     *   once after they have all been applied.
+     * Return a number of (perceived) seconds to add or subtract from the baseTraversalTimeSeconds due to an additional
+     * consideration such as elevation change or sun or noise exposure. This is typically computed by multiplying the
+     * base traversal time by a per-edge factor, but other approaches may be used. Negative values may be returned,
+     * but if the sum of additionalTraversalTimeSeconds for all different CostFields yields a negative overall
+     * traversal time for an edge during routing, this time will be clamped to the smallest allowed value (1 second).
+     * TODO This and the base traversal time function could all return doubles, which are rounded only once after they
+     *      have all been summed. This should reduce roundoff error.
      */
-    int transformTraversalTimeSeconds (EdgeStore.Edge currentEdge, int traversalTimeSeconds);
+    int additionalTraversalTimeSeconds (EdgeStore.Edge currentEdge, int baseTraversalTimeSeconds);
 
     /**
      * A unique name to identify this cost field for display on a map. It should be usable as a JSON key, so it should
@@ -37,16 +42,17 @@ public interface CostField {
 
     /**
      * Returns a length-independent value associated with a particular edge for the purpose of display on a map.
+     * Typically a multiplier that this class applies to the base traversal cost to find additional traversal cost.
      */
     double getDisplayValue (int edgeIndex);
 
     /** Interface for classes that create a CostField for a given StreetLayer, usually by overlaying a raster file. */
-    interface Loader {
+    interface Loader<T extends CostField> {
         void setNorthShiftMeters (double northShiftMeters);
         void setEastShiftMeters (double eastShiftMeters);
         void setInputScale (double inputScale);
         void setOutputScale (double outputScale);
-        CostField load (StreetLayer streets);
+        T load (StreetLayer streets);
     }
 
 }

--- a/src/main/java/com/conveyal/r5/rastercost/ElevationCostField.java
+++ b/src/main/java/com/conveyal/r5/rastercost/ElevationCostField.java
@@ -60,8 +60,8 @@ public class ElevationCostField implements CostField, Serializable {
     }
 
     @Override
-    public int transformTraversalTimeSeconds (EdgeStore.Edge currentEdge, int traversalTimeSeconds) {
-        return (int) Math.round(traversalTimeSeconds * factorForEdge(currentEdge));
+    public int additionalTraversalTimeSeconds (EdgeStore.Edge currentEdge, int traversalTimeSeconds) {
+        return (int) Math.round(traversalTimeSeconds * (factorForEdge(currentEdge) - 1));
     }
 
     @Override

--- a/src/main/java/com/conveyal/r5/rastercost/ElevationCostField.java
+++ b/src/main/java/com/conveyal/r5/rastercost/ElevationCostField.java
@@ -112,6 +112,7 @@ public class ElevationCostField implements CostField, Serializable {
      * but it works fine for a memoryless difficulty scaling function like the Tobler hiking function.
      */
     public void forEachElevationSegment (EdgeStore.Edge edge, ElevationSegmentConsumer consumer) {
+        consumer.reset(); // Zero out any state from previous usage of the instance.
         double remainingMeters = edge.getLengthM();
         // Do not go through getFromVertex method because we do not currently truly reverse edges.
         // This is only to keep the iteration logic below simple until we actually need reverse iteration.
@@ -149,10 +150,12 @@ public class ElevationCostField implements CostField, Serializable {
     /**
      * A functional interface that consumes segments in a street edge's elevation profile one by one.
      * Each segment is represented as a distance across the ground (always positive) and a signed vertical change.
-     * Both values are in meters.
+     * Both values are in meters. The reset() function allows consumer instances to be reused, which could lead to
+     * thread safety issues. Considering how efficient Java garbage collection has become, we may want to change this
+     * and require one instance per calculation with no reset().
      */
-    @FunctionalInterface
     public interface ElevationSegmentConsumer {
+        void reset ();
         void consumeElevationSegment (int index, double xMeters, double yMeters);
     }
 

--- a/src/main/java/com/conveyal/r5/rastercost/ElevationCostField.java
+++ b/src/main/java/com/conveyal/r5/rastercost/ElevationCostField.java
@@ -61,7 +61,7 @@ public class ElevationCostField implements CostField, Serializable {
 
     @Override
     public int additionalTraversalTimeSeconds (EdgeStore.Edge currentEdge, int traversalTimeSeconds) {
-        return (int) Math.round(traversalTimeSeconds * (factorForEdge(currentEdge) - 1));
+        return (int) Math.round(traversalTimeSeconds * edgeFactors.get(currentEdge.getEdgeIndex()));
     }
 
     @Override
@@ -98,12 +98,10 @@ public class ElevationCostField implements CostField, Serializable {
      * For each edge in the network (not edge pair), a traversal time multiplier.
      * This multiplier is not symmetric with respect to travel direction,
      * so unlike the elevation it's derived from it must be stored for each edge not edge pair.
+     * The edge factors we store will yield the _difference_ in perceived travel time (cost) to be chained additively
+     * Thus 0 means no adjustment to the base traversal time, and 1 means to double the base traversal time.
      */
     public TFloatList edgeFactors;
-
-    public double factorForEdge (EdgeStore.Edge edge) {
-        return edgeFactors.get(edge.getEdgeIndex());
-    }
 
     /**
      * Call a function for every segment in this edge's elevation profile.
@@ -165,6 +163,7 @@ public class ElevationCostField implements CostField, Serializable {
      * weighted result for all segments in an edge.
      */
     public interface ElevationCostCalculator extends ElevationCostField.ElevationSegmentConsumer {
+        /** Return a nonzero positive multiplier for edge traversal time normalized to 1 for flat ground. */
         double weightedElevationFactor ();
     }
 
@@ -184,9 +183,15 @@ public class ElevationCostField implements CostField, Serializable {
         }
     }
 
+    /**
+     * Adjust the factors returned by the elevation cost calculators, which should be 1 on flat ground,
+     * to account for the user-specified outputScale and the fact that we want to return the _difference_ in cost
+     * to be included in a series of additive terms.
+     */
     private double weightedAverageForEdge (EdgeStore.Edge edge) {
+
         forEachElevationSegment(edge, costCalculator);
-        return 1 + (costCalculator.weightedElevationFactor() - 1) * outputScale;
+        return (costCalculator.weightedElevationFactor() - 1) * outputScale;
     }
 
 }

--- a/src/main/java/com/conveyal/r5/rastercost/ElevationLoader.java
+++ b/src/main/java/com/conveyal/r5/rastercost/ElevationLoader.java
@@ -9,6 +9,7 @@ import gnu.trove.list.array.TShortArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandles;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -20,9 +21,9 @@ import static com.conveyal.r5.rastercost.ElevationCostField.DECIMETERS_PER_METER
  *
  * Does geotools support mosaicing coverages together?
  */
-public class ElevationLoader implements CostField.Loader {
+public class ElevationLoader implements CostField.Loader<ElevationCostField> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ElevationLoader.class);
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public static final short[] EMPTY_SHORT_ARRAY = new short[0];
 

--- a/src/main/java/com/conveyal/r5/rastercost/MinettiCalculator.java
+++ b/src/main/java/com/conveyal/r5/rastercost/MinettiCalculator.java
@@ -30,6 +30,12 @@ public class MinettiCalculator implements ElevationCostField.ElevationCostCalcul
     private double xDistance = 0;
 
     @Override
+    public void reset () {
+        weightedSum = 0;
+        xDistance = 0;
+    }
+
+    @Override
     public void consumeElevationSegment (int index, double xMeters, double yMeters) {
         weightedSum += xMeters * minettiCwi(xMeters, yMeters);
         xDistance += xMeters;

--- a/src/main/java/com/conveyal/r5/rastercost/MinettiCalculator.java
+++ b/src/main/java/com/conveyal/r5/rastercost/MinettiCalculator.java
@@ -42,10 +42,10 @@ public class MinettiCalculator implements ElevationCostField.ElevationCostCalcul
     }
 
     /** Return a travel time multiplier for the entire edge, a weighted sum of the factors for all segments. */
+    @Override
     public double weightedElevationFactor () {
         return weightedSum / xDistance;
     }
-
 
     public static double minettiCwi (double dx, double dy) {
         double gradient = dy/dx;

--- a/src/main/java/com/conveyal/r5/rastercost/RasterDataSourceSampler.java
+++ b/src/main/java/com/conveyal/r5/rastercost/RasterDataSourceSampler.java
@@ -113,7 +113,9 @@ public class RasterDataSourceSampler {
         checkArgument(northShiftMeters > -20 && northShiftMeters < 20, "northShiftMeters should be in range (-20...20).");
         // this.northShiftMeters = northShiftMeters;
         latShiftDegrees = northShiftMeters / METERS_PER_DEGREE_LATITUDE;
-        LOG.info("Latitude of sampled points will be shifted by {} degrees.", latShiftDegrees);
+        if (latShiftDegrees != 0) {
+            LOG.info("Latitude of sampled points will be shifted by {} degrees.", latShiftDegrees);
+        }
     }
 
     /**

--- a/src/main/java/com/conveyal/r5/rastercost/SunLoader.java
+++ b/src/main/java/com/conveyal/r5/rastercost/SunLoader.java
@@ -8,6 +8,7 @@ import gnu.trove.list.array.TFloatArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandles;
 import java.util.BitSet;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -17,9 +18,9 @@ import java.util.stream.IntStream;
  * This reuses the same raster sampler as the ElevationLoader to sample at very high resolution (1 meter) and return
  * arrays of doubles which will then be re-interpreted as true or false (nonzero or zero).
  */
-public class SunLoader implements CostField.Loader {
+public class SunLoader implements CostField.Loader<SunCostField> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(SunLoader.class);
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     /** If the input contains shade rather than sun, then boolean values must be inverted. */
     private final boolean invert = true;
@@ -33,7 +34,7 @@ public class SunLoader implements CostField.Loader {
     }
 
     @Override
-    public CostField load (StreetLayer streets) {
+    public SunCostField load (StreetLayer streets) {
         final LambdaCounter edgeCounter = new LambdaCounter(LOG, streets.edgeStore.nEdgePairs(), 100_000,
                 "Sampled sun/shade for {} of {} edge pairs.");
 

--- a/src/main/java/com/conveyal/r5/rastercost/ToblerCalculator.java
+++ b/src/main/java/com/conveyal/r5/rastercost/ToblerCalculator.java
@@ -38,6 +38,7 @@ public class ToblerCalculator implements ElevationCostField.ElevationCostCalcula
      * Return a travel time multiplier for the entire edge, a weighted sum of the factors for all segments.
      * This is inverted, as Tobler produces speed units and we want a time or effort multiplier.
      */
+    @Override
     public double weightedElevationFactor () {
         return 1 / (weightedToblerSum / xDistance);
     }

--- a/src/main/java/com/conveyal/r5/rastercost/ToblerCalculator.java
+++ b/src/main/java/com/conveyal/r5/rastercost/ToblerCalculator.java
@@ -23,6 +23,12 @@ public class ToblerCalculator implements ElevationCostField.ElevationCostCalcula
     }
 
     @Override
+    public void reset () {
+        weightedToblerSum = 0;
+        xDistance = 0;
+    }
+
+    @Override
     public void consumeElevationSegment (int index, double xMeters, double yMeters) {
         weightedToblerSum += xMeters * tobler(xMeters, yMeters);
         xDistance += xMeters;

--- a/src/main/java/com/conveyal/r5/streets/StreetRouter.java
+++ b/src/main/java/com/conveyal/r5/streets/StreetRouter.java
@@ -302,6 +302,7 @@ public class StreetRouter {
             // TODO either: 1) don't hardwire drive-on-right, or 2) global https://en.wikipedia.org/wiki/Dagen_H
             this.timeCalculator = new BasicTraversalTimeCalculator(streetLayer, true);
         }
+        // If any additional costs such as hills or sun are defined, add them on to the base traversal times.
         if (notNullOrEmpty(streetLayer.edgeStore.costFields)) {
             this.timeCalculator = new MultistageTraversalTimeCalculator(this.timeCalculator, streetLayer.edgeStore.costFields);
         }


### PR DESCRIPTION
This PR builds on #782, changing the way cost rasters are applied and how their parameters are interpreted. It is set to merge into that PR rather than dev. The changes in this PR were influenced by https://github.com/conveyal/r5/pull/782#discussion_r817434445. 

Instead of each cost applying to the output of the previous cost and potentially amplifying its effects, each cost is applied separately to the base traversal time of the edge, and all of these differential costs are added together.

In each CostField, the multipliers are now stored normalized to zero instead of one, i.e. a factor of zero means "no additional effect, don't change the base traversal time" and a factor of one means "add 1x the base traversal time", i.e. double the cost of traversing that edge. More importantly for the user, the outputScale parameter to the RasterCost modifications are also interpreted in this way. A value of 0 would completely eliminate the effect, positive 1 would give the default effect, and -1 would invert the effect.

This will require changes to modifications in scenarios and in network build JSON to maintain the expected results.

Elevation effects on edges are reported in vector tiles are changed for consistency with outputScale. Values greater than 0 will be associated with uphill slopes or steep downhill slopes (using extra time and energy), and values less than 0 with gentle downhill slopes (using less time and energy). For this reason, this PR will require a small change to the "network inspector" UI to center the blue-red color scale on zero instead of one. A suggested change is at conveyal/ui#1745.

Sun effects are still reported in vector tiles as the percentage of shade on each edge. They could be reported multiplied with the outputScale but are not currently.

This PR **also fixes a serious bug** with elevation calculation that was introduced when I made it possible to choose between two calculator modules. The calculators were not reset between each edge, leading to uselessly diluted averages.

I have backported just the bugfix to #782, so  if we don't want to change all the modification JSON right now as required by this PR, we can still use #782.

