### PR TITLE
Refine spot instance startup

### DIFF
--- a/src/main/java/com/conveyal/analysis/components/broker/Broker.java
+++ b/src/main/java/com/conveyal/analysis/components/broker/Broker.java
@@ -263,6 +263,7 @@ public class Broker implements Component {
         // configured maximum
         if (workerCatalog.totalWorkerCount() * 2 > config.maxWorkers()) {
             nSpot = Math.min(nSpot, (config.maxWorkers() - workerCatalog.totalWorkerCount()) / 2);
+            LOG.info("Worker pool over half of maximum size. Number of new spot instances set to {}", nSpot);
         }
 
         if (workerCatalog.totalWorkerCount() + nOnDemand + nSpot >= config.maxWorkers()) {


### PR DESCRIPTION
When a regional analysis triggers a request to start spot instance workers, if the request would lead the total number of workers to exceed our configured limit (~6x higher on prod vs. staging), the request is totally ignored.

This PR changes that behavior and reduces the likelihood requests will be ignored:
* Reduces the number of instances requested for higher zoom and non-transit analyses
* Adds a backoff function (h/t Zeno's paradox) -- if we are halfway to the limit on the total number of workers, no more than half of the available remaining slots will be requested

Three additional refinements could be considered -- per-access group limits, further reducing the number of instances requested when analyses don't have frequency-based routes (we don't yet expose `hasFrequency()` in a convenient place though), and sizing the spot instance request based on observed tasks per minute.