### PR TITLE
Check duplicate and missing GTFS entity keys

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,10 +125,8 @@ repositories {
     // Put Open Source Geospatial before Maven Central to get JAI core, see https://stackoverflow.com/a/26993223
     maven { url 'https://repo.osgeo.org/repository/release/' }
     mavenCentral()
-    // TODO review whether we really need the repositories below
+    // Polyline encoder 0.2 is now in Maven repo
     maven { url 'https://maven.conveyal.com' }
-    // For the polyline encoder
-    maven { url 'https://nexus.axiomalaska.com/nexus/content/repositories/public-releases' }
 }
 
 // Exclude all JUnit 4 transitive dependencies - IntelliJ bug causes it to think we're using Junit 4 instead of 5.

--- a/src/main/java/com/conveyal/gtfs/error/DuplicateKeyError.java
+++ b/src/main/java/com/conveyal/gtfs/error/DuplicateKeyError.java
@@ -8,8 +8,8 @@ import java.io.Serializable;
 public class DuplicateKeyError extends GTFSError implements Serializable {
     public static final long serialVersionUID = 1L;
 
-    public DuplicateKeyError(String file, long line, String field) {
-        super(file, line, field);
+    public DuplicateKeyError(String file, long line, String field, String id) {
+        super(file, line, field, id);
     }
 
     @Override public String getMessage() {

--- a/src/main/java/com/conveyal/gtfs/error/MissingKeyError.java
+++ b/src/main/java/com/conveyal/gtfs/error/MissingKeyError.java
@@ -1,0 +1,22 @@
+package com.conveyal.gtfs.error;
+
+import com.conveyal.gtfs.validator.model.Priority;
+
+import java.io.Serializable;
+
+/** Indicates that a GTFS entity was not added to a table because it had no primary key. */
+public class MissingKeyError extends GTFSError implements Serializable {
+    public static final long serialVersionUID = 1L;
+
+    public MissingKeyError(String file, long line, String field) {
+        super(file, line, field);
+    }
+
+    @Override public String getMessage() {
+        return "Missing primary key.";
+    }
+
+    @Override public Priority getPriority() {
+        return Priority.MEDIUM;
+    }
+}

--- a/src/main/java/com/conveyal/gtfs/model/Agency.java
+++ b/src/main/java/com/conveyal/gtfs/model/Agency.java
@@ -20,6 +20,11 @@ public class Agency extends Entity {
     public URL    agency_branding_url;
     public String feed_id;
 
+    @Override
+    public String getId() {
+        return agency_id;
+    }
+
     public static class Loader extends Entity.Loader<Agency> {
 
         public Loader(GTFSFeed feed) {
@@ -45,11 +50,11 @@ public class Agency extends Entity {
             a.agency_fare_url = getUrlField("agency_fare_url", false);
             a.agency_branding_url = getUrlField("agency_branding_url", false);
             a.feed_id = feed.feedId;
-
-            // TODO clooge due to not being able to have null keys in mapdb
-            if (a.agency_id == null) a.agency_id = "NONE";
-
-            feed.agency.put(a.agency_id, a);
+            // Kludge because mapdb does not support null keys
+            if (a.agency_id == null) {
+                a.agency_id = "NONE";
+            }
+            insertCheckingDuplicateKey(feed.agency, a, "agency_id");
         }
 
     }

--- a/src/main/java/com/conveyal/gtfs/model/Calendar.java
+++ b/src/main/java/com/conveyal/gtfs/model/Calendar.java
@@ -52,7 +52,7 @@ public class Calendar extends Entity implements Serializable {
             String service_id = getStringField("service_id", true); // TODO service_id can reference either calendar or calendar_dates.
             Service service = services.computeIfAbsent(service_id, Service::new);
             if (service.calendar != null) {
-                feed.errors.add(new DuplicateKeyError(tableName, row, "service_id"));
+                feed.errors.add(new DuplicateKeyError(tableName, row, "service_id", service_id));
             } else {
                 Calendar c = new Calendar();
                 c.sourceFileLine = row + 1; // offset line number by 1 to account for 0-based row index

--- a/src/main/java/com/conveyal/gtfs/model/CalendarDate.java
+++ b/src/main/java/com/conveyal/gtfs/model/CalendarDate.java
@@ -52,7 +52,8 @@ public class CalendarDate extends Entity implements Cloneable, Serializable {
             Service service = services.computeIfAbsent(service_id, Service::new);
             LocalDate date = getDateField("date", true);
             if (service.calendar_dates.containsKey(date)) {
-                feed.errors.add(new DuplicateKeyError(tableName, row, "(service_id, date)"));
+                String keyString = String.format("(%s,%s)", service_id, date.toString());
+                feed.errors.add(new DuplicateKeyError(tableName, row, "(service_id, date)", keyString));
             } else {
                 CalendarDate cd = new CalendarDate();
                 cd.sourceFileLine = row + 1; // offset line number by 1 to account for 0-based row index

--- a/src/main/java/com/conveyal/gtfs/model/Entity.java
+++ b/src/main/java/com/conveyal/gtfs/model/Entity.java
@@ -314,13 +314,13 @@ public abstract class Entity implements Serializable {
         protected void insertCheckingDuplicateKey (Map<String, E> map, E value, String keyField) {
             String key = value.getId();
             if (key == null) {
-                feed.errors.add(new MissingKeyError(tableName, value.sourceFileLine, keyField));
+                feed.errors.add(new MissingKeyError(tableName, row, keyField));
                 return;
             }
             // Map returns previous value if one was already present
             E previousValue = map.put(key, value);
             if (previousValue != null) {
-                feed.errors.add(new DuplicateKeyError(tableName, value.sourceFileLine, keyField, key));
+                feed.errors.add(new DuplicateKeyError(tableName, row, keyField, key));
             }
         }
     }

--- a/src/main/java/com/conveyal/gtfs/model/Entity.java
+++ b/src/main/java/com/conveyal/gtfs/model/Entity.java
@@ -1,6 +1,8 @@
 package com.conveyal.gtfs.model;
 
 import com.beust.jcommander.internal.Sets;
+import com.conveyal.gtfs.error.DuplicateKeyError;
+import com.conveyal.gtfs.error.MissingKeyError;
 import com.conveyal.r5.analyst.progress.ProgressInputStream;
 import com.conveyal.gtfs.GTFSFeed;
 import com.conveyal.gtfs.error.DateParseError;
@@ -57,8 +59,10 @@ public abstract class Entity implements Serializable {
      *          with a sequence number. For example stop_times and shapes have no single field that uniquely
      *          identifies a row, and the stop_sequence or shape_pt_sequence must also be considered.
      */
-    public String getId () {
-        return null;
+    public String getId() {
+        // Several entities have compound keys which are handled as tuple objects, not strings.
+        // Fail fast if anything tries to fetch a string ID for those Entity types.
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -301,6 +305,24 @@ public abstract class Entity implements Serializable {
             }
         }
 
+        /**
+         * Insert the given value into the map, checking whether a value already exists with its key.
+         * The entity type must override getId() for this to work. We have to pass in the name of the key field for
+         * error reporting purposes because although there is a method to get the ID of an Entity there is not a method
+         * to get the name of the field(s) it is taken from.
+         */
+        protected void insertCheckingDuplicateKey (Map<String, E> map, E value, String keyField) {
+            String key = value.getId();
+            if (key == null) {
+                feed.errors.add(new MissingKeyError(tableName, value.sourceFileLine, keyField));
+                return;
+            }
+            // Map returns previous value if one was already present
+            E previousValue = map.put(key, value);
+            if (previousValue != null) {
+                feed.errors.add(new DuplicateKeyError(tableName, value.sourceFileLine, keyField, key));
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/conveyal/gtfs/model/FareAttribute.java
+++ b/src/main/java/com/conveyal/gtfs/model/FareAttribute.java
@@ -39,7 +39,7 @@ public class FareAttribute extends Entity {
             String fareId = getStringField("fare_id", true);
             Fare fare = fares.computeIfAbsent(fareId, Fare::new);
             if (fare.fare_attribute != null) {
-                feed.errors.add(new DuplicateKeyError(tableName, row, "fare_id"));
+                feed.errors.add(new DuplicateKeyError(tableName, row, "fare_id", fareId));
             } else {
                 FareAttribute fa = new FareAttribute();
                 fa.sourceFileLine = row + 1; // offset line number by 1 to account for 0-based row index

--- a/src/main/java/com/conveyal/gtfs/model/Route.java
+++ b/src/main/java/com/conveyal/gtfs/model/Route.java
@@ -32,6 +32,11 @@ public class Route extends Entity { // implements Entity.Factory<Route>
     public URL route_branding_url;
     public String feed_id;
 
+    @Override
+    public String getId() {
+        return route_id;
+    }
+
     public static class Loader extends Entity.Loader<Route> {
 
         public Loader(GTFSFeed feed) {
@@ -72,7 +77,7 @@ public class Route extends Entity { // implements Entity.Factory<Route>
             r.route_text_color = getStringField("route_text_color", false);
             r.route_branding_url = getUrlField("route_branding_url", false);
             r.feed_id = feed.feedId;
-            feed.routes.put(r.route_id, r);
+            insertCheckingDuplicateKey(feed.routes, r, "route_id");
         }
 
     }

--- a/src/main/java/com/conveyal/gtfs/model/Stop.java
+++ b/src/main/java/com/conveyal/gtfs/model/Stop.java
@@ -1,10 +1,12 @@
 package com.conveyal.gtfs.model;
 
 import com.conveyal.gtfs.GTFSFeed;
+import com.conveyal.gtfs.error.DuplicateKeyError;
 
 import java.io.IOException;
 import java.net.URL;
 import java.util.Iterator;
+import java.util.Map;
 
 public class Stop extends Entity {
 
@@ -61,11 +63,12 @@ public class Stop extends Entity {
             s.stop_timezone  = getStringField("stop_timezone", false);
             s.wheelchair_boarding = getStringField("wheelchair_boarding", false);
             s.feed_id = feed.feedId;
-            /* TODO check ref integrity later, this table self-references via parent_station */
-            feed.stops.put(s.stop_id, s);
+            // Referential integrity is checked later after fully loaded. Stops self-reference via parent_station. 
+            insertCheckingDuplicateKey(feed.stops, s, "stop_id");
         }
 
     }
+
 
     public static class Writer extends Entity.Writer<Stop> {
         public Writer (GTFSFeed feed) {

--- a/src/main/java/com/conveyal/gtfs/model/StopTime.java
+++ b/src/main/java/com/conveyal/gtfs/model/StopTime.java
@@ -28,7 +28,7 @@ public class StopTime extends Entity implements Cloneable, Serializable {
 
     @Override
     public String getId() {
-        return trip_id; // Needs sequence number to be unique
+        return trip_id; // Concatenate with sequence number to make unique
     }
 
     @Override

--- a/src/main/java/com/conveyal/gtfs/model/Trip.java
+++ b/src/main/java/com/conveyal/gtfs/model/Trip.java
@@ -20,6 +20,11 @@ public class Trip extends Entity {
     public int    wheelchair_accessible;
     public String feed_id;
 
+    @Override
+    public String getId() {
+        return trip_id;
+    }
+
     public static class Loader extends Entity.Loader<Trip> {
 
         public Loader(GTFSFeed feed) {
@@ -47,7 +52,7 @@ public class Trip extends Entity {
             t.bikes_allowed   = getIntField("bikes_allowed", false, 0, 2);
             t.wheelchair_accessible = getIntField("wheelchair_accessible", false, 0, 2);
             t.feed_id = feed.feedId;
-            feed.trips.put(t.trip_id, t);
+            insertCheckingDuplicateKey(feed.trips, t, "trip_id");
 
             /*
               Check referential integrity without storing references. Trip cannot directly reference Services or


### PR DESCRIPTION
Addresses #792. A method is defined and applied for all entity types with simple string IDs, including stops and routes.