### PR TITLE
Prevent runaway error reporting

### DIFF
--- a/src/main/java/com/conveyal/analysis/components/broker/Broker.java
+++ b/src/main/java/com/conveyal/analysis/components/broker/Broker.java
@@ -398,7 +398,11 @@ public class Broker implements Component {
      */
     private synchronized void recordJobError (Job job, String error) {
         if (job != null) {
-            job.errors.add(error);
+            // Limit the number of errors recorded to one.
+            // Still using a Set<String> instead of just String since the set of errors is exposed in a UI-facing API.
+            if (job.errors.isEmpty()) {
+                job.errors.add(error);
+            }
         }
     }
 

--- a/src/main/java/com/conveyal/analysis/components/broker/Job.java
+++ b/src/main/java/com/conveyal/analysis/components/broker/Job.java
@@ -123,8 +123,11 @@ public class Job {
     public int deliveryPass = 0;
 
     /**
-     * If any error compromises the usabilty or quality of results from any origin, it is recorded here.
+     * If any error compromises the usability or quality of results from any origin, it is recorded here.
      * This is a Set because identical errors are likely to be reported from many workers or individual tasks.
+     * The presence of an error here causes the job to be considered "errored" and "inactive" and stop delivering tasks.
+     * There is some risk here of accumulating unbounded amounts of large error messages (see #919).
+     * The field type could be changed to a single String instead of Set, but it's exposed on a UI-facing API as a Set.
      */
     public final Set<String> errors = new HashSet();
 

--- a/src/main/java/com/conveyal/analysis/components/eventbus/ErrorEvent.java
+++ b/src/main/java/com/conveyal/analysis/components/eventbus/ErrorEvent.java
@@ -2,6 +2,8 @@ package com.conveyal.analysis.components.eventbus;
 
 import com.conveyal.r5.util.ExceptionUtils;
 
+import static com.conveyal.r5.util.ExceptionUtils.filterStackTrace;
+
 /**
  * This Event is fired each time a Throwable (usually an Exception or Error) occurs on the backend. It can then be
  * recorded or tracked in various places - the console logs, Slack, etc. This could eventually be used for errors on
@@ -57,22 +59,6 @@ public class ErrorEvent extends Event {
             builder.append(filterStackTrace(stackTrace));
         }
         return builder.toString();
-    }
-
-    private static String filterStackTrace (String stackTrace) {
-        if (stackTrace == null) return null;
-        final String unknownFrame = "Unknown stack frame, probably optimized out by JVM.";
-        String error = stackTrace.lines().findFirst().get();
-        String frame = stackTrace.lines()
-                .map(String::strip)
-                .filter(s -> s.startsWith("at "))
-                .findFirst().orElse(unknownFrame);
-        String conveyalFrame = stackTrace.lines()
-                .map(String::strip)
-                .filter(s -> s.startsWith("at com.conveyal."))
-                .filter(s -> !frame.equals(s))
-                .findFirst().orElse("");
-        return String.join("\n", error, frame, conveyalFrame);
     }
 
 }

--- a/src/main/java/com/conveyal/r5/analyst/cluster/RegionalWorkResult.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/RegionalWorkResult.java
@@ -69,11 +69,17 @@ public class RegionalWorkResult {
         // TODO checkTravelTimeInvariants, checkAccessibilityInvariants to verify that values are monotonically increasing
     }
 
-    /** Constructor used when results for this origin are considered unusable due to an unhandled error. */
+    /**
+     * Constructor used when results for this origin are considered unusable due to an unhandled error. Besides the
+     * short-form exception, most result fields are left null. There is no information to communicate, and because
+     * errors are often produced faster than valid results, we don't want to flood the backend with unnecessarily
+     * voluminous error reports. The short-form exception message is used for a similar reason, to limit the total size
+     * of error messages.
+     */
     public RegionalWorkResult(Throwable t, RegionalTask task) {
         this.jobId = task.jobId;
         this.taskId = task.taskId;
-        this.error = ExceptionUtils.shortAndLongString(t);
+        this.error = ExceptionUtils.filterStackTrace(t);
     }
 
 }

--- a/src/main/java/com/conveyal/r5/util/ExceptionUtils.java
+++ b/src/main/java/com/conveyal/r5/util/ExceptionUtils.java
@@ -50,4 +50,29 @@ public abstract class ExceptionUtils {
         return shortCauseString(throwable) + "\n[detail follows]\n" + stackTraceString(throwable);
     }
 
+    /**
+     * Given a full stack trace string with one frame per line, keep only the exception name, the first stack frame,
+     * and all additional frames that come from Conveyal packages. This yields a much shorter stack trace that still
+     * shows where the exception was thrown and where the problem originates in our own code.
+     */
+    public static String filterStackTrace (String stackTrace) {
+        if (stackTrace == null) return null;
+        final String unknownFrame = "Unknown stack frame, probably optimized out by JVM.";
+        String error = stackTrace.lines().findFirst().get();
+        String frame = stackTrace.lines()
+                .map(String::strip)
+                .filter(s -> s.startsWith("at "))
+                .findFirst().orElse(unknownFrame);
+        String conveyalFrame = stackTrace.lines()
+                .map(String::strip)
+                .filter(s -> s.startsWith("at com.conveyal."))
+                .filter(s -> !frame.equals(s))
+                .findFirst().orElse("");
+        return String.join("\n", error, frame, conveyalFrame);
+    }
+
+    public static String filterStackTrace (Throwable throwable) {
+        return filterStackTrace(stackTraceString(throwable));
+    }
+
 }


### PR DESCRIPTION
This PR addresses problems discussed in #919 and #887. It makes two small changes, each of which alone would prevent the runaway error reporting observed on 2023-12-18 (EST). In addition it reduces the volume of errors sent and recorded.