### PR TITLE
Fix condition for logging IndexedPolygonCollection attribute type errors

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/scenario/IndexedPolygonCollection.java
+++ b/src/main/java/com/conveyal/r5/analyst/scenario/IndexedPolygonCollection.java
@@ -132,7 +132,7 @@ public class IndexedPolygonCollection {
             boolean indexThisFeature = true;
             if (id == null) {
                 allPolygonsHaveIds = false;
-            } else if (!(name instanceof String)) {
+            } else if (!(id instanceof String)) {
                 errors.add(String.format("Value '%s' of attribute '%s' of feature %d should be a string.",
                         id, idAttribute, featureNumber));
                 indexThisFeature = false;


### PR DESCRIPTION
Because of an apparent copy/paste mistake in our code, users will see a confusing error if they try to use a pickup delay geojson without `name` properties. This PR corrects the mistake, checking the `id` property in the appropriate place (and leaving the `name` property checks unchanged in the following lines).