### PR TITLE
Add an endpoint for deleting tasks

### DIFF
--- a/src/main/java/com/conveyal/analysis/components/TaskScheduler.java
+++ b/src/main/java/com/conveyal/analysis/components/TaskScheduler.java
@@ -173,6 +173,14 @@ public class TaskScheduler implements Component {
         }
     }
 
+    public boolean removeTaskForUser (String userEmail, String taskId) {
+        synchronized (tasksForUser) {
+            Set<Task> tasks = tasksForUser.get(userEmail);
+            if (tasks == null) return false;
+            return tasks.removeIf(t -> t.id.toString().equals(taskId));
+        }
+    }
+
     // Q: Should the caller ever create its own Tasks, or if are tasks created here inside the TaskScheduler from
     // other raw information? Having the caller creating a Task seems like a good way to configure execution details
     // like heavy/light/periodic, and submit user information without passing it in. That task request could be separate

--- a/src/main/java/com/conveyal/analysis/components/TaskScheduler.java
+++ b/src/main/java/com/conveyal/analysis/components/TaskScheduler.java
@@ -174,6 +174,19 @@ public class TaskScheduler implements Component {
         }
     }
 
+    public Task getTaskForUser (String userEmail, String taskId) {
+        synchronized (tasksForUser) {
+            Set<Task> tasks = tasksForUser.get(userEmail);
+            if (tasks == null) return null;
+            for (Task t : tasks) {
+                if (t.id.toString().equals(taskId)) {
+                    return t;
+                }
+            }
+            return null;
+        }
+    }
+
     public boolean removeTaskForUser (String userEmail, String taskId) {
         synchronized (tasksForUser) {
             Set<Task> tasks = tasksForUser.get(userEmail);

--- a/src/main/java/com/conveyal/analysis/components/TaskScheduler.java
+++ b/src/main/java/com/conveyal/analysis/components/TaskScheduler.java
@@ -169,7 +169,7 @@ public class TaskScheduler implements Component {
                     .map(Task::toApiTask)
                     .collect(Collectors.toUnmodifiableList());
             // Purge tasks older than one day.
-            tasks.removeIf(t -> t.durationComplete().toDays() > 1);
+            tasks.removeIf(t -> t.durationComplete().toDays() > 3);
             return apiTaskList;
         }
     }

--- a/src/main/java/com/conveyal/analysis/components/TaskScheduler.java
+++ b/src/main/java/com/conveyal/analysis/components/TaskScheduler.java
@@ -168,7 +168,7 @@ public class TaskScheduler implements Component {
             List<ApiTask> apiTaskList = tasks.stream()
                     .map(Task::toApiTask)
                     .collect(Collectors.toUnmodifiableList());
-            // Purge tasks older than one day.
+            // Purge old tasks.
             tasks.removeIf(t -> t.durationComplete().toDays() > 3);
             return apiTaskList;
         }

--- a/src/main/java/com/conveyal/analysis/components/TaskScheduler.java
+++ b/src/main/java/com/conveyal/analysis/components/TaskScheduler.java
@@ -174,6 +174,9 @@ public class TaskScheduler implements Component {
         }
     }
 
+    /**
+     * Return a single task. Does not purge old tasks.
+     */
     public Task getTaskForUser (String userEmail, String taskId) {
         synchronized (tasksForUser) {
             Set<Task> tasks = tasksForUser.get(userEmail);
@@ -187,6 +190,9 @@ public class TaskScheduler implements Component {
         }
     }
 
+    /**
+     * Remove a task. Returns false if task does not exist. Returns true if task exists and is properly removed.
+     */
     public boolean removeTaskForUser (String userEmail, String taskId) {
         synchronized (tasksForUser) {
             Set<Task> tasks = tasksForUser.get(userEmail);

--- a/src/main/java/com/conveyal/analysis/components/TaskScheduler.java
+++ b/src/main/java/com/conveyal/analysis/components/TaskScheduler.java
@@ -168,7 +168,8 @@ public class TaskScheduler implements Component {
             List<ApiTask> apiTaskList = tasks.stream()
                     .map(Task::toApiTask)
                     .collect(Collectors.toUnmodifiableList());
-            tasks.removeIf(t -> t.durationComplete().getSeconds() > 60);
+            // Purge tasks older than one day.
+            tasks.removeIf(t -> t.durationComplete().toDays() > 1);
             return apiTaskList;
         }
     }

--- a/src/main/java/com/conveyal/analysis/controllers/UserActivityController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/UserActivityController.java
@@ -57,9 +57,9 @@ public class UserActivityController implements HttpController {
         UserPermissions userPermissions = UserPermissions.from(req);
         String id = req.params("id");
         if (taskScheduler.removeTaskForUser(userPermissions.email, id)) {
-            return ImmutableMap.of("message", "Successfully removed activity.");
+            return ImmutableMap.of("message", "Successfully cleared activity.");
         } else {
-            throw AnalysisServerException.badRequest("Failed to remove activity.");
+            throw AnalysisServerException.badRequest("Failed to clear activity.");
         }
     }
 


### PR DESCRIPTION
Allow users to manually clear a tasks. Additionally, increases the automatic purge time to 24 hours.

Corresponds to https://github.com/conveyal/ui/pull/1835 which greatly simplifies the client side logic for handling tasks.