### PR TITLE
Increase limit on geographic extents for grids, OSM, and GTFS

### DIFF
--- a/src/main/java/com/conveyal/r5/common/GeometryUtils.java
+++ b/src/main/java/com/conveyal/r5/common/GeometryUtils.java
@@ -23,8 +23,8 @@ public class GeometryUtils {
     /** Average of polar and equatorial radii, https://en.wikipedia.org/wiki/Earth */
     public static final double RADIUS_OF_EARTH_M = 6_367_450;
 
-    /** Maximum area allowed for the bounding box of an uploaded shapefile -- large enough for New York State.  */
-    private static final double MAX_BOUNDING_BOX_AREA_SQ_KM = 250_000;
+    /** Maximum area allowed for the bounding box of uploaded files -- large enough for California.  */
+    private static final double MAX_BOUNDING_BOX_AREA_SQ_KM = 975_000;
 
     /**
      * Haversine formula for distance on the sphere. We used to have a fastDistance function that would estimate this


### PR DESCRIPTION
We had a longstanding 250k sq km limit on grids, and in #748 applied the same limit to GTFS and OSM. This limit is too strict; a few users have encountered the size error when building a network with previously uploaded OSM and the latest worker version.

I considered separate limits for grids (because the 250k limit was in place for a while) and network inputs, but I don't think the added conditionals are worth it.

We should test uploading a large (e.g. California-size) shapefile and converting it to a grid to ensure this works. I am less concerned about the network input files, because we did not have a limit on those until recently.