### PR TITLE
Copy street class to split edges

### DIFF
--- a/src/main/java/com/conveyal/r5/streets/EdgeStore.java
+++ b/src/main/java/com/conveyal/r5/streets/EdgeStore.java
@@ -15,7 +15,6 @@ import com.conveyal.r5.util.TIntIntHashMultimap;
 import com.conveyal.r5.util.TIntIntMultimap;
 import gnu.trove.iterator.TIntIntIterator;
 import gnu.trove.list.TByteList;
-import gnu.trove.list.TFloatList;
 import gnu.trove.list.TIntList;
 import gnu.trove.list.TLongList;
 import gnu.trove.list.TShortList;
@@ -42,8 +41,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.function.IntConsumer;
-
-import static com.google.common.base.Preconditions.checkState;
 
 /**
  * This stores all the characteristics of the edges in the street graph layer of the transport network.

--- a/src/main/java/com/conveyal/r5/streets/EdgeStore.java
+++ b/src/main/java/com/conveyal/r5/streets/EdgeStore.java
@@ -8,6 +8,7 @@ import com.conveyal.r5.profile.ProfileRequest;
 import com.conveyal.r5.profile.StreetMode;
 import com.conveyal.r5.rastercost.CostField;
 import com.conveyal.r5.trove.AugmentedList;
+import com.conveyal.r5.trove.TByteAugmentedList;
 import com.conveyal.r5.trove.TIntAugmentedList;
 import com.conveyal.r5.trove.TLongAugmentedList;
 import com.conveyal.r5.util.P2;
@@ -1256,12 +1257,11 @@ public class EdgeStore implements Serializable {
         copy.geometries = new AugmentedList<>(geometries);
         copy.lengths_mm = new TIntAugmentedList(lengths_mm);
         copy.osmids = new TLongAugmentedList(this.osmids);
-        copy.streetClasses = new TByteArrayList(this.streetClasses); // FIXME Implement TByteAugmentedList
+        copy.streetClasses = new TByteAugmentedList(this.streetClasses);
         copy.temporarilyDeletedEdges = new TIntHashSet();
-        // Angles are deep copy for now FIXME we are copying these entire arrays! Implement TByteAugmentedList
-        copy.inAngles = new TByteArrayList(inAngles);
-        copy.outAngles = new TByteArrayList(outAngles);
-        // We don't expect to add/change any turn restrictions.
+        copy.inAngles = new TByteAugmentedList(inAngles);
+        copy.outAngles = new TByteAugmentedList(outAngles);
+        // We don't expect to add/change any turn restrictions. TODO Consider split streets though.
         copy.turnRestrictions = turnRestrictions;
         copy.turnRestrictionsReverse = turnRestrictionsReverse;
         if (edgeTraversalTimes != null) {

--- a/src/main/java/com/conveyal/r5/streets/EdgeStore.java
+++ b/src/main/java/com/conveyal/r5/streets/EdgeStore.java
@@ -109,7 +109,7 @@ public class EdgeStore implements Serializable {
     public TLongList osmids;
 
     /**
-     * For each edge _pair_, the OSM highway class is was derived from. Integer codes are defined in the StreetClass
+     * For each edge _pair_, the OSM highway class it was derived from. Integer codes are defined in the StreetClass
      * enum. Like OSM IDs and street names, these could be factored out into a table of OSM way data.
      */
     public TByteList streetClasses;
@@ -562,6 +562,7 @@ public class EdgeStore implements Serializable {
             flags.set(backEdge, other.getEdgeStore().flags.get(otherBackEdge));
             speeds.set(foreEdge, other.getEdgeStore().speeds.get(otherForeEdge));
             speeds.set(backEdge, other.getEdgeStore().speeds.get(otherBackEdge));
+            streetClasses.set(pairIndex, other.getEdgeStore().streetClasses.get(pairIndex));
         }
 
         public void copyPairGeometry(Edge other) {

--- a/src/main/java/com/conveyal/r5/trove/TByteAugmentedList.java
+++ b/src/main/java/com/conveyal/r5/trove/TByteAugmentedList.java
@@ -1,0 +1,338 @@
+package com.conveyal.r5.trove;
+
+import gnu.trove.TByteCollection;
+import gnu.trove.function.TByteFunction;
+import gnu.trove.iterator.TByteIterator;
+import gnu.trove.list.TByteList;
+import gnu.trove.list.TLongList;
+import gnu.trove.list.array.TByteArrayList;
+import gnu.trove.list.array.TLongArrayList;
+import gnu.trove.procedure.TByteProcedure;
+
+import java.util.Collection;
+import java.util.Random;
+
+/**
+ * FIXME we now have four TXAugmentedList classes. This is manual templating of primitive generics which is pretty
+ *       easy to write but might be a real problem to maintain.
+ */
+public class TByteAugmentedList implements TByteList {
+
+    private final TByteList base;
+
+    private final TByteList extension;
+
+    public TByteAugmentedList (TByteList base) {
+        this.base = base;
+        this.extension = new TByteArrayList();
+    }
+
+    @Override
+    public byte get (int index) {
+        if (index < base.size()) {
+            return base.get(index);
+        } else {
+            return extension.get(index - base.size());
+        }
+    }
+
+    @Override
+    public byte set (int index, byte value) {
+        if (index < base.size()) {
+            throw new RuntimeException("Modifying the base graph is not allowed.");
+        } else {
+            return extension.set(index - base.size(), value);
+        }
+    }
+
+    @Override
+    public boolean add (byte val) {
+        return extension.add(val);
+    }
+
+    @Override
+    public int size() {
+        return base.size() + extension.size();
+    }
+
+
+    /**
+     *  Nominally implement the (enormous) TByteList interface.
+     *  But all of these remain unimplemented until we need them.
+     */
+
+    @Override
+    public byte getNoEntryValue () {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isEmpty () {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void add (byte[] vals) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void add (byte[] vals, int offset, int length) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void insert (int offset, byte value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void insert (int offset, byte[] values) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void insert (int offset, byte[] values, int valOffset, int len) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void set (int offset, byte[] values) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void set (int offset, byte[] values, int valOffset, int length) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte replace (int offset, byte val) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clear () {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove (byte value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean containsAll (Collection<?> collection) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean containsAll (TByteCollection collection) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean containsAll (byte[] array) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean addAll (Collection<? extends Byte> collection) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean addAll (TByteCollection collection) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean addAll (byte[] array) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean retainAll (Collection<?> collection) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean retainAll (TByteCollection collection) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean retainAll (byte[] array) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeAll (Collection<?> collection) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeAll (TByteCollection collection) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeAll (byte[] array) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte removeAt (int offset) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void remove (int offset, int length) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void transformValues (TByteFunction function) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void reverse () {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void reverse (int from, int to) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void shuffle (Random rand) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TByteList subList (int begin, int end) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[] toArray () {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[] toArray (int offset, int len) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[] toArray (byte[] dest) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[] toArray (byte[] dest, int offset, int len) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[] toArray (byte[] dest, int source_pos, int dest_pos, int len) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean forEach (TByteProcedure procedure) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean forEachDescending (TByteProcedure procedure) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void sort () {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void sort (int fromIndex, int toIndex) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void fill (byte val) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void fill (int fromIndex, int toIndex, byte val) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int binarySearch (byte value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int binarySearch (byte value, int fromIndex, int toIndex) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int indexOf (byte value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int indexOf (int offset, byte value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int lastIndexOf (byte value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int lastIndexOf (int offset, byte value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean contains (byte value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TByteIterator iterator () {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TByteList grep (TByteProcedure condition) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TByteList inverseGrep (TByteProcedure condition) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte max () {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte min () {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte sum () {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
When new edges are created at split points for transit stops, the new edges have flags and speeds copied from the original unsplit edge. The streetClass values should be copied in the same place, as proposed in this PR.

To test, check to make sure that streets don't switch to class 4 at transit stops. Before the fix:
![image](https://user-images.githubusercontent.com/2173529/161634268-6b3d5a53-3ca6-44df-9677-afb0f884cab6.png)

Based on discussions, @abyrd added another change here, addressing an existing FIXME related to Trove lists for streetClasses and in/out angles.