### PR TITLE
Pin gradle version used in Github Action workflows

### DIFF
--- a/.github/workflows/cypress-integration.yml
+++ b/.github/workflows/cypress-integration.yml
@@ -22,13 +22,10 @@ jobs:
         with:
           fetch-depth: 0
           path: r5
-      # Build .jar and copy to ./ui directory (along with config file)
-      # Cache Gradle dependencies to speed up the shadow jar build
-      - uses: actions/cache@v1
-        id: cache
+      - uses: gradle/gradle-build-action@v2.4.0
         with:
-          path: ~/.gradle/caches
-          key: gradle-caches
+          gradle-version: 7.6.1
+      # Build .jar and copy to ./ui directory (along with config file)
       - uses: actions/setup-java@v1
         with:
           java-version: 11

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,16 +31,14 @@ jobs:
     - uses: actions/checkout@v2.3.2
       with:
         fetch-depth: 0
+    - uses: gradle/gradle-build-action@2.4.0
+      with:
+        gradle-version: 7.6.1
     # Java setup step completes very fast, no need to run in a preconfigured docker container.
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
         java-version: 11
-    - uses: actions/cache@v1
-      id: cache
-      with:
-        path: ~/.gradle/caches
-        key: gradle-caches
     - name: Show version string
       run: gradle -q printVersion | head -n1
     - name: Build and Test

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: actions/checkout@v2.3.2
       with:
         fetch-depth: 0
-    - uses: gradle/gradle-build-action@2.4.0
+    - uses: gradle/gradle-build-action@v2.4.0
       with:
         gradle-version: 7.6.1
     # Java setup step completes very fast, no need to run in a preconfigured docker container.


### PR DESCRIPTION
Apparently the default gradle version used in Github actions switched to v8.0 when it was released three weeks ago. Our workflows started failing around then with messages like:
```
Welcome to Gradle 8.0.2!

FAILURE: Build failed with an exception.

* What went wrong:
org/gradle/api/plugins/MavenPlugin
```
Before this change, our most recent successful workflow run used gradle v7.6. This PR pins the gradle version used in our workflows at v7.6.1, using the [`gradle-build-action` plugin](https://github.com/marketplace/actions/gradle-build-action#why-use-the-gradle-build-action). It also removes our custom gradle caching; `gradle-build-action` handles caching itself and recommends not caching gradle with `actions/cache` because of possible interference.

We will need a similar change to fix the CodeQL action, but I am not familiar with the `autobuild` command used there.