### PR TITLE
Fix off-by-one in CSV error message

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/FreeFormPointSet.java
+++ b/src/main/java/com/conveyal/r5/analyst/FreeFormPointSet.java
@@ -123,7 +123,7 @@ public class FreeFormPointSet extends PointSet {
             return ret;
         } catch (NumberFormatException nfe) {
             throw new ParameterException(
-                String.format("Improperly formatted floating point value on line %d of CSV input", rec)
+                String.format("Improperly formatted floating point value near line %d of CSV input", rec + 1)
             );
         }
     }


### PR DESCRIPTION
The record index starts at the first record, while the source CSV index starts at the header.

Also, switching to "near line x" instead of "on line x" for users who may be troubleshooting with spreadsheet software that uses 1-based indexing.