### PR TITLE
Remove unused pattern trips field

### DIFF
--- a/src/main/java/com/conveyal/analysis/models/ConvertToFrequency.java
+++ b/src/main/java/com/conveyal/analysis/models/ConvertToFrequency.java
@@ -32,9 +32,6 @@ public class ConvertToFrequency extends Modification {
         /** trip from which to copy travel times */
         public String sourceTrip;
 
-        /** trips on the selected patterns which could be used as source trips */
-        public String[] patternTrips;
-
         public AddTrips.PatternTimetable toR5 (String feed) {
             AddTrips.PatternTimetable pt = toBaseR5Timetable();
 


### PR DESCRIPTION
This field is not used anywhere in R5 and will no longer be used in the UI. This corresponds to https://github.com/conveyal/ui/pull/1978.