### PR TITLE
Allow setting seed for frequency offsets

### DIFF
--- a/src/main/java/com/conveyal/analysis/models/AnalysisRequest.java
+++ b/src/main/java/com/conveyal/analysis/models/AnalysisRequest.java
@@ -55,6 +55,7 @@ public class AnalysisRequest {
     public float toLon;
     public int fromTime;
     public int monteCarloDraws = 200;
+    public boolean lockSchedules = false;
     public int toTime;
     public String transitModes;
     public float walkSpeed;
@@ -244,6 +245,7 @@ public class AnalysisRequest {
         task.cutoffsMinutes = cutoffsMinutes;
         
         task.logRequest = logRequest;
+        task.lockSchedules = lockSchedules;
 
         task.accessModes = getEnumSetFromString(accessModes);
         task.directModes = getEnumSetFromString(directModes);

--- a/src/main/java/com/conveyal/r5/profile/FastRaptorWorker.java
+++ b/src/main/java/com/conveyal/r5/profile/FastRaptorWorker.java
@@ -145,7 +145,7 @@ public class FastRaptorWorker {
         this.accessStops = accessStops;
         this.servicesActive  = transit.getActiveServicesForDate(request.date);
 
-        offsets = new FrequencyRandomOffsets(transitLayer);
+        offsets = new FrequencyRandomOffsets(transitLayer, request);
 
         // compute number of minutes for scheduled search
         nMinutes = request.getTimeWindowLengthMinutes();

--- a/src/main/java/com/conveyal/r5/profile/McRaptorSuboptimalPathProfileRouter.java
+++ b/src/main/java/com/conveyal/r5/profile/McRaptorSuboptimalPathProfileRouter.java
@@ -113,7 +113,7 @@ public class McRaptorSuboptimalPathProfileRouter {
         this.touchedPatterns = new BitSet(network.transitLayer.tripPatterns.size());
         this.patternsNearDestination = new BitSet(network.transitLayer.tripPatterns.size());
         this.servicesActive = network.transitLayer.getActiveServicesForDate(req.date);
-        this.offsets = new FrequencyRandomOffsets(network.transitLayer);
+        this.offsets = new FrequencyRandomOffsets(network.transitLayer, request);
         this.saveFinalStates = saveFinalStates;
         if (saveFinalStates) this.finalStatesByDepartureTime = new TIntObjectHashMap<>();
 
@@ -150,7 +150,8 @@ public class McRaptorSuboptimalPathProfileRouter {
 
         // We start at end of time window and work backwards (which is what range-RAPTOR does, in case we
         // re-implement that here). We use a constrained random walk to choose which departure minutes to sample as we
-        // work backward through the time window.  According to others (Owen and Jiang?), this is a good way to reduce
+        // work backward through the time window.  According to Owen and Murphy (2019)
+        // https://www.jtlu.org/index.php/jtlu/article/view/1379), this is a good way to reduce
         // the number of samples without causing an issue with variance in results.  This value is the constraint
         // (upper limit) on the walk.
         // multiply by two because E[random] = 1/2 * max.
@@ -535,7 +536,7 @@ public class McRaptorSuboptimalPathProfileRouter {
     }
 
     private ArrayList<Integer> generateDepartureTimesToSample (ProfileRequest request) {
-        // See Owen and Jiang 2016 (unfortunately no longer available online), add between f / 2 and
+        // See Owen and Murphy 2019 (https://www.jtlu.org/index.php/jtlu/article/view/1379), add between f / 2 and
         // f + f / 2, where f is the mean step.
         int randomWalkStepMean = (request.toTime - request.fromTime) / request.monteCarloDraws;
         int randomWalkStepWidthOneSided = randomWalkStepMean / 2;

--- a/src/main/java/com/conveyal/r5/profile/ProfileRequest.java
+++ b/src/main/java/com/conveyal/r5/profile/ProfileRequest.java
@@ -123,6 +123,8 @@ public class ProfileRequest implements Serializable, Cloneable {
     
     /** the maximum number of options presented PER ACCESS MODE */
     public int limit;
+
+    public boolean lockSchedules = false;
     
     /** The modes used to access transit */
     @JsonSerialize(using = LegModeSetSerializer.class)

--- a/src/test/java/com/conveyal/r5/transit/FrequencyRandomOffsetsTest.java
+++ b/src/test/java/com/conveyal/r5/transit/FrequencyRandomOffsetsTest.java
@@ -69,7 +69,7 @@ public class FrequencyRandomOffsetsTest {
         layer.tripPatterns.add(pattern2);
         layer.rebuildTransientIndexes();
 
-        FrequencyRandomOffsets fro = new FrequencyRandomOffsets(layer);
+        FrequencyRandomOffsets fro = new FrequencyRandomOffsets(layer, null);
         fro.randomize();
 
         // check that phasing is correct
@@ -136,7 +136,7 @@ public class FrequencyRandomOffsetsTest {
         layer.tripPatterns.add(pattern2);
         layer.rebuildTransientIndexes();
 
-        FrequencyRandomOffsets fro = new FrequencyRandomOffsets(layer);
+        FrequencyRandomOffsets fro = new FrequencyRandomOffsets(layer, null);
         fro.randomize();
 
         // check that phasing is correct


### PR DESCRIPTION
Addresses #714: with frequency-based routes, users are often distracted by spurious changes in access from random schedule differences between scenarios. 

This PR allows "locking" schedules by setting the seed used for randomizing frequency offsets to a deterministic value for each origin (namely, a multiple of `fromLat`, as is done in the multi-criteria router: see `FrequencyRandomOffsets`). It also adds a field to the analysis request to activate this mode (see `AnalysisRequest`). With `lockSchedules: true`, a given origin will use the same frequency offsets across scenarios, so resulting changes in access should be systematic ones. This PR also includes other minor changes for related tests and documentation.

To test, fetch isochrones repeatedly along an infrequent frequency-based route. Without `lockSchedules`, the isochrone should "waver." With this PR and `lockSchedules: true` (or using build `v6.9-7-ged8378e`, which hardcodes the logic to avoid needing to start a backend server on this branch), there should be no variability with repeatedly fetched isochrones.

In documentation, we should encourage users to run analysis without locking schedules first, to get a sense of variability. If certain corridors show large variability, they may want to use phasing. We've discussed other longer-term changes related to optimized schedules, but the approach proposed here is a minimally invasive one that addresses multiple user requests.