### PR TITLE
Add zoom level to aggregation areas

### DIFF
--- a/src/main/java/com/conveyal/analysis/datasource/derivation/AggregationAreaDerivation.java
+++ b/src/main/java/com/conveyal/analysis/datasource/derivation/AggregationAreaDerivation.java
@@ -22,8 +22,6 @@ import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.operation.union.UnaryUnionOp;
 import org.opengis.feature.simple.SimpleFeature;
-import org.opengis.referencing.FactoryException;
-import org.opengis.referencing.operation.TransformException;
 import spark.Request;
 
 import java.io.File;
@@ -37,7 +35,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPOutputStream;
 
-import static com.conveyal.file.FileStorageFormat.GEOJSON;
 import static com.conveyal.file.FileStorageFormat.SHP;
 import static com.conveyal.r5.analyst.WebMercatorGridPointSet.parseZoom;
 import static com.conveyal.r5.analyst.progress.WorkProductType.AGGREGATION_AREA;
@@ -209,7 +206,7 @@ public class AggregationAreaDerivation implements DataDerivation<SpatialDataSour
                 maskGrid.grid[pixel.x][pixel.y] = pixel.weight * 100_000;
             });
 
-            AggregationArea aggregationArea = new AggregationArea(userPermissions, name, spatialDataSource);
+            AggregationArea aggregationArea = new AggregationArea(userPermissions, name, spatialDataSource, zoom);
 
             try {
                 File gridFile = FileUtils.createScratchFile("grid");

--- a/src/main/java/com/conveyal/analysis/models/AggregationArea.java
+++ b/src/main/java/com/conveyal/analysis/models/AggregationArea.java
@@ -22,13 +22,16 @@ public class AggregationArea extends BaseModel {
     public String dataSourceId;
     public String dataGroupId;
 
+    public int zoom;
+
     /** Zero-argument constructor required for Mongo automatic POJO deserialization. */
     public AggregationArea () { }
 
-    public AggregationArea(UserPermissions user, String name, SpatialDataSource dataSource) {
+    public AggregationArea(UserPermissions user, String name, SpatialDataSource dataSource, int zoom) {
         super(user, name);
         this.regionId = dataSource.regionId;
         this.dataSourceId = dataSource._id.toString();
+        this.zoom = zoom;
     }
 
     @JsonIgnore


### PR DESCRIPTION
Store the zoom level of each aggregation area in the database. It is currently only in the grid file itself and therefore we cannot search the database for aggregation areas by zoom level. 

There is work started on a [script](https://github.com/conveyal/ui/pull/1832) to find all aggregation area files, parse the zoom level and add it to the corresponding database entry.