### PR TITLE
Use regional tasks in Simpson Desert tests

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/TravelTimeComputer.java
+++ b/src/main/java/com/conveyal/r5/analyst/TravelTimeComputer.java
@@ -88,11 +88,9 @@ public class TravelTimeComputer {
         ) {
             // Freeform destinations. Destination PointSet was set by handleOneRequest in the main AnalystWorker.
             destinations = request.destinationPointSets[0];
-        } else if (!isNullOrEmpty(request.destinationPointSets)) {
-            LOG.warn("ONLY VALID IN TESTING: Using PointSet object embedded in request outside regional analysis.");
-            destinations = request.destinationPointSets[0];
         } else {
             // Gridded (non-freeform) destinations. This method finds them differently for regional and single requests.
+            // We don't support freeform destinations for single point requests, as they must also return gridded travel times.
             WebMercatorExtents destinationGridExtents = request.getWebMercatorExtents();
             // Make a WebMercatorGridPointSet with the right extents, referring to the network's base grid and linkage.
             destinations = AnalysisWorkerTask.gridPointSetCache.get(destinationGridExtents, network.fullExtentGridPointSet);

--- a/src/main/java/com/conveyal/r5/analyst/TravelTimeReducer.java
+++ b/src/main/java/com/conveyal/r5/analyst/TravelTimeReducer.java
@@ -346,6 +346,8 @@ public class TravelTimeReducer {
     /**
      * Sanity check: all opportunity data sets should have the same size and location as the points to which we'll
      * calculate travel times. They will only be used if we're calculating accessibility.
+     * TODO: expand to cover all cases where destinationPointSets are present, not just accessibility to Mercator grids.
+     * Need to verify first: should this be skipped for one-to-one regional requests on FreeFormPointSets?
      */
     public void checkOpportunityExtents (PointSet travelTimePointSet) {
         if (calculateAccessibility) {

--- a/src/main/java/com/conveyal/r5/analyst/cluster/RegionalTask.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/RegionalTask.java
@@ -46,7 +46,8 @@ public class RegionalTask extends AnalysisWorkerTask implements Cloneable {
     public boolean oneToOne = false;
 
     /**
-     * Whether to record travel times between origins and destinations
+     * Whether to record travel times between origins and destinations. This is done automatically for
+     * TravelTimeSurfaceTask (single point tasks) but must be manually enabled on RegionalTasks using this field.
      */
     public boolean recordTimes;
 

--- a/src/test/java/com/conveyal/r5/analyst/network/GridLayout.java
+++ b/src/test/java/com/conveyal/r5/analyst/network/GridLayout.java
@@ -2,9 +2,6 @@ package com.conveyal.r5.analyst.network;
 
 import com.conveyal.gtfs.GTFSFeed;
 import com.conveyal.osmlib.OSM;
-import com.conveyal.r5.analyst.Grid;
-import com.conveyal.r5.analyst.WebMercatorGridPointSet;
-import com.conveyal.r5.analyst.cluster.AnalysisWorkerTask;
 import com.conveyal.r5.common.SphericalDistanceLibrary;
 import com.conveyal.r5.profile.StreetMode;
 import com.conveyal.r5.transit.TransportNetwork;
@@ -13,12 +10,9 @@ import org.locationtech.jts.geom.CoordinateXY;
 import org.locationtech.jts.geom.Envelope;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
-
-import static com.conveyal.r5.analyst.WebMercatorExtents.DEFAULT_ZOOM;
 
 /**
  * This is used in testing, to represent and create gridded transport systems with very regular spacing of roads and
@@ -165,8 +159,8 @@ public class GridLayout {
     }
 
     /** Creates a builder for analysis worker tasks, which represent searches on this grid network. */
-    public GridSinglePointTaskBuilder newTaskBuilder() {
-        return new GridSinglePointTaskBuilder(this);
+    public GridRegionalTaskBuilder newTaskBuilder() {
+        return new GridRegionalTaskBuilder(this);
     }
 
     /** Get the minimum envelope containing all the points in this grid. */

--- a/src/test/java/com/conveyal/r5/analyst/network/SimpsonDesertTests.java
+++ b/src/test/java/com/conveyal/r5/analyst/network/SimpsonDesertTests.java
@@ -23,11 +23,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * version to the next of R5 (a form of snapshot testing) this checks that they match theoretically expected travel
  * times given headways, transfer points, distances, common trunks and competing lines, etc.
  *
- * Originally we were using web Mercator gridded destinations, as this was the only option in single point analyses.
+ * Originally we were using web Mercator gridded destinations, as this was the only option in single point tasks.
  * Because these tests record travel time distributions at the destinations using a large number of Monte Carlo draws,
  * this was doing a lot of work and storing a lot of data for up to thousands of destinations we weren't actually using.
- * A testing code path now exists to measure travel times to one or more freeform destinations in single point mode.
- * However, it is still possible to measure times to the whole grid if singleFreeformDestination is not called.
+ * Regional tasks with freeform destinations are now used to measure travel times to a limited number of points.
+ * This could be extended to use gridded destination PointSets for future tests.
  */
 public class SimpsonDesertTests {
 
@@ -64,8 +64,7 @@ public class SimpsonDesertTests {
         // always 10 minutes. So scheduled range is expected to be 1 minute slack, 0-20 minutes wait, 10 minutes ride,
         // 10 minutes wait, 10 minutes ride, giving 31 to 51 minutes.
         // This estimation logic could be better codified as something like TravelTimeEstimate.waitWithHeadaway(20) etc.
-
-        // TODO For some reason observed is off by 1 minute, figure out why.
+        // TODO: For some reason observed is dealyed by 1 minute. Figure out why, perhaps due to integer minute binning.
         Distribution expected = new Distribution(31, 20).delay(1);
         expected.multiAssertSimilar(oneOriginResult.travelTimes, 0);
     }
@@ -179,7 +178,7 @@ public class SimpsonDesertTests {
         TransportNetwork network = gridLayout.generateNetwork();
 
         // 0. Reuse this task builder to produce several tasks. See caveats on build() method.
-        GridSinglePointTaskBuilder taskBuilder = gridLayout.newTaskBuilder()
+        GridRegionalTaskBuilder taskBuilder = gridLayout.newTaskBuilder()
                 .departureTimeWindow(7, 0, 5)
                 .maxRides(1)
                 .setOrigin(30, 50)


### PR DESCRIPTION
This is a follow up to #896 that fixes #907. Explanation in comments on that issue #907.

This has been integrated into the 2023 fall release branch and tested as backend/worker v6.9-11-g679fd4b. So far it looks to be working correctly for single point requests both with and without destination grids supplied for accessibility calculations.