### PR TITLE
Make all row numbers one-based for consistency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,10 +125,8 @@ repositories {
     // Put Open Source Geospatial before Maven Central to get JAI core, see https://stackoverflow.com/a/26993223
     maven { url 'https://repo.osgeo.org/repository/release/' }
     mavenCentral()
-    // TODO review whether we really need the repositories below
+    // Polyline encoder 0.2 is now in Maven repo
     maven { url 'https://maven.conveyal.com' }
-    // For the polyline encoder
-    maven { url 'https://nexus.axiomalaska.com/nexus/content/repositories/public-releases' }
 }
 
 // Exclude all JUnit 4 transitive dependencies - IntelliJ bug causes it to think we're using Junit 4 instead of 5.

--- a/src/main/java/com/conveyal/gtfs/model/Agency.java
+++ b/src/main/java/com/conveyal/gtfs/model/Agency.java
@@ -34,7 +34,7 @@ public class Agency extends Entity {
         @Override
         public void loadOneRow() throws IOException {
             Agency a = new Agency();
-            a.sourceFileLine = row + 1; // offset line number by 1 to account for 0-based row index
+            a.sourceFileLine = row;
             a.agency_id    = getStringField("agency_id", false); // can only be absent if there is a single agency -- requires a special validator.
             a.agency_name  = getStringField("agency_name", true);
             a.agency_url   = getUrlField("agency_url", true);

--- a/src/main/java/com/conveyal/gtfs/model/Calendar.java
+++ b/src/main/java/com/conveyal/gtfs/model/Calendar.java
@@ -55,7 +55,7 @@ public class Calendar extends Entity implements Serializable {
                 feed.errors.add(new DuplicateKeyError(tableName, row, "service_id"));
             } else {
                 Calendar c = new Calendar();
-                c.sourceFileLine = row + 1; // offset line number by 1 to account for 0-based row index
+                c.sourceFileLine = row;
                 c.service_id = service.service_id;
                 c.monday = getIntField("monday", true, 0, 1);
                 c.tuesday = getIntField("tuesday", true, 0, 1);

--- a/src/main/java/com/conveyal/gtfs/model/CalendarDate.java
+++ b/src/main/java/com/conveyal/gtfs/model/CalendarDate.java
@@ -55,7 +55,7 @@ public class CalendarDate extends Entity implements Cloneable, Serializable {
                 feed.errors.add(new DuplicateKeyError(tableName, row, "(service_id, date)"));
             } else {
                 CalendarDate cd = new CalendarDate();
-                cd.sourceFileLine = row + 1; // offset line number by 1 to account for 0-based row index
+                cd.sourceFileLine = row;
                 cd.service_id = service_id;
                 cd.date = date;
                 cd.exception_type = getIntField("exception_type", true, 1, 2);

--- a/src/main/java/com/conveyal/gtfs/model/FareAttribute.java
+++ b/src/main/java/com/conveyal/gtfs/model/FareAttribute.java
@@ -42,7 +42,7 @@ public class FareAttribute extends Entity {
                 feed.errors.add(new DuplicateKeyError(tableName, row, "fare_id"));
             } else {
                 FareAttribute fa = new FareAttribute();
-                fa.sourceFileLine = row + 1; // offset line number by 1 to account for 0-based row index
+                fa.sourceFileLine = row;
                 fa.fare_id = fareId;
                 fa.price = getDoubleField("price", true, 0, Integer.MAX_VALUE);
                 fa.currency_type = getStringField("currency_type", true);

--- a/src/main/java/com/conveyal/gtfs/model/FareRule.java
+++ b/src/main/java/com/conveyal/gtfs/model/FareRule.java
@@ -43,7 +43,7 @@ public class FareRule extends Entity {
 
             Fare fare = fares.computeIfAbsent(fareId, Fare::new);
             FareRule fr = new FareRule();
-            fr.sourceFileLine = row + 1; // offset line number by 1 to account for 0-based row index
+            fr.sourceFileLine = row;
             fr.fare_id = fare.fare_id;
             fr.route_id = getStringField("route_id", false);
             fr.origin_id = getStringField("origin_id", false);

--- a/src/main/java/com/conveyal/gtfs/model/FeedInfo.java
+++ b/src/main/java/com/conveyal/gtfs/model/FeedInfo.java
@@ -41,7 +41,7 @@ public class FeedInfo extends Entity implements Cloneable {
         @Override
         public void loadOneRow() throws IOException {
             FeedInfo fi = new FeedInfo();
-            fi.sourceFileLine = row + 1; // offset line number by 1 to account for 0-based row index
+            fi.sourceFileLine = row;
             fi.feed_id = getStringField("feed_id", false);
             fi.feed_publisher_name = getStringField("feed_publisher_name", true);
             fi.feed_publisher_url = getUrlField("feed_publisher_url", true);

--- a/src/main/java/com/conveyal/gtfs/model/Frequency.java
+++ b/src/main/java/com/conveyal/gtfs/model/Frequency.java
@@ -57,7 +57,7 @@ public class Frequency extends Entity implements Comparable<Frequency> {
         public void loadOneRow() throws IOException {
             Frequency f = new Frequency();
             Trip trip = getRefField("trip_id", true, feed.trips);
-            f.sourceFileLine = row + 1; // offset line number by 1 to account for 0-based row index
+            f.sourceFileLine = row;
             f.trip_id = trip.trip_id;
             f.start_time = getTimeField("start_time", true);
             f.end_time = getTimeField("end_time", true);

--- a/src/main/java/com/conveyal/gtfs/model/Route.java
+++ b/src/main/java/com/conveyal/gtfs/model/Route.java
@@ -46,7 +46,7 @@ public class Route extends Entity { // implements Entity.Factory<Route>
         @Override
         public void loadOneRow() throws IOException {
             Route r = new Route();
-            r.sourceFileLine = row + 1; // offset line number by 1 to account for 0-based row index
+            r.sourceFileLine = row;
             r.route_id = getStringField("route_id", true);
             Agency agency = getRefField("agency_id", false, feed.agency);
 

--- a/src/main/java/com/conveyal/gtfs/model/ShapePoint.java
+++ b/src/main/java/com/conveyal/gtfs/model/ShapePoint.java
@@ -46,7 +46,7 @@ public class ShapePoint extends Entity {
             double shape_dist_traveled = getDoubleField("shape_dist_traveled", false, 0D, Double.MAX_VALUE);
 
             ShapePoint s = new ShapePoint(shape_id, shape_pt_lat, shape_pt_lon, shape_pt_sequence, shape_dist_traveled);
-            s.sourceFileLine = row + 1; // offset line number by 1 to account for 0-based row index
+            s.sourceFileLine = row;
             feed.shape_points.put(new Tuple2<String, Integer>(s.shape_id, s.shape_pt_sequence), s);
         }
     }

--- a/src/main/java/com/conveyal/gtfs/model/Stop.java
+++ b/src/main/java/com/conveyal/gtfs/model/Stop.java
@@ -43,7 +43,7 @@ public class Stop extends Entity {
         @Override
         public void loadOneRow() throws IOException {
             Stop s = new Stop();
-            s.sourceFileLine = row + 1; // offset line number by 1 to account for 0-based row index
+            s.sourceFileLine = row;
             s.stop_id   = getStringField("stop_id", true);
             s.stop_code = getStringField("stop_code", false);
             s.stop_name = getStringField("stop_name", true);

--- a/src/main/java/com/conveyal/gtfs/model/StopTime.java
+++ b/src/main/java/com/conveyal/gtfs/model/StopTime.java
@@ -50,7 +50,7 @@ public class StopTime extends Entity implements Cloneable, Serializable {
         @Override
         public void loadOneRow() throws IOException {
             StopTime st = new StopTime();
-            st.sourceFileLine = row + 1; // offset line number by 1 to account for 0-based row index
+            st.sourceFileLine = row;
             st.trip_id        = getStringField("trip_id", true);
             // TODO: arrival_time and departure time are not required, but if one is present the other should be
             // also, if this is the first or last stop, they are both required

--- a/src/main/java/com/conveyal/gtfs/model/Transfer.java
+++ b/src/main/java/com/conveyal/gtfs/model/Transfer.java
@@ -31,7 +31,7 @@ public class Transfer extends Entity {
         @Override
         public void loadOneRow() throws IOException {
             Transfer tr = new Transfer();
-            tr.sourceFileLine    = row + 1; // offset line number by 1 to account for 0-based row index
+            tr.sourceFileLine    = row;
             tr.from_stop_id      = getStringField("from_stop_id", true);
             tr.to_stop_id        = getStringField("to_stop_id", true);
             tr.transfer_type     = getIntField("transfer_type", true, 0, 3);
@@ -48,6 +48,7 @@ public class Transfer extends Entity {
             getRefField("from_trip_id", false, feed.trips);
             getRefField("to_trip_id", false, feed.trips);
 
+            // row number used as an arbitrary unique string to give MapDB a key.
             feed.transfers.put(Long.toString(row), tr);
         }
 

--- a/src/main/java/com/conveyal/gtfs/model/Trip.java
+++ b/src/main/java/com/conveyal/gtfs/model/Trip.java
@@ -35,7 +35,7 @@ public class Trip extends Entity {
         public void loadOneRow() throws IOException {
             Trip t = new Trip();
 
-            t.sourceFileLine  = row + 1; // offset line number by 1 to account for 0-based row index
+            t.sourceFileLine  = row;
             t.route_id        = getStringField("route_id", true);
             t.service_id      = getStringField("service_id", true);
             t.trip_id         = getStringField("trip_id", true);


### PR DESCRIPTION
Some error messages (particularly those produced in post-validation) had row numbers based on entity.sourceFileLine which is one-based, while others used raw zero-based row numbers.

In testing all sorts of error messages now appear to consistently match the line numbers shown in text editors.