### PR TITLE
Allow UUIDs without hyphens

### DIFF
--- a/src/test/java/com/conveyal/analysis/controllers/ArgumentValidationTest.java
+++ b/src/test/java/com/conveyal/analysis/controllers/ArgumentValidationTest.java
@@ -7,7 +7,13 @@ import org.junit.jupiter.api.Test;
 import java.util.UUID;
 
 /**
+ * Tests that check how parameters received over the HTTP API are validated.
+ * These validators should be fairly strict about what they accept, and should not tolerate the presence of things
+ * like semicolons or double dashes that indicate attempts to corrupt or gain access to database contents.
  *
+ * Arguably we should have another layer of input sanitization that not only refuses but logs anything that contains
+ * characters or substrings that could be associated with an attempted attack, and that same validator should be
+ * applied to every input (perhaps called from every other input validator).
  */
 public class ArgumentValidationTest {
 
@@ -17,7 +23,7 @@ public class ArgumentValidationTest {
             BrokerController.checkIdParameter("hello", "param");
         });
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            BrokerController.checkIdParameter("Robert'; DROP TABLE Students;--", "param");
+            BrokerController.checkIdParameter("Robert'); DROP TABLE Students;--", "param");
             // https://xkcd.com/327/
         });
         Assertions.assertThrows(IllegalArgumentException.class, () -> {

--- a/src/test/java/com/conveyal/analysis/controllers/ArgumentValidationTest.java
+++ b/src/test/java/com/conveyal/analysis/controllers/ArgumentValidationTest.java
@@ -1,0 +1,39 @@
+package com.conveyal.analysis.controllers;
+
+import com.conveyal.analysis.components.broker.Broker;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+/**
+ *
+ */
+public class ArgumentValidationTest {
+
+    @Test
+    void testIdValidation () {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            BrokerController.checkIdParameter("hello", "param");
+        });
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            BrokerController.checkIdParameter("Robert'; DROP TABLE Students;--", "param");
+            // https://xkcd.com/327/
+        });
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            BrokerController.checkIdParameter("0123456789012345", "param");
+        });
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            BrokerController.checkIdParameter("0123456789ABCDEF67890ZZZZ5678901", "param");
+        });
+        Assertions.assertDoesNotThrow(() -> {
+            BrokerController.checkIdParameter("0123456789abcDEF6789012345678901", "param");
+        });
+        Assertions.assertDoesNotThrow(() -> {
+            String validUuid = UUID.randomUUID().toString();
+            BrokerController.checkIdParameter(validUuid, "param");
+        });
+    }
+
+
+}


### PR DESCRIPTION
We used UUIDs without hyphens for a period in the past. This PR modifies the `BrokerController.checkUuid` method to allow those.

Migrating these IDs would be ideal. But migrating IDs is not simple. We have a bigger DB migration planned in the future and will migrate IDs to a single type then.