### PR TITLE
Avoid setting multiple LTS flags on edges via modifications

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/scenario/ModifyStreets.java
+++ b/src/main/java/com/conveyal/r5/analyst/scenario/ModifyStreets.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 
-import static com.conveyal.r5.labeling.LevelOfTrafficStressLabeler.intToLts;
+import static com.conveyal.r5.streets.EdgeStore.intToLts;
 
 /**
  * This modification selects all edges inside a given set of polygons and changes their characteristics.
@@ -213,8 +213,7 @@ public class ModifyStreets extends Modification {
         newEdge.disallowAllModes();
         newEdge.allowStreetModes(allowedModes);
         if (bikeLts != null) {
-            // Overwrite the LTS copied in the flags
-            newEdge.setFlag(intToLts(bikeLts));
+            newEdge.setLts(bikeLts);
         }
         if (carSpeedKph != null) {
             newEdge.setSpeedKph(carSpeedKph);

--- a/src/main/java/com/conveyal/r5/analyst/scenario/ShapefileLts.java
+++ b/src/main/java/com/conveyal/r5/analyst/scenario/ShapefileLts.java
@@ -55,7 +55,9 @@ public class ShapefileLts extends Modification {
     @Override
     public boolean apply (TransportNetwork network) {
         // Replicate the entire flags array so we can write to it (following copy-on-write policy).
-        // Otherwise the TIntAugmentedList only allows extending the base graph.
+        // Otherwise the TIntAugmentedList only allows extending the base graph. An alternative approach can be seen in
+        // ModifyStreets, where all affected edges are marked deleted and then recreated in the augmented lists.
+        // The appraoch here assumes a high percentage of edges changed, while ModifyStreets assumes a small percentage.
         network.streetLayer.edgeStore.flags = new TIntArrayList(network.streetLayer.edgeStore.flags);
         ShapefileMatcher shapefileMatcher = new ShapefileMatcher(network.streetLayer);
         try {

--- a/src/test/java/com/conveyal/r5/analyst/scenario/ModifyStreetsTest.java
+++ b/src/test/java/com/conveyal/r5/analyst/scenario/ModifyStreetsTest.java
@@ -1,24 +1,28 @@
 package com.conveyal.r5.analyst.scenario;
 
+import com.conveyal.osmlib.OSM;
 import com.conveyal.r5.analyst.WebMercatorExtents;
 import com.conveyal.r5.analyst.WebMercatorGridPointSet;
 import com.conveyal.r5.analyst.cluster.TravelTimeSurfaceTask;
+import com.conveyal.r5.analyst.scenario.FakeGraph.TransitNetwork;
 import com.conveyal.r5.api.util.LegMode;
 import com.conveyal.r5.api.util.TransitModes;
 import com.conveyal.r5.profile.StreetMode;
+import com.conveyal.r5.streets.EdgeStore.Edge;
+import com.conveyal.r5.streets.EdgeStore.EdgeFlag;
+import com.conveyal.r5.streets.StreetLayer;
 import com.conveyal.r5.streets.StreetRouter;
 import com.conveyal.r5.transit.TransportNetwork;
-import com.conveyal.r5.util.LambdaCounter;
 import gnu.trove.map.TIntIntMap;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Envelope;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
-import java.util.List;
 
+import static com.conveyal.r5.analyst.scenario.FakeGraph.buildNetwork;
+import static com.conveyal.r5.streets.EdgeStore.intToLts;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -26,18 +30,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class ModifyStreetsTest {
 
-    final double FROM_LAT = 40.0;
-    final double FROM_LON = -83.0;
-    final int TIME_LIMIT_SECONDS = 1200;
+    private static final double FROM_LAT = 40.0;
+    private static final double FROM_LON = -83.0;
+    private static final double SIZE_DEGREES = 0.05;
+    private static final int TIME_LIMIT_SECONDS = 1200;
     // Analysis bounds
-    final double SIZE_DEGREES = 0.05;
-    final double WEST = FROM_LON - SIZE_DEGREES;
-    final double EAST = FROM_LON + SIZE_DEGREES;
-    final double SOUTH = FROM_LAT - SIZE_DEGREES;
-    final double NORTH = FROM_LAT + SIZE_DEGREES;
+    private static final int MIN_ELEMENTS = 100;
 
     /**
-     * Using a `ModifyStreets` modification, test that adjusting the `walkTimeFactor` appropriately changes route time.
+     * Using a `ModifyStreets` modification, test that adjusting the `walkTimeFactor` appropriately changes travel time.
      * Also indirectly tests that the necessary generalized cost data tables will be added to the network when missing.
      */
     @Test
@@ -47,19 +48,11 @@ public class ModifyStreetsTest {
         var ms = new ModifyStreets();
         ms.allowedModes = EnumSet.of(StreetMode.WALK);
         ms.walkTimeFactor = 0.1;
-        ms.polygons = new double[][][]{{
-                {WEST, NORTH},
-                {EAST, NORTH},
-                {EAST, SOUTH},
-                {WEST, SOUTH},
-                {WEST, NORTH}
-        }};
+        ms.polygons = makeModificationPolygon(FROM_LON, FROM_LAT, SIZE_DEGREES);
+        var modifiedNetwork = applySingleModification(network, ms);
 
-        var scenario = new Scenario();
-        scenario.modifications = Arrays.asList(ms);
-
-        var reachedVertices = getReachedVertices(network, new Scenario());
-        var reachedVerticesWithModification = getReachedVertices(network, scenario);
+        var reachedVertices = getReachedVertices(network);
+        var reachedVerticesWithModification = getReachedVertices(modifiedNetwork);
 
         int nReachedVertices = reachedVertices.size();
         int nReachedVerticesWithModification = reachedVerticesWithModification.size();
@@ -67,26 +60,21 @@ public class ModifyStreetsTest {
         assertTrue(nReachedVertices > 500);
         assertTrue(nReachedVerticesWithModification > nReachedVertices * 2);
 
-        int[] nLowerTimes = new int[1]; // Sidestep annoying Java "effectively final" rule.
-        reachedVertices.forEachKey(v -> {
+        int nLowerTimes = 0;
+        for (int v : reachedVertices.keys()) {
             int travelTime = reachedVertices.get(v);
             int travelTimeWithModification = reachedVerticesWithModification.get(v);
             assertTrue(travelTimeWithModification != -1);
             assertTrue(travelTimeWithModification <= travelTime);
             if (travelTimeWithModification != travelTime) {
-                nLowerTimes[0] += 1;
+                nLowerTimes += 1;
                 assertTrue(travelTimeWithModification * 1.3 < travelTime);
             }
-            return true;
-        });
-        assertTrue(nLowerTimes[0] > 500);
+        }
+        assertTrue(nLowerTimes > 500);
     }
 
-    TIntIntMap getReachedVertices(TransportNetwork network, Scenario scenario) {
-        var modifiedNetwork = scenario.applyToTransportNetwork(network);
-        Assertions.assertEquals(0, modifiedNetwork.scenarioApplicationWarnings.size());
-
-        var extents = WebMercatorExtents.forWgsEnvelope(new Envelope(WEST, EAST, SOUTH, NORTH), WebMercatorGridPointSet.DEFAULT_ZOOM);
+    private static TIntIntMap getReachedVertices(TransportNetwork network) {
         var task = new TravelTimeSurfaceTask();
         task.accessModes = EnumSet.of(LegMode.WALK);
         task.directModes = EnumSet.of(LegMode.WALK);
@@ -94,13 +82,15 @@ public class ModifyStreetsTest {
         task.percentiles = new int[]{50};
         task.fromLat = FROM_LAT;
         task.fromLon = FROM_LON;
-        task.north = extents.north;
-        task.west = extents.west;
-        task.height = extents.height;
-        task.width = extents.width;
-        task.zoom = extents.zoom;
 
-        var streetRouter = new StreetRouter(modifiedNetwork.streetLayer);
+        WebMercatorGridPointSet gps = new WebMercatorGridPointSet(network);
+        task.north = gps.north;
+        task.west = gps.west;
+        task.height = gps.height;
+        task.width = gps.width;
+        task.zoom = gps.zoom;
+
+        var streetRouter = new StreetRouter(network.streetLayer);
         streetRouter.profileRequest = task;
         streetRouter.setOrigin(task.fromLat, task.fromLon);
         streetRouter.streetMode = StreetMode.WALK;
@@ -109,4 +99,90 @@ public class ModifyStreetsTest {
 
         return streetRouter.getReachedVertices();
     }
+
+    /**
+     * Test that our LTS labeling process, as well as street modifications, do not set more than one LTS value on a
+     * single edge. The LTS is stored as bit flags, so even though LTS values are mutually exclusive it is technically
+     * possible (but meaningless) for more than one to be present on the same edge.
+     */
+    @Test
+    public void testLtsRepresentation () {
+        TransportNetwork network = buildNetwork(TransitNetwork.SINGLE_LINE);
+        checkStreetLayerLts(network.streetLayer);
+
+        ModifyStreets mod = new ModifyStreets();
+        mod.allowedModes = EnumSet.of(StreetMode.BICYCLE);
+        mod.polygons = makeModificationPolygon(FROM_LON, FROM_LAT, SIZE_DEGREES);
+        mod.bikeLts = 1;
+
+        TransportNetwork modifiedNetwork = applySingleModification(network, mod);
+        checkStreetLayerLts(modifiedNetwork.streetLayer);
+
+        // Check that the modification set a bunch of edges to have LTS 1.
+        int nLtsOneBefore = countLts(network.streetLayer, 1);
+        int nLtsOneAfter = countLts(modifiedNetwork.streetLayer, 1);
+        assertTrue(nLtsOneAfter > nLtsOneBefore * 1.5);
+        assertTrue(nLtsOneAfter > MIN_ELEMENTS);
+    }
+
+    private void checkStreetLayerLts(StreetLayer streets) {
+        assertTrue(streets.edgeStore.nEdges() > MIN_ELEMENTS);
+        int nWithLts = 0;
+        for (Edge e = streets.edgeStore.getCursor(0); e.advance(); ) {
+            int nSet = 0;
+            if (e.getFlag(EdgeFlag.BIKE_LTS_1)) nSet += 1;
+            if (e.getFlag(EdgeFlag.BIKE_LTS_2)) nSet += 1;
+            if (e.getFlag(EdgeFlag.BIKE_LTS_3)) nSet += 1;
+            if (e.getFlag(EdgeFlag.BIKE_LTS_4)) nSet += 1;
+            assertTrue(nSet == 0 || nSet == 1);
+            if (nSet > 0) nWithLts += 1;
+        }
+        assertTrue(nWithLts > MIN_ELEMENTS);
+    }
+
+    /** @return the number of edges in the supplied street layer that have the given LTS level set. **/
+    private int countLts (StreetLayer streets, int lts) {
+        EdgeFlag ltsFlag = intToLts(lts);
+        int n = 0;
+        for (Edge e = streets.edgeStore.getCursor(0); e.advance(); ) {
+            if (e.getFlag(ltsFlag)) {
+                n += 1;
+            }
+        }
+        return n;
+    }
+
+    //// Static utility functions for constructing test modifications and scenarios
+
+    private static TransportNetwork applySingleModification (TransportNetwork baseNetwork, Modification modification) {
+        Scenario scenario = new Scenario();
+        scenario.modifications = Arrays.asList(modification);
+        TransportNetwork modifiedNetwork = scenario.applyToTransportNetwork(baseNetwork);
+        Assertions.assertEquals(0, modifiedNetwork.scenarioApplicationWarnings.size());
+        return modifiedNetwork;
+    }
+
+    private static double[][][] makeModificationPolygon (Envelope env) {
+        return new double[][][]{{
+                {env.getMinX(), env.getMaxY()},
+                {env.getMaxX(), env.getMaxY()},
+                {env.getMaxX(), env.getMinY()},
+                {env.getMinX(), env.getMinY()},
+                {env.getMinX(), env.getMaxY()}
+        }};
+    }
+
+    private static double[][][] makeModificationPolygon (double centerLon, double centerLat, double radiusDegrees) {
+        Envelope env = makeEnvelope(centerLon, centerLat, radiusDegrees);
+        return makeModificationPolygon(env);
+    }
+
+    private static Envelope makeEnvelope (double centerLon, double centerLat, double radiusDegrees) {
+        final double west = centerLon - radiusDegrees;
+        final double east = centerLon + radiusDegrees;
+        final double south = centerLat - radiusDegrees;
+        final double north = centerLat + radiusDegrees;
+        return new Envelope(west, east, south, north);
+    }
+
 }

--- a/src/test/resources/manual/README.txt
+++ b/src/test/resources/manual/README.txt
@@ -1,0 +1,3 @@
+This directory contains fixtures for manual testing. This includes files that are useful
+for improvised testing (various transportation network inputs or geospatial inputs) as well
+as files referenced by well-defined manual tests carried out before each release.


### PR DESCRIPTION
Add method that clears all LTS flags before setting a new one. This method is then used in ModifyStreets and ShapefileMatcher. Code comments have been clarified to avoid creating similar problems in the future.

Some refactoring was also done to improve readability (enum value imports and braces around conditional blocks).

This enforces certain behavior in Modifications. It is still possible for the LevelOfTrafficStressLabeler to set multiple flags during initial network build, though it seems to have been designed not to, and LTS data has always been set with this mechanism in the past.  Further checks and normalization should be added to always allow only a single LTS flag, at every place they are ever set. In theory this would be doing extra work. In practice it's a series of bitwise ORs on the same register and should not incur any slowdown. Safety and predictably all but require these extra checks, as we're stuck with a data structure susceptible to representing multiple mutually exclusive values at once.

There should also be a simple test that loads a network and applies an modify-streets modification, checking at each stage that no edge has conflicting LTS values associated with it.