### PR TITLE
Exclude modifications for regional analysis lookup

### DIFF
--- a/src/main/java/com/conveyal/analysis/controllers/RegionalAnalysisController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/RegionalAnalysisController.java
@@ -527,8 +527,11 @@ public class RegionalAnalysisController implements HttpController {
      * the given regional analysis.
      */
     private JsonNode getScenarioJsonUrl (Request request, Response response) {
-        RegionalAnalysis regionalAnalysis = Persistence.regionalAnalyses
-                .findByIdIfPermitted(request.params("_id"), UserPermissions.from(request));
+        RegionalAnalysis regionalAnalysis = Persistence.regionalAnalyses.findByIdIfPermitted(
+                request.params("_id"),
+                DBProjection.exclude("request.scenario.modifications"),
+                UserPermissions.from(request)
+        );
         // In the persisted objects, regionalAnalysis.scenarioId seems to be null. Get it from the embedded request.
         final String networkId = regionalAnalysis.bundleId;
         final String scenarioId = regionalAnalysis.request.scenarioId;

--- a/src/main/java/com/conveyal/analysis/persistence/MongoMap.java
+++ b/src/main/java/com/conveyal/analysis/persistence/MongoMap.java
@@ -43,12 +43,11 @@ public class MongoMap<V extends Model> {
         return (int) wrappedCollection.getCount();
     }
 
-    public V findByIdFromRequestIfPermitted(Request request) {
-        return findByIdIfPermitted(request.params("_id"), UserPermissions.from(request));
-    }
-
-    public V findByIdIfPermitted(String id, UserPermissions userPermissions) {
-        V result = wrappedCollection.findOneById(id);
+    /**
+     * `fields` is nullable.
+     */
+    public V findByIdIfPermitted(String id, DBObject fields, UserPermissions userPermissions) {
+        V result = wrappedCollection.findOneById(id, fields);
 
         if (result == null) {
             throw AnalysisServerException.notFound(String.format(
@@ -59,6 +58,14 @@ public class MongoMap<V extends Model> {
         } else {
             return result;
         }
+    }
+
+    public V findByIdIfPermitted(String id, UserPermissions userPermissions) {
+        return findByIdIfPermitted(id, null, userPermissions);
+    }
+
+    public V findByIdFromRequestIfPermitted(Request request) {
+        return findByIdIfPermitted(request.params("_id"), UserPermissions.from(request));
     }
 
     public V get(String key) {


### PR DESCRIPTION
This change adds a new helper method to pass a `fields` object to `MongoMap#findByIdIfPermitted` and utilizes that to exclude modifications while looking up a regional analysis to generate a `scenarioJsonUrl`.

This will prevent `JacksonDBDecoder` errors from occurring if custom modifications are used in a worker version that do not also exist in the server. Sample errors like:

```
java.lang.RuntimeException: IOException encountered while reading from a byte array input stream
at org.mongojack.internal.stream.JacksonDBDecoder.decode(JacksonDBDecoder.java:67)
at com.conveyal.analysis.persistence.MongoMap.findByIdIfPermitted(MongoMap.java:51)
```