### PR TITLE
Optimize allocation management

### DIFF
--- a/src/main/java/com/conveyal/r5/util/TIntObjectHashMultimap.java
+++ b/src/main/java/com/conveyal/r5/util/TIntObjectHashMultimap.java
@@ -17,7 +17,12 @@ public class TIntObjectHashMultimap<V> implements TIntObjectMultimap<V> {
 
     @Override
     public boolean put(int key, V value) {
-        if (!wrapped.containsKey(key)) wrapped.put(key, new ArrayList<>());
+        if (!wrapped.containsKey(key)) {
+            wrapped.put(key, new ArrayList<>(2));
+        } else {
+            ArrayList<V> wrappedList = (ArrayList<V>) wrapped.get(key);
+            wrappedList.ensureCapacity(wrappedList.size() * 2);
+        }
         return wrapped.get(key).add(value);
     }
 


### PR DESCRIPTION
In larger data scenarios the memory allocation scenario for the `put` results in a lot of discarded arrays due to re-sizing. So, this sizes it more intelligently. In the small scenarios it shouldn't matter, but in the larger ones it can make a huge difference.