### PR TITLE
Update build.gradle for gradle 8.x (and future 9.x)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -33,14 +33,11 @@ jobs:
         fetch-depth: 0
     # Java setup step completes very fast, no need to run in a preconfigured docker container.
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
         java-version: 11
-    - uses: actions/cache@v1
-      id: cache
-      with:
-        path: ~/.gradle/caches
-        key: gradle-caches
+        distribution: temurin
+        cache: 'gradle'
     - name: Show version string
       run: gradle -q printVersion | head -n1
     - name: Build and Test

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id 'java'
-    id 'com.github.johnrengelman.shadow' version '6.0.0'
+    id 'com.github.johnrengelman.shadow' version '8.1.0'
     id 'maven-publish'
-    id 'com.palantir.git-version' version '0.12.3'
+    id 'com.palantir.git-version' version '2.0.0'
 }
 
 group = 'com.conveyal'
@@ -72,9 +72,11 @@ tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
 
-// A task to copy all dependencies of the project into a single directory
+// A task to copy all dependency JARs needed at runtime into a single directory
 task copyDependencies(type: Copy) {
-    from configurations.default
+    from(sourceSets.main.runtimeClasspath) {
+        include '*.jar'
+    }
     into 'dependencies'
 }
 
@@ -82,7 +84,7 @@ task copyDependencies(type: Copy) {
 task runBackend (type: JavaExec) {
    dependsOn(build)
    classpath(sourceSets.main.runtimeClasspath)
-   main("com.conveyal.analysis.BackendMain")
+   mainClass = 'com.conveyal.analysis.BackendMain'
 }
 
 // Start up an analysis local backend from a shaded JAR and ask it to shut down immediately.
@@ -91,7 +93,7 @@ task runBackend (type: JavaExec) {
 task testShadowJarRunnable(type: JavaExec) {
     dependsOn(shadowJar)
     classpath(shadowJar.archiveFile.get())
-    main("com.conveyal.analysis.BackendMain")
+    mainClass = 'com.conveyal.analysis.BackendMain'
     jvmArgs("-Dconveyal.immediate.shutdown=true")
 }
 


### PR DESCRIPTION
This is an alternative approach to #866.

Updated build.gradle to use newer versions of plugins that are compatible with Gradle 8.x.
Also fixed deprecation warnings for Gradle 9.x and switched to gradle dependency caching built in to setup-java action.
See further discussion on https://github.com/conveyal/r5/pull/866#issuecomment-1469820507

I have tested all the build tasks we normally use.

