### PR TITLE
Use the zoom level in aggregation area data group name

### DIFF
--- a/src/main/java/com/conveyal/analysis/datasource/derivation/AggregationAreaDerivation.java
+++ b/src/main/java/com/conveyal/analysis/datasource/derivation/AggregationAreaDerivation.java
@@ -172,7 +172,7 @@ public class AggregationAreaDerivation implements DataDerivation<SpatialDataSour
     public void action (ProgressListener progressListener) throws Exception {
 
         ArrayList<AggregationArea> aggregationAreas = new ArrayList<>();
-        String groupDescription = "Aggregation areas from polygons";
+        String groupDescription = "z" + this.zoom + ": aggregation areas";
         DataGroup dataGroup = new DataGroup(userPermissions, spatialDataSource._id.toString(), groupDescription);
 
         progressListener.beginTask("Reading data source", finalFeatures.size() + 1);


### PR DESCRIPTION
This will help when searching through data groups. Note: since the data group doesn't have any properties itself it must be in the name.