### PR TITLE
Always checkGridSize when creating grids

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,10 +125,8 @@ repositories {
     // Put Open Source Geospatial before Maven Central to get JAI core, see https://stackoverflow.com/a/26993223
     maven { url 'https://repo.osgeo.org/repository/release/' }
     mavenCentral()
-    // TODO review whether we really need the repositories below
+    // Polyline encoder 0.2 is now in Maven repo
     maven { url 'https://maven.conveyal.com' }
-    // For the polyline encoder
-    maven { url 'https://nexus.axiomalaska.com/nexus/content/repositories/public-releases' }
 }
 
 // Exclude all JUnit 4 transitive dependencies - IntelliJ bug causes it to think we're using Junit 4 instead of 5.

--- a/src/main/java/com/conveyal/analysis/models/AnalysisRequest.java
+++ b/src/main/java/com/conveyal/analysis/models/AnalysisRequest.java
@@ -28,9 +28,6 @@ import java.util.stream.Collectors;
  * sends/forwards to R5 workers (see {@link AnalysisWorkerTask}), though it has many of the same fields.
  */
 public class AnalysisRequest {
-    private static int MIN_ZOOM = 9;
-    private static int MAX_ZOOM = 12;
-    private static int MAX_GRID_CELLS = 5_000_000;
 
     /**
      * These three IDs are redundant, and just help reduce the number of database lookups necessary.
@@ -207,7 +204,6 @@ public class AnalysisRequest {
         // TODO define class with static factory function WebMercatorGridBounds.fromLatLonBounds().
         //      Also include getIndex(x, y), getX(index), getY(index), totalTasks()
         WebMercatorExtents extents = WebMercatorExtents.forWgsEnvelope(bounds.envelope(), zoom);
-        checkGridSize(extents);
         task.height = extents.height;
         task.north = extents.north;
         task.west = extents.west;
@@ -268,21 +264,6 @@ public class AnalysisRequest {
             } else {
                 throw new IllegalArgumentException("Must be admin user to inject faults.");
             }
-        }
-    }
-
-    private static void checkGridSize (WebMercatorExtents extents) {
-        if (extents.zoom < MIN_ZOOM || extents.zoom > MAX_ZOOM) {
-            throw AnalysisServerException.badRequest(String.format(
-                    "Requested zoom (%s) is outside valid range (%s - %s)", extents.zoom, MIN_ZOOM, MAX_ZOOM
-            ));
-        }
-        if (extents.height * extents.width > MAX_GRID_CELLS) {
-            throw AnalysisServerException.badRequest(String.format(
-                    "Requested number of destinations (%s) exceeds limit (%s). " +
-                            "Set smaller custom geographic bounds or a lower zoom level.",
-                            extents.height * extents.width, MAX_GRID_CELLS
-            ));
         }
     }
 

--- a/src/main/java/com/conveyal/gtfs/model/Pattern.java
+++ b/src/main/java/com/conveyal/gtfs/model/Pattern.java
@@ -24,9 +24,15 @@ public class Pattern implements Serializable {
     // TODO: add set of shapes
 //    public Set<String> associatedShapes;
 
-    // This is the only place in the library we are still using the old JTS package name. These objects are
-    // serialized into MapDB files. We want to read and write MapDB files that old workers can understand.
+    // This is the only place we are still using the old JTS package name.
+    // Hopefully we can get rid of this - it's the only thing still using JTS objects under the obsolete vividsolutions
+    // package name so is pulling in extra dependencies and requiring conversions (toLegacyLineString).
+    // Unfortunately these objects are serialized into MapDB files, and we want to read and write MapDB files that
+    // old workers can understand. This cannot be migrated to newer JTS package names without deprecating all older
+    // workers, then deleting all MapDB representations of GTFS data from S3 and the local cache directory, forcing
+    // them to all be rebuilt the next time they're used.
     public com.vividsolutions.jts.geom.LineString geometry;
+
     public String name;
     public String route_id;
     public static Joiner joiner = Joiner.on("-").skipNulls();

--- a/src/main/java/com/conveyal/r5/analyst/Grid.java
+++ b/src/main/java/com/conveyal/r5/analyst/Grid.java
@@ -107,6 +107,11 @@ public class Grid extends PointSet {
         this(new WebMercatorExtents(west, north, width, height, zoom));
     }
 
+    /**
+     * Other constructors and factory methods all call this one, and Grid has a WebMercatorExtents field, which means
+     * Grid construction always follows construction of a WebMercatorExtents, whose constructor always performs a
+     * check on the size of the grid.
+     */
     public Grid (WebMercatorExtents extents) {
         this.extents = extents;
         this.grid = new double[extents.width][extents.height];

--- a/src/main/java/com/conveyal/r5/util/EncodedPolylineSerializer.java
+++ b/src/main/java/com/conveyal/r5/util/EncodedPolylineSerializer.java
@@ -17,9 +17,8 @@ import java.io.IOException;
  * com.conveyal.r5.transitive.TransitivePattern, which is in turn only used in
  * com.conveyal.r5.transitive.TransitiveNetwork, which is in turn only used in
  * com.conveyal.r5.analyst.cluster.AnalysisWorker#saveTauiMetadata.
- * That dependency has required maintainance on a few occasions and is hosted at a repo outside Maven Central which has
- * become unavailable on a few occations. We should evaluate licence compatibility (LGPL) for copying it into this repo
- * ("vendoring" it).
+ * That dependency has required maintainance on a few occasions and was hosted at a repo outside Maven Central which has
+ * become unavailable on a few occations. We have copied the artifact to our S3-backed Conveyal Maven repo.
  */
 public class EncodedPolylineSerializer extends JsonSerializer<LineString> {
 

--- a/src/main/java/com/conveyal/r5/util/EncodedPolylineSerializer.java
+++ b/src/main/java/com/conveyal/r5/util/EncodedPolylineSerializer.java
@@ -11,9 +11,15 @@ import org.locationtech.jts.geom.LineString;
 import java.io.IOException;
 
 /**
- * Serialize to Google encoded polyline.
- * Hopefully we can get rid of this - it's the only thing still using JTS objects under the vividsolutions package name
- * so is pulling in extra dependencies and requiring conversions (toLegacyLineString).
+ * Serialize JTS LineString to Google encoded polyline.
+ *
+ * This class is the only use of dependency com.axiomalaska:polyline-encoder, and it is only used in
+ * com.conveyal.r5.transitive.TransitivePattern, which is in turn only used in
+ * com.conveyal.r5.transitive.TransitiveNetwork, which is in turn only used in
+ * com.conveyal.r5.analyst.cluster.AnalysisWorker#saveTauiMetadata.
+ * That dependency has required maintainance on a few occasions and is hosted at a repo outside Maven Central which has
+ * become unavailable on a few occations. We should evaluate licence compatibility (LGPL) for copying it into this repo
+ * ("vendoring" it).
  */
 public class EncodedPolylineSerializer extends JsonSerializer<LineString> {
 

--- a/src/test/java/com/conveyal/r5/analyst/GridTest.java
+++ b/src/test/java/com/conveyal/r5/analyst/GridTest.java
@@ -26,31 +26,33 @@ public class GridTest {
     @Test
     public void testGetMercatorEnvelopeMeters() throws Exception {
         // Southeastern Australia
-        // Correct meter coordinates from http://www.maptiler.org/google-maps-coordinates-tile-bounds-projection/
-        int zoom = 4;
-        int xTile = 14;
-        int yTile = 9;
+        // Reference coordinates in meters from http://www.maptiler.org/google-maps-coordinates-tile-bounds-projection/
+        int zoom = 9;
+        int xTile = 465;
+        int yTile = 312;
         Grid grid = new Grid(256 * xTile, 256 * yTile, 256, 256, zoom);
         ReferencedEnvelope envelope = grid.getWebMercatorExtents().getMercatorEnvelopeMeters();
-        assertEquals(15028131.257091936, envelope.getMinX(), 0.1);
-        assertEquals(-5009377.085697312, envelope.getMinY(), 0.1);
-        assertEquals(17532819.79994059, envelope.getMaxX(), 0.1);
-        assertEquals(-2504688.542848654, envelope.getMaxY(), 0.1);
+        assertEquals(16358747.0, envelope.getMinX(), 1);
+        assertEquals(-4461476.0, envelope.getMinY(), 1);
+        assertEquals(16437019.0, envelope.getMaxX(), 1);
+        assertEquals(-4383205.0, envelope.getMaxY(), 1);
 
-        // Cutting through Paris
-        zoom = 5;
-        xTile = 16;
-        yTile = 11;
+        // The tile east of Greenwich
+        // Reference coordinates in meters from http://www.maptiler.org/google-maps-coordinates-tile-bounds-projection/
+        // Expect the zero edge to be more exact, others to within one meter.
+        zoom = 12;
+        xTile = 2048;
+        yTile = 1362;
         grid = new Grid(256 * xTile, 256 * yTile, 256, 256, zoom);
         envelope = grid.getWebMercatorExtents().getMercatorEnvelopeMeters();
-        assertEquals(0, envelope.getMinX(), 0.1);
-        assertEquals(5009377.085697312, envelope.getMinY(), 0.1);
-        assertEquals(1252344.271424327, envelope.getMaxX(), 0.1);
-        assertEquals(6261721.357121639, envelope.getMaxY(), 0.1);
+        assertEquals(0.0, envelope.getMinX(), 0.01);
+        assertEquals(6701999.0, envelope.getMinY(), 1);
+        assertEquals(9784.0, envelope.getMaxX(), 1);
+        assertEquals(6711783.0, envelope.getMaxY(), 1);
 
 //        /**
-//         * Make sure the Mercator projection works properly. Open the resulting file in GIS and
-//         * compare with http://www.maptiler.org/google-maps-coordinates-tile-bounds-projection/
+//         * Uncomment to manually verify that the Mercator projection works properly. Open the resulting file in GIS
+//         * and compare with http://www.maptiler.org/google-maps-coordinates-tile-bounds-projection/
 //         */
 //        OutputStream outputStream = new FileOutputStream("test.tiff");
 //        grid.writeGeotiff(outputStream);

--- a/src/test/java/com/conveyal/r5/analyst/network/GridSinglePointTaskBuilder.java
+++ b/src/test/java/com/conveyal/r5/analyst/network/GridSinglePointTaskBuilder.java
@@ -108,6 +108,10 @@ public class GridSinglePointTaskBuilder {
         return this;
     }
 
+    /**
+     * Even if you're not actually using the opportunity count, you should call this to set the grid extents on the
+     * resulting task. Otherwise it will fail checks on the grid dimensions and zoom level.
+     */
     public GridSinglePointTaskBuilder uniformOpportunityDensity (double density) {
         Grid grid = gridLayout.makeUniformOpportunityDataset(density);
         task.destinationPointSets = new PointSet[] { grid };

--- a/src/test/java/com/conveyal/r5/analyst/network/RandomFrequencyPhasingTests.java
+++ b/src/test/java/com/conveyal/r5/analyst/network/RandomFrequencyPhasingTests.java
@@ -52,6 +52,7 @@ public class RandomFrequencyPhasingTests {
                 .weekendMorningPeak()
                 .setOrigin(20, 20)
                 .monteCarloDraws(1000)
+                .uniformOpportunityDensity(10)
                 .build();
 
         TravelTimeComputer computer = new TravelTimeComputer(task, network);


### PR DESCRIPTION
Addresses issue #844. All Grid and WebMercatorExtents constructors / factory methods will now hit the zoom and extents checks. Tests updated to use acceptable zoom levels. Comments in code further explaining the approach.

As far as I know every place we use Grid and WebMercatorExtents is legitimately subject to these restrictions. We should think about whether there are legitimate places we need to use other zoom levels, though I think the cell-count restrictions would be valid everywhere (retina raster map tiles should never exceed 512x512).

If we used WebMercatorExtents to make map tiles for example, we'd need an exception to the zoom level restrictions, but our VectorMapTile class does not make use of WebMercatorExtents. As an aside, WebMercatorExtents contains its own methods for computing tile2lon and tile2lat which are an exact copy of those in the `com.conveyal.osmlib.display.WebMercatorTile` utility class. Some deduplication would be possible but these are tiny functions copied verbatim from the OSM wiki. 