### PR TITLE
Update MongoDB driver to 4.8.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,7 @@ dependencies {
     }
 
     // Database driver.
-    implementation 'org.mongodb:mongo-java-driver:3.11.0'
+    implementation 'org.mongodb:mongodb-driver-sync:4.8.2'
 
     // Legacy system for storing Java objects, this functionality is now provided by the MongoDB driver itself.
     implementation 'org.mongojack:mongojack:2.10.1'


### PR DESCRIPTION
MongoDB currently provides documentation for versions v4.3 to v4.8. When making changes, its useful to have available documentation for the driver we are using.