### PR TITLE
Check population density around stops

### DIFF
--- a/src/main/java/com/conveyal/gtfs/error/SuspectStopLocationError.java
+++ b/src/main/java/com/conveyal/gtfs/error/SuspectStopLocationError.java
@@ -1,0 +1,30 @@
+package com.conveyal.gtfs.error;
+
+import com.conveyal.gtfs.validator.model.Priority;
+
+import java.io.Serializable;
+
+/**
+ * Indicates that a stop is in a suspect location, for example in a place like a desert where there are not enough
+ * people to support public transit. This can be the result of incorrect coordinate transforms into WGS84.
+ * Stops are often located on "null island" at (0,0). This can also happen in other coordinate systems before they
+ * are transformed to WGS84: the origin of a common French coordinate system is in the Sahara.
+ */
+public class SuspectStopLocationError extends GTFSError implements Serializable {
+    public static final long serialVersionUID = 1L;
+
+    public SuspectStopLocationError(String stopId, long line) {
+        super("stops", line, "stop_id", stopId);
+    }
+
+    @Override public String getMessage() {
+        return String.format(
+            "Stop with ID %s is located in a 1/4 degree cell with less than 5 inhabitants per square km.",
+            affectedEntityId
+        );
+    }
+
+    @Override public Priority getPriority() {
+        return Priority.MEDIUM;
+    }
+}


### PR DESCRIPTION
While working on duplicate ID checks I noticed we were running tests on this validator but not applying it to the stops.

Results seem good after testing out on several feeds. Null island ferry results in warnings, most other feeds produce no warnings. Some places like Montreal get warnings on particular routes that have stops in mountainous parkland (Parc des Sept Chutes) but this makes sense.

I'm creating this as a draft. This is not a critical validation rule, and the population density thresholds might benefit from some tweaking.

I also noticed that we don't return the affected entity ID in `com.conveyal.analysis.models.Bundle.GtfsErrorSummary`, so we end up generating a lot of custom messages that contain the entity ID, rather than providing structured data that would allow the UI to display the ID together with the filename, line number, and field name.