### PR TITLE
Path summaries: return raw data in JSON

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalysisWorker.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalysisWorker.java
@@ -38,7 +38,6 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
@@ -348,7 +347,7 @@ public class AnalysisWorker implements Component {
                     oneOriginResult.accessibility,
                     transportNetwork.scenarioApplicationWarnings,
                     transportNetwork.scenarioApplicationInfo,
-                    oneOriginResult.paths
+                    oneOriginResult.paths != null ? new PathResultSummary(oneOriginResult.paths, transportNetwork.transitLayer) : null
             );
         }
         // Single-point tasks don't have a job ID. For now, we'll categorize them by scenario ID.
@@ -488,7 +487,7 @@ public class AnalysisWorker implements Component {
 
         public List<TaskError> scenarioApplicationInfo;
 
-        public List<PathResult.PathIterations> pathSummaries;
+        public PathResultSummary pathSummaries;
 
         @Override
         public String toString () {
@@ -515,7 +514,7 @@ public class AnalysisWorker implements Component {
             AccessibilityResult accessibilityResult,
             List<TaskError> scenarioApplicationWarnings,
             List<TaskError> scenarioApplicationInfo,
-            PathResult pathResult
+            PathResultSummary pathResult
     ) throws IOException {
         var jsonBlock = new GridJsonBlock();
         jsonBlock.scenarioApplicationInfo = scenarioApplicationInfo;
@@ -526,7 +525,7 @@ public class AnalysisWorker implements Component {
             // study area). But we'd need to control the number of decimal places serialized into the JSON.
             jsonBlock.accessibility = accessibilityResult.getIntValues();
         }
-        jsonBlock.pathSummaries = pathResult == null ? Collections.EMPTY_LIST : pathResult.getPathIterationsForDestination();
+        jsonBlock.pathSummaries = pathResult;
         LOG.debug("Travel time surface written, appending {}.", jsonBlock);
         // We could do this when setting up the Spark handler, supplying writeValue as the response transformer
         // But then you also have to handle the case where you are returning raw bytes.

--- a/src/main/java/com/conveyal/r5/analyst/cluster/PathResult.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/PathResult.java
@@ -153,16 +153,16 @@ public class PathResult {
      * Wraps path and iteration details for JSON serialization
      */
     public static class PathIterations {
-        public StreetTimesAndModes.StreetTimeAndMode access; // StreetTimesAndModes.StreetTimeAndMode would be more machine-readable.
+        public StreetTimesAndModes.StreetTimeAndMode access;
         public StreetTimesAndModes.StreetTimeAndMode egress;
         public Collection<RouteSequence.TransitLeg> transitLegs;
-        public Collection<HumanReadableIteration> iterations;
+        public Collection<Iteration> iterations;
 
         PathIterations(RouteSequence pathTemplate, TransitLayer transitLayer, Collection<Iteration> iterations) {
             this.access = pathTemplate.stopSequence.access;
             this.egress = pathTemplate.stopSequence.egress;
             this.transitLegs = pathTemplate.transitLegs(transitLayer);
-            this.iterations = iterations.stream().map(HumanReadableIteration::new).collect(Collectors.toList());
+            this.iterations = iterations;
         }
     }
 
@@ -208,21 +208,4 @@ public class PathResult {
             this.totalTime = totalTime;
         }
     }
-
-    /**
-     * Timestamp style clock times, and rounded wait/total time, for inspection as JSON.
-     */
-    public static class HumanReadableIteration {
-        public int departureTime;
-        public int[] waitTimes;
-        public int totalTime;
-
-        HumanReadableIteration(Iteration iteration) {
-            // TODO track departure time for non-transit paths (so direct trips don't show departure time 00:00).
-            this.departureTime = iteration.departureTime;
-            this.waitTimes =  iteration.waitTimes.toArray();
-            this.totalTime =  iteration.totalTime;
-        }
-    }
-
 }

--- a/src/main/java/com/conveyal/r5/analyst/cluster/PathResult.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/PathResult.java
@@ -46,7 +46,7 @@ public class PathResult {
      * details. For now, the path template is a route-based path ignoring per-iteration details such as wait time.
      * With additional changes, patterns could be collapsed further to route combinations or modes.
      */
-    private final Multimap<RouteSequence, Iteration>[] iterationsForPathTemplates;
+    public final Multimap<RouteSequence, Iteration>[] iterationsForPathTemplates;
     private final TransitLayer transitLayer;
 
     public static String[] DATA_COLUMNS = new String[]{

--- a/src/main/java/com/conveyal/r5/analyst/cluster/PathResult.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/PathResult.java
@@ -1,5 +1,6 @@
 package com.conveyal.r5.analyst.cluster;
 
+import com.conveyal.r5.analyst.StreetTimesAndModes;
 import com.conveyal.r5.transit.TransitLayer;
 import com.conveyal.r5.transit.path.Path;
 import com.conveyal.r5.transit.path.PatternSequence;
@@ -11,7 +12,6 @@ import gnu.trove.list.array.TIntArrayList;
 import org.apache.commons.lang3.ArrayUtils;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
@@ -153,21 +153,16 @@ public class PathResult {
      * Wraps path and iteration details for JSON serialization
      */
     public static class PathIterations {
-        public String access; // StreetTimesAndModes.StreetTimeAndMode would be more machine-readable.
-        public String egress;
+        public StreetTimesAndModes.StreetTimeAndMode access; // StreetTimesAndModes.StreetTimeAndMode would be more machine-readable.
+        public StreetTimesAndModes.StreetTimeAndMode egress;
         public Collection<RouteSequence.TransitLeg> transitLegs;
         public Collection<HumanReadableIteration> iterations;
 
         PathIterations(RouteSequence pathTemplate, TransitLayer transitLayer, Collection<Iteration> iterations) {
-            this.access = pathTemplate.stopSequence.access == null ? null : pathTemplate.stopSequence.access.toString();
-            this.egress = pathTemplate.stopSequence.egress == null ? null : pathTemplate.stopSequence.egress.toString();
+            this.access = pathTemplate.stopSequence.access;
+            this.egress = pathTemplate.stopSequence.egress;
             this.transitLegs = pathTemplate.transitLegs(transitLayer);
             this.iterations = iterations.stream().map(HumanReadableIteration::new).collect(Collectors.toList());
-            iterations.forEach(pathTemplate.stopSequence::transferTime); // The transferTime method includes an
-            // assertion that the transfer time is non-negative, i.e. that the access + egress + wait + ride times of
-            // a specific iteration do not exceed the total travel time. Perform that sense check here, even though
-            // the transfer time is not reported to the front-end for the human-readable single-point responses.
-            // TODO add transferTime to HumanReadableIteration?
         }
     }
 
@@ -218,19 +213,15 @@ public class PathResult {
      * Timestamp style clock times, and rounded wait/total time, for inspection as JSON.
      */
     public static class HumanReadableIteration {
-        public String departureTime;
-        public double[] waitTimes;
-        public double totalTime;
+        public int departureTime;
+        public int[] waitTimes;
+        public int totalTime;
 
         HumanReadableIteration(Iteration iteration) {
             // TODO track departure time for non-transit paths (so direct trips don't show departure time 00:00).
-            this.departureTime =
-                    String.format("%02d:%02d", Math.floorDiv(iteration.departureTime, 3600),
-                            (int) (iteration.departureTime / 60.0 % 60));
-            this.waitTimes =  Arrays.stream(iteration.waitTimes.toArray()).mapToDouble(
-                    wait -> Math.round(wait / 60f * 10) / 10.0
-            ).toArray();
-            this.totalTime =  Math.round(iteration.totalTime / 60f * 10) / 10.0;
+            this.departureTime = iteration.departureTime;
+            this.waitTimes =  iteration.waitTimes.toArray();
+            this.totalTime =  iteration.totalTime;
         }
     }
 

--- a/src/main/java/com/conveyal/r5/analyst/cluster/PathResultSummary.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/PathResultSummary.java
@@ -164,7 +164,7 @@ public class PathResultSummary {
     }
 
     /**
-     * Get the stop ID. If it does not exist, it is a new stop and return "new".
+     * Get the stop ID. If the ID does not exist, the stop is a new one added by a modification, so return "new".
      *
      * @param stopIndex
      * @return stopId

--- a/src/main/java/com/conveyal/r5/analyst/cluster/PathResultSummary.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/PathResultSummary.java
@@ -11,7 +11,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Convert a PathResult to an API friendly version. Uses the transit layer to get route information from the patterns.
+ * Convert a PathResult to an API friendly version. Uses the transit layer to get route and stop details.
  */
 public class PathResultSummary {
     public List<IterationDetails> iterations = new ArrayList<>();
@@ -65,7 +65,8 @@ public class PathResultSummary {
     }
 
     /**
-     * Wraps path and iteration details for JSON serialization
+     * An itinerary taken from a path result, including access and egress mode, transit legs, duration range, and how
+     * many iterations this itinerary was used.
      */
     static class Itinerary {
         public StreetTimesAndModes.StreetTimeAndMode access;

--- a/src/main/java/com/conveyal/r5/analyst/cluster/PathResultSummary.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/PathResultSummary.java
@@ -22,6 +22,9 @@ public class PathResultSummary {
             PathResult pathResult,
             TransitLayer transitLayer
     ) {
+        if (pathResult == null || pathResult.iterationsForPathTemplates.length != 1 || pathResult.iterationsForPathTemplates[0] == null)
+            return;
+
         // Iterate through each path result creating a list of iteration details and itineraries that reference each
         // other through an index.
         int itineraryIndex = 0;

--- a/src/main/java/com/conveyal/r5/analyst/cluster/PathResultSummary.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/PathResultSummary.java
@@ -125,11 +125,11 @@ public class PathResultSummary {
             inVehicleTime = stopSequence.rideTimesSeconds.get(routeIndex);
 
             int boardStopIndex = stopSequence.boardStops.get(routeIndex);
-            boardStopId = transitLayer.getStopId(boardStopIndex);
+            boardStopId = getStopId(transitLayer, boardStopIndex);
             boardStopName = transitLayer.stopNames.get(boardStopIndex);
 
             int alightStopIndex = stopSequence.alightStops.get(routeIndex);
-            alightStopId = transitLayer.getStopId(alightStopIndex);
+            alightStopId = getStopId(transitLayer, alightStopIndex);
             alightStopName = transitLayer.stopNames.get(alightStopIndex);
         }
     }
@@ -159,5 +159,17 @@ public class PathResultSummary {
             if (diff != 0) return diff;
             return this.itineraryIndex - o.itineraryIndex;
         }
+    }
+
+    /**
+     * Get the stop ID. If it does not exist, it is a new stop and return "new".
+     *
+     * @param stopIndex
+     * @return stopId
+     */
+    private static String getStopId(TransitLayer transitLayer, int stopIndex) {
+        String stopId = transitLayer.stopIdForIndex.get(stopIndex);
+        if (stopId == null) return "[new]";
+        return stopId;
     }
 }

--- a/src/main/java/com/conveyal/r5/analyst/cluster/PathResultSummary.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/PathResultSummary.java
@@ -1,0 +1,159 @@
+package com.conveyal.r5.analyst.cluster;
+
+import com.conveyal.r5.analyst.StreetTimesAndModes;
+import com.conveyal.r5.transit.TransitLayer;
+import com.conveyal.r5.transit.path.StopSequence;
+import gnu.trove.list.TIntList;
+import gnu.trove.list.array.TIntArrayList;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Convert a PathResult to an API friendly version. Uses the transit layer to get route information from the patterns.
+ */
+public class PathResultSummary {
+    public List<IterationDetails> iterations = new ArrayList<>();
+    public List<Itinerary> itineraries = new ArrayList<>();
+    public int fastestPathTime = Integer.MAX_VALUE;
+
+    public PathResultSummary(
+            PathResult pathResult,
+            TransitLayer transitLayer
+    ) {
+        // Iterate through each path result creating a list of iteration details and itineraries that reference each
+        // other through an index.
+        int itineraryIndex = 0;
+        for (var pathTemplate : pathResult.iterationsForPathTemplates[0].keySet()) {
+            var allIterations = pathResult.iterationsForPathTemplates[0].get(pathTemplate);
+            TIntArrayList durations = new TIntArrayList();
+            int fastestIteration = Integer.MAX_VALUE;
+            for (var iteration : allIterations) {
+                if (iteration.totalTime < fastestIteration) {
+                    fastestIteration = iteration.totalTime;
+                    if (fastestIteration < fastestPathTime) fastestPathTime = fastestIteration;
+                }
+                // Add to the set of durations
+                durations.add(iteration.totalTime);
+                IterationDetails iterationDetails = new IterationDetails(
+                        iteration.departureTime,
+                        iteration.waitTimes,
+                        iteration.totalTime,
+                        itineraryIndex
+                );
+                // Add to the list of departure times
+                this.iterations.add(iterationDetails);
+            }
+            List<TransitLeg> transitLegs = new ArrayList<>();
+            for (int routeIndex = 0; routeIndex < pathTemplate.routes.size(); routeIndex++) {
+                transitLegs.add(new TransitLeg(transitLayer, pathTemplate.stopSequence, routeIndex));
+            }
+            itineraries.add(new Itinerary(
+                    pathTemplate.stopSequence.access,
+                    pathTemplate.stopSequence.egress,
+                    transitLegs,
+                    allIterations.size(),
+                    durations.min(),
+                    durations.max(),
+                    itineraryIndex
+            ));
+            itineraryIndex += 1;
+        }
+        // Sort the iterations (by departure time and itinerary index)
+        Collections.sort(iterations);
+    }
+
+    /**
+     * Wraps path and iteration details for JSON serialization
+     */
+    static class Itinerary {
+        public StreetTimesAndModes.StreetTimeAndMode access;
+        public StreetTimesAndModes.StreetTimeAndMode egress;
+        public List<TransitLeg> transitLegs;
+        public int iterationsOptimal;
+        public int minDuration;
+        public int maxDuration;
+
+        public int index;
+
+        Itinerary(
+                StreetTimesAndModes.StreetTimeAndMode access,
+                StreetTimesAndModes.StreetTimeAndMode egress,
+                List<TransitLeg> transitLegs,
+                int iterationsOptimal,
+                int minDuration,
+                int maxDuration,
+                int index
+        ) {
+            this.access = access;
+            this.egress = egress;
+            this.transitLegs = transitLegs;
+            this.iterationsOptimal = iterationsOptimal;
+            this.maxDuration = maxDuration;
+            this.minDuration = minDuration;
+            this.index = index;
+        }
+    }
+
+    /**
+     * String representations of the boarding stop, alighting stop, and route, with in-vehicle time.
+     */
+    static class TransitLeg {
+        public String routeId;
+        public String routeName;
+        public int inVehicleTime;
+        public String boardStopId;
+        public String boardStopName;
+
+        public String alightStopId;
+        public String alightStopName;
+
+        public TransitLeg(
+                TransitLayer transitLayer,
+                StopSequence stopSequence,
+                int routeIndex
+        ) {
+            var routeInfo = transitLayer.routes.get(routeIndex);
+            routeId = routeInfo.route_id;
+            routeName = routeInfo.getName();
+
+            inVehicleTime = stopSequence.rideTimesSeconds.get(routeIndex);
+
+            int boardStopIndex = stopSequence.boardStops.get(routeIndex);
+            boardStopId = transitLayer.getStopId(boardStopIndex);
+            boardStopName = transitLayer.stopNames.get(boardStopIndex);
+
+            int alightStopIndex = stopSequence.alightStops.get(routeIndex);
+            alightStopId = transitLayer.getStopId(alightStopIndex);
+            alightStopName = transitLayer.stopNames.get(alightStopIndex);
+        }
+    }
+
+    /**
+     * Temporal details of a specific iteration of our RAPTOR implementation (per-leg wait times and total time
+     * implied by a specific departure time and randomized schedule offsets).
+     */
+    public static class IterationDetails implements Comparable<IterationDetails> {
+        public final int departureTime;
+        public final int[] waitTimes;
+        public final int totalWaitTime;
+        public final int totalTime;
+        public final int itineraryIndex;
+
+        public IterationDetails(int departureTime, TIntList waitTimes, int totalTime, int itineraryIndex) {
+            this.departureTime = departureTime;
+            this.waitTimes = waitTimes.toArray();
+            this.totalTime = totalTime;
+            this.totalWaitTime = waitTimes.sum();
+            this.itineraryIndex = itineraryIndex;
+        }
+
+        @Override
+        public int compareTo(IterationDetails o) {
+            int diff = this.departureTime - o.departureTime;
+            if (diff != 0) return diff;
+            return this.itineraryIndex - o.itineraryIndex;
+        }
+    }
+}

--- a/src/main/java/com/conveyal/r5/analyst/cluster/PathResultSummary.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/PathResultSummary.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class PathResultSummary {
     public List<IterationDetails> iterations = new ArrayList<>();
     public List<Itinerary> itineraries = new ArrayList<>();
-    public int fastestPathTime = Integer.MAX_VALUE;
+    public int fastestPathSeconds = Integer.MAX_VALUE;
 
     public PathResultSummary(
             PathResult pathResult,
@@ -35,7 +35,7 @@ public class PathResultSummary {
             for (var iteration : allIterations) {
                 if (iteration.totalTime < fastestIteration) {
                     fastestIteration = iteration.totalTime;
-                    if (fastestIteration < fastestPathTime) fastestPathTime = fastestIteration;
+                    if (fastestIteration < fastestPathSeconds) fastestPathSeconds = fastestIteration;
                 }
                 // Add to the set of durations
                 durations.add(iteration.totalTime);
@@ -68,16 +68,16 @@ public class PathResultSummary {
     }
 
     /**
-     * An itinerary taken from a path result, including access and egress mode, transit legs, duration range, and how
-     * many iterations this itinerary was used.
+     * An itinerary taken from a path result, including access and egress mode, transit legs, duration range (seconds),
+     * and how many iterations this itinerary was used.
      */
     static class Itinerary {
         public StreetTimesAndModes.StreetTimeAndMode access;
         public StreetTimesAndModes.StreetTimeAndMode egress;
         public List<TransitLeg> transitLegs;
         public int iterationsOptimal;
-        public int minDuration;
-        public int maxDuration;
+        public int minSeconds;
+        public int maxSeconds;
 
         public int index;
 
@@ -86,27 +86,27 @@ public class PathResultSummary {
                 StreetTimesAndModes.StreetTimeAndMode egress,
                 List<TransitLeg> transitLegs,
                 int iterationsOptimal,
-                int minDuration,
-                int maxDuration,
+                int minSeconds,
+                int maxSeconds,
                 int index
         ) {
             this.access = access;
             this.egress = egress;
             this.transitLegs = transitLegs;
             this.iterationsOptimal = iterationsOptimal;
-            this.maxDuration = maxDuration;
-            this.minDuration = minDuration;
+            this.maxSeconds = maxSeconds;
+            this.minSeconds = minSeconds;
             this.index = index;
         }
     }
 
     /**
-     * String representations of the boarding stop, alighting stop, and route, with in-vehicle time.
+     * String representations of the boarding stop, alighting stop, and route, with ride time (in seconds).
      */
     static class TransitLeg {
         public String routeId;
         public String routeName;
-        public int inVehicleTime;
+        public int rideTimeSeconds;
         public String boardStopId;
         public String boardStopName;
 
@@ -122,7 +122,7 @@ public class PathResultSummary {
             routeId = routeInfo.route_id;
             routeName = routeInfo.getName();
 
-            inVehicleTime = stopSequence.rideTimesSeconds.get(routeIndex);
+            rideTimeSeconds = stopSequence.rideTimesSeconds.get(routeIndex);
 
             int boardStopIndex = stopSequence.boardStops.get(routeIndex);
             boardStopId = getStopId(transitLayer, boardStopIndex);
@@ -137,6 +137,8 @@ public class PathResultSummary {
     /**
      * Temporal details of a specific iteration of our RAPTOR implementation (per-leg wait times and total time
      * implied by a specific departure time and randomized schedule offsets).
+     * <p>
+     * All times are in seconds. Departure time is seconds from midnight.
      */
     public static class IterationDetails implements Comparable<IterationDetails> {
         public final int departureTime;

--- a/src/main/java/com/conveyal/r5/transit/RouteInfo.java
+++ b/src/main/java/com/conveyal/r5/transit/RouteInfo.java
@@ -33,5 +33,15 @@ public class RouteInfo implements Serializable {
         this.agency_url = route.route_url;
     }
 
-    public RouteInfo () { /* do nothing */ }
+    public RouteInfo() { /* do nothing */ }
+
+    public String getName() {
+        if (route_short_name != null) {
+            return route_short_name;
+        } else if (route_long_name != null) {
+            return route_long_name;
+        } else {
+            return route_id;
+        }
+    }
 }

--- a/src/main/java/com/conveyal/r5/transit/TransitLayer.java
+++ b/src/main/java/com/conveyal/r5/transit/TransitLayer.java
@@ -841,4 +841,15 @@ public class TransitLayer implements Serializable, Cloneable {
         return stopIdForIndex.get(stopIndex).split(":")[1];
     }
 
+    /**
+     * Get the stop ID. If it does not exist, it is a new stop and return "new".
+     *
+     * @param stopIndex
+     * @return stopId
+     */
+    public String getStopId(int stopIndex) {
+        String stopId = stopIdForIndex.get(stopIndex);
+        if (stopId == null) return "[new]";
+        return stopId;
+    }
 }

--- a/src/main/java/com/conveyal/r5/transit/TransitLayer.java
+++ b/src/main/java/com/conveyal/r5/transit/TransitLayer.java
@@ -46,7 +46,6 @@ import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -823,9 +822,9 @@ public class TransitLayer implements Serializable, Cloneable {
         String route = routeInfo.route_id;
         if (includeName) {
             if (routeInfo.route_short_name != null) {
-                route += " (" + routeInfo.route_short_name + ")";
+                return routeInfo.route_short_name;
             } else if (routeInfo.route_long_name != null){
-                route += " (" + routeInfo.route_long_name + ")";
+                return routeInfo.route_long_name;
             }
         }
         return route;
@@ -837,9 +836,9 @@ public class TransitLayer implements Serializable, Cloneable {
      */
     public String stopString(int stopIndex, boolean includeName) {
         // TODO use a compact feed index, instead of splitting to remove feedIds
-        String stop = stopIdForIndex.get(stopIndex) == null ? "[new]" : stopIdForIndex.get(stopIndex).split(":")[1];
-        if (includeName) stop += " (" + stopNames.get(stopIndex) + ")";
-        return stop;
+        if (stopIdForIndex.get(stopIndex) == null) return "[new]";
+        if (includeName) return stopNames.get(stopIndex);
+        return stopIdForIndex.get(stopIndex).split(":")[1];
     }
 
 }

--- a/src/main/java/com/conveyal/r5/transit/TransitLayer.java
+++ b/src/main/java/com/conveyal/r5/transit/TransitLayer.java
@@ -822,9 +822,9 @@ public class TransitLayer implements Serializable, Cloneable {
         String route = routeInfo.route_id;
         if (includeName) {
             if (routeInfo.route_short_name != null) {
-                return routeInfo.route_short_name;
+                route += " (" + routeInfo.route_short_name + ")";
             } else if (routeInfo.route_long_name != null){
-                return routeInfo.route_long_name;
+                route += " (" + routeInfo.route_long_name + ")";
             }
         }
         return route;
@@ -836,20 +836,8 @@ public class TransitLayer implements Serializable, Cloneable {
      */
     public String stopString(int stopIndex, boolean includeName) {
         // TODO use a compact feed index, instead of splitting to remove feedIds
-        if (stopIdForIndex.get(stopIndex) == null) return "[new]";
-        if (includeName) return stopNames.get(stopIndex);
-        return stopIdForIndex.get(stopIndex).split(":")[1];
-    }
-
-    /**
-     * Get the stop ID. If it does not exist, it is a new stop and return "new".
-     *
-     * @param stopIndex
-     * @return stopId
-     */
-    public String getStopId(int stopIndex) {
-        String stopId = stopIdForIndex.get(stopIndex);
-        if (stopId == null) return "[new]";
-        return stopId;
+        String stop = stopIdForIndex.get(stopIndex) == null ? "[new]" : stopIdForIndex.get(stopIndex).split(":")[1];
+        if (includeName) stop += " (" + stopNames.get(stopIndex) + ")";
+        return stop;
     }
 }

--- a/src/main/java/com/conveyal/r5/transit/path/RouteSequence.java
+++ b/src/main/java/com/conveyal/r5/transit/path/RouteSequence.java
@@ -12,8 +12,10 @@ import java.util.StringJoiner;
 /** A door-to-door path that includes the routes ridden between stops */
 public class RouteSequence {
 
-    /** Route indexes (those used in R5 transit layer) for each transit leg */
-    private final TIntList routes;
+    /**
+     * Route indexes (those used in R5 transit layer) for each transit leg
+     */
+    public final TIntList routes;
     public final StopSequence stopSequence;
 
     /** Convert a pattern-based path into a more general route-based path. */

--- a/src/main/java/com/conveyal/r5/transit/path/RouteSequence.java
+++ b/src/main/java/com/conveyal/r5/transit/path/RouteSequence.java
@@ -69,13 +69,13 @@ public class RouteSequence {
      */
     public static class TransitLeg {
         public String route;
-        public int inVehicleTime;
+        public double inVehicleTime;
         public String board;
         public String alight;
 
         public TransitLeg (String route, int inVehicleTime, String boardStop, String alightStop) {
             this.route = route;
-            this.inVehicleTime = inVehicleTime;
+            this.inVehicleTime = Math.round(inVehicleTime / 60f * 10) / 10.0;
             this.board = boardStop;
             this.alight = alightStop;
         }

--- a/src/main/java/com/conveyal/r5/transit/path/RouteSequence.java
+++ b/src/main/java/com/conveyal/r5/transit/path/RouteSequence.java
@@ -67,13 +67,13 @@ public class RouteSequence {
      */
     public static class TransitLeg {
         public String route;
-        public double inVehicleTime;
+        public int inVehicleTime;
         public String board;
         public String alight;
 
         public TransitLeg (String route, int inVehicleTime, String boardStop, String alightStop) {
             this.route = route;
-            this.inVehicleTime = Math.round(inVehicleTime / 60f * 10) / 10.0;
+            this.inVehicleTime = inVehicleTime;
             this.board = boardStop;
             this.alight = alightStop;
         }

--- a/src/test/java/com/conveyal/r5/analyst/network/SimpsonDesertTests.java
+++ b/src/test/java/com/conveyal/r5/analyst/network/SimpsonDesertTests.java
@@ -147,6 +147,13 @@ public class SimpsonDesertTests {
     }
 
     /**
+     * For evaluating results from the tests below.
+     */
+    private int[] roundPathTimesToMinutes (PathResult.PathIterations paths) {
+        return paths.iterations.stream().mapToInt(i -> (int) (Math.round(i.totalTime / 60f * 10) / 10.0)).toArray();
+    }
+
+    /**
      * Test that the router correctly handles overtaking trips on the same route. Consider Trip A and Trip B, on a
      * horizontal route where each hop time is 30 seconds, except when Trip A slows to 10 minutes/hop for hops 20 and
      * 21. If Trip A leaves the first stop at 7:10 and Trip B leaves the first stop at 7:20, Trip A runs 10 minutes
@@ -187,7 +194,7 @@ public class SimpsonDesertTests {
 
         OneOriginResult standardResult = new TravelTimeComputer(standardRider, network).computeTravelTimes();
         List<PathResult.PathIterations> standardPaths = standardResult.paths.getPathIterationsForDestination();
-        int[] standardTimes = standardPaths.get(0).iterations.stream().mapToInt(i -> (int) i.totalTime).toArray();
+        int[] standardTimes = roundPathTimesToMinutes(standardPaths.get(0));
         // Trip B departs stop 30 at 7:35. So 30-35 minute wait, plus ~5 minute ride and ~5 minute egress leg
         assertTrue(Arrays.equals(new int[]{45, 44, 43, 42, 41}, standardTimes));
 
@@ -198,7 +205,7 @@ public class SimpsonDesertTests {
 
         OneOriginResult naiveResult = new TravelTimeComputer(naiveRider, network).computeTravelTimes();
         List<PathResult.PathIterations> naivePaths = naiveResult.paths.getPathIterationsForDestination();
-        int[] naiveTimes = naivePaths.get(0).iterations.stream().mapToInt(i -> (int) i.totalTime).toArray();
+        int[] naiveTimes = roundPathTimesToMinutes(naivePaths.get(0));
         // Trip A departs stop 10 at 7:15. So 10-15 minute wait, plus ~35 minute ride and ~5 minute egress leg
         assertTrue(Arrays.equals(new int[]{54, 53, 52, 51, 50}, naiveTimes));
 
@@ -210,7 +217,7 @@ public class SimpsonDesertTests {
 
         OneOriginResult savvyResult = new TravelTimeComputer(savvyRider, network).computeTravelTimes();
         List<PathResult.PathIterations> savvyPaths = savvyResult.paths.getPathIterationsForDestination();
-        int[] savvyTimes = savvyPaths.get(0).iterations.stream().mapToInt(i -> (int) i.totalTime).toArray();
+        int[] savvyTimes = roundPathTimesToMinutes(savvyPaths.get(0));
         // Trip B departs stop 10 at 7:25. So 8-12 minute wait, plus ~16 minute ride and ~5 minute egress leg
         assertTrue(Arrays.equals(new int[]{32, 31, 30, 29, 28}, savvyTimes));
     }


### PR DESCRIPTION
Returning raw path summary data for usage in the UI. Necessary for sorting and converting to other formats.

- [x] Return route & stop IDs along with the names.
- [x] Ensure the changes don't effect regional analysis path outputs.