### PR TITLE
Remove jitpack maven repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,10 +123,8 @@ repositories {
     // Put Open Source Geospatial before Maven Central to get JAI core, see https://stackoverflow.com/a/26993223
     maven { url 'https://repo.osgeo.org/repository/release/' }
     mavenCentral()
-    // TODO review whether we really need these repositories
+    // TODO review whether we really need the repositories below
     maven { url 'https://maven.conveyal.com' }
-    // Used for importing java projects from github (why do we need this?)
-    maven { url 'https://jitpack.io' }
     // For the polyline encoder
     maven { url 'https://nexus.axiomalaska.com/nexus/content/repositories/public-releases' }
 }


### PR DESCRIPTION
I did a local build after wiping out my gradle caches directory and it didn't seem to fetch anything from jitpack that's not also on the maven central repo.

This repo was recently unavailable which broke our build. It seems like we don't actually need it.