### PR TITLE
Handle GTFS feeds with pathway nodes

### DIFF
--- a/src/main/java/com/conveyal/analysis/controllers/BundleController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/BundleController.java
@@ -16,6 +16,7 @@ import com.conveyal.gtfs.GTFSFeed;
 import com.conveyal.gtfs.error.GTFSError;
 import com.conveyal.gtfs.error.GeneralError;
 import com.conveyal.gtfs.model.Stop;
+import com.conveyal.gtfs.validator.PostLoadValidator;
 import com.conveyal.osmlib.Node;
 import com.conveyal.osmlib.OSM;
 import com.conveyal.r5.analyst.progress.ProgressInputStream;
@@ -198,6 +199,9 @@ public class BundleController implements HttpController {
                         GTFSFeed feed = GTFSFeed.newWritableFile(tempDbFile);
                         feed.progressListener = progressListener;
                         feed.loadFromFile(zipFile, new ObjectId().toString());
+
+                        // Perform any more complex validation that requires cross-table checks.
+                        new PostLoadValidator(feed).validate();
 
                         // Find and validate the extents of the GTFS, defined by all stops in the feed.
                         for (Stop s : feed.stops.values()) {

--- a/src/main/java/com/conveyal/analysis/controllers/GtfsController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/GtfsController.java
@@ -151,7 +151,8 @@ public class GtfsController implements HttpController {
         }
     }
     /**
-     * Return StopApiResponse values for GTFS stops (location_type = 0) in a single feed
+     * Return StopApiResponse values for GTFS stops (location_type = 0) in a single feed.
+     * All other location_types (station, entrance, generic node, boarding area) are skipped.
      */
     private List<StopApiResponse> getAllStopsForOneFeed(Request req, Response res) {
         GTFSFeed feed = getFeedFromRequest(req);
@@ -160,8 +161,8 @@ public class GtfsController implements HttpController {
     }
 
     /**
-     * Groups the feedId and stops (location_type = 0; not parent stations, entrances/exits, generic nodes, etc.) for a
-     * given GTFS feed
+     * Compound return type for the feedId and stops with location_type = 0 for a given GTFS feed.
+     * All other location_types (station, entrance, generic node, boarding area) are skipped.
      */
     static class FeedGroupStopsApiResponse {
         public final String feedId;

--- a/src/main/java/com/conveyal/gtfs/GTFSCache.java
+++ b/src/main/java/com/conveyal/gtfs/GTFSCache.java
@@ -220,6 +220,12 @@ public class GTFSCache implements Component {
         final GTFSFeed feed = this.get(bundleScopedFeedId);
         LOG.info("{}: indexing {} stops", feed.feedId, feed.stops.size());
         for (Stop stop : feed.stops.values()) {
+            // To match existing GTFS API, include only stop objects that have location_type 0.
+            // All other location_types (station, entrance, generic node, boarding area) are skipped.
+            // Missing (NaN) coordinates will confuse the spatial index and cascade hundreds of errors.
+            if (stop.location_type != 0 || !Double.isFinite(stop.stop_lat) || !Double.isFinite(stop.stop_lon)) {
+                continue;
+            }
             Envelope stopEnvelope = new Envelope(stop.stop_lon, stop.stop_lon, stop.stop_lat, stop.stop_lat);
             Point point = GeometryUtils.geometryFactory.createPoint(new Coordinate(stop.stop_lon, stop.stop_lat));
 

--- a/src/main/java/com/conveyal/gtfs/error/ForbiddenFieldError.java
+++ b/src/main/java/com/conveyal/gtfs/error/ForbiddenFieldError.java
@@ -1,0 +1,22 @@
+package com.conveyal.gtfs.error;
+
+import com.conveyal.gtfs.validator.model.Priority;
+
+import java.io.Serializable;
+
+/** Indicates that a field considered forbidden is present in a GTFS feed on a particular line. */
+public class ForbiddenFieldError extends GTFSError implements Serializable {
+    public static final long serialVersionUID = 1L;
+
+    public ForbiddenFieldError (String file, long line, String field) {
+        super(file, line, field);
+    }
+
+    @Override public String getMessage() {
+        return String.format("A value was supplied for a forbidden column.");
+    }
+
+    @Override public Priority getPriority() {
+        return Priority.MEDIUM;
+    }
+}

--- a/src/main/java/com/conveyal/gtfs/model/Calendar.java
+++ b/src/main/java/com/conveyal/gtfs/model/Calendar.java
@@ -41,7 +41,8 @@ public class Calendar extends Entity implements Serializable {
 
         @Override
         protected boolean isRequired() {
-            return true;
+            // One of calendar or calendar_dates must be present - check in more flexible modular validation later.
+            return false;
         }
 
         @Override

--- a/src/main/java/com/conveyal/gtfs/model/CalendarDate.java
+++ b/src/main/java/com/conveyal/gtfs/model/CalendarDate.java
@@ -41,6 +41,7 @@ public class CalendarDate extends Entity implements Cloneable, Serializable {
 
         @Override
         protected boolean isRequired() {
+            // One of calendar or calendar_dates must be present - check in more flexible modular validation later.
             return false;
         }
 

--- a/src/main/java/com/conveyal/gtfs/model/Entity.java
+++ b/src/main/java/com/conveyal/gtfs/model/Entity.java
@@ -208,6 +208,7 @@ public abstract class Entity implements Serializable {
             return url;
         }
 
+        /** @return NaN if the number is missing or cannot be parsed. */
         protected double getDoubleField(String column, boolean required, double min, double max) throws IOException {
             String str = getFieldCheckRequired(column, required);
             double val = Double.NaN;

--- a/src/main/java/com/conveyal/gtfs/model/Stop.java
+++ b/src/main/java/com/conveyal/gtfs/model/Stop.java
@@ -48,17 +48,20 @@ public class Stop extends Entity {
             s.stop_code = getStringField("stop_code", false);
             s.stop_name = getStringField("stop_name", true);
             s.stop_desc = getStringField("stop_desc", false);
-            s.stop_lat  = getDoubleField("stop_lat", true, -90D, 90D);
-            s.stop_lon  = getDoubleField("stop_lon", true, -180D, 180D);
             s.zone_id   = getStringField("zone_id", false);
             s.stop_url  = getUrlField("stop_url", false);
-            s.location_type  = getIntField("location_type", false, 0, 1);
-            s.parent_station = getStringField("parent_station", false);
+            s.location_type  = getIntField("location_type", false, 0, 4);
+            // 0...2 are stop, station, and entrance which must have lat and lon. Other nodes do not need coordinates.
+            boolean coord_required = s.location_type <= 2;
+            s.stop_lat  = getDoubleField("stop_lat", coord_required, -90D, 90D);
+            s.stop_lon  = getDoubleField("stop_lon", coord_required, -180D, 180D);
+            // Required for entrances, generic nodes, and boarding areas. Optional for stops, forbidden for stations.
+            boolean parent_station_required = s.location_type >= 2;
+            s.parent_station = getStringField("parent_station", parent_station_required);
             s.stop_timezone  = getStringField("stop_timezone", false);
             s.wheelchair_boarding = getStringField("wheelchair_boarding", false);
             s.feed_id = feed.feedId;
             /* TODO check ref integrity later, this table self-references via parent_station */
-
             feed.stops.put(s.stop_id, s);
         }
 

--- a/src/main/java/com/conveyal/gtfs/validator/PostLoadValidator.java
+++ b/src/main/java/com/conveyal/gtfs/validator/PostLoadValidator.java
@@ -1,0 +1,104 @@
+package com.conveyal.gtfs.validator;
+
+import com.conveyal.gtfs.GTFSFeed;
+import com.conveyal.gtfs.error.EmptyFieldError;
+import com.conveyal.gtfs.error.ForbiddenFieldError;
+import com.conveyal.gtfs.error.GeneralError;
+import com.conveyal.gtfs.error.RangeError;
+import com.conveyal.gtfs.error.ReferentialIntegrityError;
+import com.conveyal.gtfs.model.Stop;
+
+/**
+ * Currently we perform a lot of validation while we're loading the rows out of the input GTFS feed.
+ * This can only catch certain categories of problems. Other problems must be found after tables are fully loaded.
+ * These include self-referential tables like stops (which reference other stops as parent_stations).
+ * This could also be expressed as a postLoadValidation method on Entity.Loader.
+ *
+ * In the original RDBMS-enabled gtfs-lib we had a lot of validation classes that would perform checks after loading.
+ * This included more complex semantic checks of the kind we do in r5 while building networks. We might want to
+ * re-import those gtfs-lib validators and adapt them to operate on MapDB only for the purposes of r5.
+ * However, validating a feed takes a lot of sorting and grouping of stop_times that will need to be repeated when we
+ * build a network. It's debatable whether we should make the user wait twice for this, as it's one of the slower steps.
+ */
+public class PostLoadValidator {
+
+    private GTFSFeed feed;
+
+    public PostLoadValidator (GTFSFeed feed) {
+        this.feed = feed;
+    }
+
+    public void validate () {
+        validateCalendarServices();
+        validateStopStationConstraints();
+    }
+
+    /**
+     * calendars and calendar_dates are the only conditionally required tables: at least one of the two must be present.
+     * The underlying requirement is that at least some service is defined.
+     */
+    private void validateCalendarServices () {
+        if (feed.services.isEmpty()) {
+            feed.errors.add(new GeneralError("calendar.txt", 0, "service_id",
+                    "Feed does not define any services in calendar or calendar_dates."));
+        }
+    }
+
+    /**
+     * Validate location_type and parent_station constraints as well as referential integrity.
+     */
+    private void validateStopStationConstraints () {
+        for (Stop stop : feed.stops.values()) {
+            if (checkRule(stop, 0, Requirement.OPTIONAL, 1)) continue;
+            if (checkRule(stop, 1, Requirement.FORBIDDEN, 0)) continue;
+            if (checkRule(stop, 2, Requirement.REQUIRED, 1)) continue;
+            if (checkRule(stop, 3, Requirement.REQUIRED, 1)) continue;
+            if (checkRule(stop, 4, Requirement.REQUIRED, 0)) continue;
+        }
+    }
+
+    private enum Requirement {
+        OPTIONAL, REQUIRED, FORBIDDEN
+    }
+    private static final String FILE = "stops.txt";
+    private static final String FIELD = "parent_station";
+
+    /**
+     * Call this method once for each location_type, defining a rules about that location_type's parent_station.
+     * @param location_type the location_type to which the rule applies
+     * @param parent_station_requirement whether the parent_station is required, forbidden, or optional
+     * @param parent_station_location_type if the parent_station is present, what location_type it must be
+     * @return true if this rule validated the stop, or false if more rules must be checked
+     */
+    public boolean checkRule (
+            Stop stop, int location_type,
+            Requirement parent_station_requirement,
+            int parent_station_location_type
+    ) {
+        // If this rule does not apply to this stop, do not perform checks.
+        if (stop.location_type != location_type) {
+            return false;
+        }
+        if (stop.parent_station == null) {
+            if (parent_station_requirement == Requirement.REQUIRED) {
+                feed.errors.add(new EmptyFieldError(FILE, stop.sourceFileLine, FIELD));
+            }
+        } else {
+            // Parent station reference was supplied.
+            if (parent_station_requirement == Requirement.FORBIDDEN) {
+                feed.errors.add(new ForbiddenFieldError(FILE, stop.sourceFileLine, FIELD));
+            }
+            Stop parent_station = feed.stops.get(stop.parent_station);
+            if (parent_station == null) {
+                feed.errors.add(new ReferentialIntegrityError(FILE, stop.sourceFileLine, FIELD, stop.parent_station));
+            } else {
+                if (parent_station.location_type != parent_station_location_type) {
+                    feed.errors.add(new RangeError(FILE, stop.sourceFileLine, FIELD,
+                            parent_station_location_type, parent_station_location_type, parent_station.location_type));
+                }
+            }
+        }
+        return true;
+    }
+
+}


### PR DESCRIPTION
This PR contains first steps to address issue #803. The most visible immediate effect is that it avoids spatial index errors from feeds with stops that lack coordinates when generating GTFS vector tiles. The underlying change is gracefully tolerating GTFS feeds that use the pathway extensions, even where we don't yet use those nodes in routing.

The code is already in working condition, but we may want to add more validation or build a full routable model from the pathways in transfers.txt. That could be done in this PR or a subsequent one.