### PR TITLE
Pre-build linkages and egress tables for additional street modes via TransportNetworkConfig

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/cluster/TransportNetworkConfig.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/TransportNetworkConfig.java
@@ -42,7 +42,7 @@ public class TransportNetworkConfig {
     public List<Modification> modifications;
 
     /**
-     * Additional modes other than walk for which to pre-build a full regional grid and distance tables.
+     * Additional modes other than walk for which to pre-build large data structures (grid linkage and cost tables).
      * When building a network, by default we build distance tables from transit stops to street vertices, to which we
      * connect a grid covering the entire street network at the default zoom level. By default we do this only for the
      * walk mode. Pre-building and serializing equivalent data structures for other modes allows workers to start up

--- a/src/main/java/com/conveyal/r5/analyst/cluster/TransportNetworkConfig.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/TransportNetworkConfig.java
@@ -4,11 +4,13 @@ import com.conveyal.r5.analyst.fare.InRoutingFareCalculator;
 import com.conveyal.r5.analyst.scenario.Modification;
 import com.conveyal.r5.analyst.scenario.RasterCost;
 import com.conveyal.r5.analyst.scenario.ShapefileLts;
+import com.conveyal.r5.profile.StreetMode;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * All inputs and options that describe how to build a particular transport network (except the serialization version).
@@ -38,5 +40,18 @@ public class TransportNetworkConfig {
 
     /** A list of _R5_ modifications to apply during network build. May be null. */
     public List<Modification> modifications;
+
+    /**
+     * Additional modes other than walk for which to pre-build a full regional grid and distance tables.
+     * When building a network, by default we build distance tables from transit stops to street vertices, to which we
+     * connect a grid covering the entire street network at the default zoom level. By default we do this only for the
+     * walk mode. Pre-building and serializing equivalent data structures for other modes allows workers to start up
+     * much faster in regional analyses. The work need only be done once when the first single-point worker to builds
+     * the network. Otherwise, hundreds of workers will each have to build these tables every time they start up.
+     * Some scenarios, such as those that affect the street layer, may still be slower to apply for modes listed here
+     * because some intermediate data (stop-to-vertex tables) are only retained for the walk mode. If this proves to be
+     * a problem it is a candidate for future optimization.
+     */
+    public Set<StreetMode> buildGridsForModes;
 
 }

--- a/src/main/java/com/conveyal/r5/streets/EgressCostTable.java
+++ b/src/main/java/com/conveyal/r5/streets/EgressCostTable.java
@@ -209,7 +209,7 @@ public class EgressCostTable implements Serializable {
             rebuildZone = linkedPointSet.streetLayer.scenarioEdgesBoundingGeometry(linkingDistanceLimitMeters);
         }
 
-        LOG.info("Creating EgressCostTables from each transit stop to PointSet points.");
+        LOG.info("Creating EgressCostTables from each transit stop to PointSet points for mode {}.", streetMode);
         if (rebuildZone != null) {
             LOG.info("Selectively computing tables for only those stops that might be affected by the scenario.");
         }
@@ -232,9 +232,9 @@ public class EgressCostTable implements Serializable {
         progressListener.beginTask(taskDescription, nStops);
 
         final LambdaCounter computeCounter = new LambdaCounter(LOG, nStops, computeLogFrequency,
-                "Computed new stop -> point tables for {} of {} transit stops.");
+                String.format("Computed new stop-to-point tables from {} of {} transit stops for mode %s.", streetMode));
         final LambdaCounter copyCounter = new LambdaCounter(LOG, nStops, copyLogFrequency,
-                "Copied unchanged stop -> point tables for {} of {} transit stops.");
+                String.format("Copied unchanged stop-to-point tables from {} of {} transit stops for mode %s.", streetMode));
         // Create a distance table from each transit stop to the points in this PointSet in parallel.
         // Each table is a flattened 2D array. Two values for each point reachable from this stop: (pointIndex, cost)
         // When applying a scenario, keep the existing distance table for those stops that could not be affected.

--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -135,7 +135,7 @@ public class LinkedPointSet implements Serializable {
      *                    the same pointSet and streetMode as the preceding arguments.
      */
     public LinkedPointSet (PointSet pointSet, StreetLayer streetLayer, StreetMode streetMode, LinkedPointSet baseLinkage) {
-        LOG.info("Linking pointset to street network...");
+        LOG.info("Linking pointset to street network for mode {}...", streetMode);
         this.pointSet = pointSet;
         this.streetLayer = streetLayer;
         this.streetMode = streetMode;
@@ -301,7 +301,7 @@ public class LinkedPointSet implements Serializable {
      */
     private void linkPointsToStreets (boolean all) {
         LambdaCounter linkCounter = new LambdaCounter(LOG, pointSet.featureCount(), 10000,
-                "Linked {} of {} PointSet points to streets.");
+                String.format("Linked {} of {} PointSet points to streets for mode %s.", streetMode));
 
         // Construct a geometry around any edges added by the scenario, or null if there are no added edges.
         // As it is derived from edge geometries this is a fixed-point geometry and must be intersected with the same.

--- a/src/main/java/com/conveyal/r5/transit/TransitLayer.java
+++ b/src/main/java/com/conveyal/r5/transit/TransitLayer.java
@@ -535,11 +535,13 @@ public class TransitLayer implements Serializable, Cloneable {
     }
 
     /**
-     * Run a distance-constrained street search from every transit stop in the graph.
+     * Run a distance-constrained street search from every transit stop in the graph using the walk mode.
      * Store the distance to every reachable street vertex for each of these origin stops.
      * If a scenario has been applied, we need to build tables for any newly created stops and any stops within
      * transfer distance or access/egress distance of those new stops. In that case a rebuildZone geometry should be
      * supplied. If rebuildZone is null, a complete rebuild of all tables will occur for all stops.
+     * Note, this rebuilds for the WALK MODE ONLY. The network only has a field for retaining walk distance tables.
+     * This is a candidate for optimization if car or bicycle scenarios are slow to apply.
      * @param rebuildZone the zone within which to rebuild tables in FIXED-POINT DEGREES, or null to build all tables.
      */
     public void buildDistanceTables(Geometry rebuildZone) {

--- a/src/main/java/com/conveyal/r5/transit/TransitLayer.java
+++ b/src/main/java/com/conveyal/r5/transit/TransitLayer.java
@@ -546,7 +546,7 @@ public class TransitLayer implements Serializable, Cloneable {
      */
     public void buildDistanceTables(Geometry rebuildZone) {
 
-        LOG.info("Finding distances from transit stops to street vertices.");
+        LOG.info("Pre-computing distances from transit stops to street vertices (WALK mode only).");
         if (rebuildZone != null) {
             LOG.info("Selectively finding distances for only those stops potentially affected by scenario application.");
         }


### PR DESCRIPTION
This is a user-configurable version of [010970c](https://github.com/conveyal/r5/pull/786/commits/010970c6af2b7250b26290301ec338b48b848a23) in #786.

The user can add `"buildGridsForModes": ["BICYCLE", "CAR"]` to the TransportNetworkConfig to pre-build linkages and distance tables and serialize them in the network. This should alleviate the problem of hundreds of regional workers all building the same distance tables (though not during some scenario applications, which will require additional optimizations).

Currently there is no way to inject TransportNetworkConfig during a bundle upload. We must manually edit the network config JSON file on the backend server (in `~/cache/bundles/networkid.json`) and `aws s3 cp` to overwrite the copy on S3 before the network is built by a single point worker.