### PR TITLE
Include names in paths in CSV

### DIFF
--- a/src/main/java/com/conveyal/analysis/models/AnalysisRequest.java
+++ b/src/main/java/com/conveyal/analysis/models/AnalysisRequest.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -175,6 +176,11 @@ public class AnalysisRequest {
      */
     public int dualAccessibilityThreshold = 0;
 
+    /**
+     * Freeform (untyped) flags for enabling experimental, undocumented, or arcane behavior in backend or workers.
+     * This should be used to replace all previous special behavior flags that were embedded inside analysis names etc.
+     */
+    public Set<String> flags;
 
     /**
      * Create the R5 `Scenario` from this request.
@@ -281,6 +287,7 @@ public class AnalysisRequest {
 
         task.includeTemporalDensity = includeTemporalDensity;
         task.dualAccessibilityThreshold = dualAccessibilityThreshold;
+        task.flags = flags;
     }
 
     private EnumSet<LegMode> getEnumSetFromString (String s) {

--- a/src/main/java/com/conveyal/analysis/models/AnalysisRequest.java
+++ b/src/main/java/com/conveyal/analysis/models/AnalysisRequest.java
@@ -12,7 +12,6 @@ import com.conveyal.r5.analyst.fare.InRoutingFareCalculator;
 import com.conveyal.r5.analyst.scenario.Scenario;
 import com.conveyal.r5.api.util.LegMode;
 import com.conveyal.r5.api.util.TransitModes;
-import com.conveyal.r5.transit.TransitLayer;
 import com.mongodb.QueryBuilder;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.checkerframework.checker.units.qual.C;

--- a/src/main/java/com/conveyal/analysis/models/AnalysisRequest.java
+++ b/src/main/java/com/conveyal/analysis/models/AnalysisRequest.java
@@ -14,7 +14,6 @@ import com.conveyal.r5.api.util.LegMode;
 import com.conveyal.r5.api.util.TransitModes;
 import com.mongodb.QueryBuilder;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.checkerframework.checker.units.qual.C;
 
 import java.time.LocalDate;
 import java.util.ArrayList;

--- a/src/main/java/com/conveyal/analysis/models/AnalysisRequest.java
+++ b/src/main/java/com/conveyal/analysis/models/AnalysisRequest.java
@@ -12,8 +12,10 @@ import com.conveyal.r5.analyst.fare.InRoutingFareCalculator;
 import com.conveyal.r5.analyst.scenario.Scenario;
 import com.conveyal.r5.api.util.LegMode;
 import com.conveyal.r5.api.util.TransitModes;
+import com.conveyal.r5.transit.TransitLayer;
 import com.mongodb.QueryBuilder;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.checkerframework.checker.units.qual.C;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -182,6 +184,9 @@ public class AnalysisRequest {
      */
     public Set<String> flags;
 
+    /** Control the details of CSV regional analysis output, including whether to output IDs, names, or both. */
+    public CsvResultOptions csvResultOptions = new CsvResultOptions();
+
     /**
      * Create the R5 `Scenario` from this request.
      */
@@ -288,6 +293,7 @@ public class AnalysisRequest {
         task.includeTemporalDensity = includeTemporalDensity;
         task.dualAccessibilityThreshold = dualAccessibilityThreshold;
         task.flags = flags;
+        task.csvResultOptions = csvResultOptions;
     }
 
     private EnumSet<LegMode> getEnumSetFromString (String s) {

--- a/src/main/java/com/conveyal/analysis/models/CsvResultOptions.java
+++ b/src/main/java/com/conveyal/analysis/models/CsvResultOptions.java
@@ -1,0 +1,18 @@
+package com.conveyal.analysis.models;
+
+import com.conveyal.r5.transit.TransitLayer;
+import com.conveyal.r5.transit.TransitLayer.EntityRepresentation;
+
+import static com.conveyal.r5.transit.TransitLayer.EntityRepresentation.ID_ONLY;
+
+/**
+ * API model type included in analysis requests to control details of CSV regional analysis output.
+ * This type is shared between AnalysisRequest (Frontend -> Broker) and AnalysisWorkerTask (Broker -> Workers).
+ * There is precedent for nested compound types shared across those top level request types (see DecayFunction).
+ */
+public class CsvResultOptions {
+    public EntityRepresentation routeRepresentation = ID_ONLY;
+    public EntityRepresentation stopRepresentation = ID_ONLY;
+    // Only feed ID representation is allowed to be null (no feed IDs at all, the default).
+    public EntityRepresentation feedRepresentation = null;
+}

--- a/src/main/java/com/conveyal/analysis/models/CsvResultOptions.java
+++ b/src/main/java/com/conveyal/analysis/models/CsvResultOptions.java
@@ -1,6 +1,5 @@
 package com.conveyal.analysis.models;
 
-import com.conveyal.r5.transit.TransitLayer;
 import com.conveyal.r5.transit.TransitLayer.EntityRepresentation;
 
 import static com.conveyal.r5.transit.TransitLayer.EntityRepresentation.ID_ONLY;

--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalysisWorkerTask.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalysisWorkerTask.java
@@ -1,5 +1,6 @@
 package com.conveyal.r5.analyst.cluster;
 
+import com.conveyal.analysis.models.CsvResultOptions;
 import com.conveyal.r5.analyst.FreeFormPointSet;
 import com.conveyal.r5.analyst.Grid;
 import com.conveyal.r5.analyst.GridTransformWrapper;
@@ -183,6 +184,9 @@ public abstract class AnalysisWorkerTask extends ProfileRequest {
      * This should be used to replace all previous special behavior flags that were embedded inside analysis names etc.
      */
     public Set<String> flags;
+
+    /** Control the details of CSV regional analysis output, including whether to output IDs, names, or both. */
+    public CsvResultOptions csvResultOptions;
 
     /**
      * Is this a single point or regional request? Needed to encode types in JSON serialization. Can that type field be

--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalysisWorkerTask.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalysisWorkerTask.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import java.util.Arrays;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -176,6 +177,12 @@ public abstract class AnalysisWorkerTask extends ProfileRequest {
      * testing or even production systems in order to observe and improve their robustness to failure.
      */
     public ChaosParameters injectFault;
+
+    /**
+     * Freeform (untyped) flags for enabling experimental, undocumented, or arcane worker behavior.
+     * This should be used to replace all previous special behavior flags that were embedded inside analysis names etc.
+     */
+    public Set<String> flags;
 
     /**
      * Is this a single point or regional request? Needed to encode types in JSON serialization. Can that type field be

--- a/src/main/java/com/conveyal/r5/analyst/cluster/PathResult.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/PathResult.java
@@ -108,7 +108,7 @@ public class PathResult {
                     int nIterations = iterations.size();
                     checkState(nIterations > 0, "A path was stored without any iterations");
                     String waits = null, transfer = null, totalTime = null;
-                    String[] path = routeSequence.detailsWithGtfsIds(transitLayer);
+                    String[] path = routeSequence.detailsWithGtfsIds(transitLayer, true);
                     double targetValue;
                     IntStream totalWaits = iterations.stream().mapToInt(i -> i.waitTimes.sum());
                     if (stat == Stat.MINIMUM) {

--- a/src/main/java/com/conveyal/r5/analyst/cluster/PathResult.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/PathResult.java
@@ -1,5 +1,6 @@
 package com.conveyal.r5.analyst.cluster;
 
+import com.conveyal.analysis.models.CsvResultOptions;
 import com.conveyal.r5.analyst.StreetTimesAndModes;
 import com.conveyal.r5.transit.TransitLayer;
 import com.conveyal.r5.transit.path.Path;
@@ -19,9 +20,6 @@ import java.util.StringJoiner;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static com.conveyal.r5.transit.TransitLayer.EntityRepresentation.ID_ONLY;
-import static com.conveyal.r5.transit.TransitLayer.EntityRepresentation.ID_AND_NAME;
-import static com.conveyal.r5.transit.TransitLayer.EntityRepresentation.NAME_ONLY;
 import static com.google.common.base.Preconditions.checkState;
 
 /**
@@ -53,7 +51,7 @@ public class PathResult {
 
     private final TransitLayer transitLayer;
 
-    private TransitLayer.EntityRepresentation nameOrId;
+    private final CsvResultOptions csvOptions;
 
     public static final String[] DATA_COLUMNS = new String[]{
             "routes",
@@ -82,17 +80,7 @@ public class PathResult {
         }
         iterationsForPathTemplates = new Multimap[nDestinations];
         this.transitLayer = transitLayer;
-        if (task.flags == null) {
-            nameOrId = ID_ONLY;
-        } else {
-            boolean includeEntityNames = task.flags.contains("csv_names");
-            boolean includeEntityIds = !task.flags.contains("csv_no_ids");
-            if (includeEntityIds && includeEntityNames) {
-                this.nameOrId = ID_AND_NAME;
-            } else if (includeEntityNames) {
-                this.nameOrId = NAME_ONLY;
-            }
-        }
+        this.csvOptions = task.csvResultOptions;
     }
 
     /**
@@ -125,7 +113,7 @@ public class PathResult {
                     int nIterations = iterations.size();
                     checkState(nIterations > 0, "A path was stored without any iterations");
                     String waits = null, transfer = null, totalTime = null;
-                    String[] path = routeSequence.detailsWithGtfsIds(transitLayer, nameOrId);
+                    String[] path = routeSequence.detailsWithGtfsIds(transitLayer, csvOptions);
                     double targetValue;
                     IntStream totalWaits = iterations.stream().mapToInt(i -> i.waitTimes.sum());
                     if (stat == Stat.MINIMUM) {

--- a/src/main/java/com/conveyal/r5/transit/TransitLayer.java
+++ b/src/main/java/com/conveyal/r5/transit/TransitLayer.java
@@ -819,7 +819,7 @@ public class TransitLayer implements Serializable, Cloneable {
     }
 
     public enum EntityRepresentation {
-        ID_ONLY, NAME_ONLY, ID_AND_NAME
+        ID_ONLY, NAME_ONLY, NAME_AND_ID
     }
 
     /**
@@ -841,7 +841,7 @@ public class TransitLayer implements Serializable, Cloneable {
         }
         return switch (nameOrId) {
             case NAME_ONLY -> name;
-            case ID_AND_NAME -> id + " (" + name + ")";
+            case NAME_AND_ID -> name + " (" + id + ")";
             default -> id;
         };
     }
@@ -869,7 +869,7 @@ public class TransitLayer implements Serializable, Cloneable {
         }
         return switch (nameOrId) {
             case NAME_ONLY -> stopName;
-            case ID_AND_NAME -> stopId + " (" + stopName + ")";
+            case NAME_AND_ID -> stopName + " (" + stopId + ")";
             default -> stopId;
         };
     }

--- a/src/main/java/com/conveyal/r5/transit/TransitLayer.java
+++ b/src/main/java/com/conveyal/r5/transit/TransitLayer.java
@@ -54,6 +54,9 @@ import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
 
+import static com.conveyal.r5.transit.TransitLayer.EntityRepresentation.ID_ONLY;
+import static com.conveyal.r5.transit.TransitLayer.EntityRepresentation.NAME_ONLY;
+
 
 /**
  * A key simplifying factor is that we don't handle overnight trips. This is fine for analysis at usual times of day.
@@ -815,31 +818,59 @@ public class TransitLayer implements Serializable, Cloneable {
         return stops;
     }
 
+    public enum EntityRepresentation {
+        ID_ONLY, NAME_ONLY, ID_AND_NAME
+    }
+
     /**
      * For the given pattern index, returns the GTFS routeId. If includeName is true, the returned string will
      * also include a route_short_name or route_long_name (if they are not null).
      */
-    public String routeString(int routeIndex, boolean includeName) {
+    public String routeString (int routeIndex, EntityRepresentation nameOrId) {
         RouteInfo routeInfo = routes.get(routeIndex);
-        String route = routeInfo.route_id;
-        if (includeName) {
-            if (routeInfo.route_short_name != null) {
-                route += " (" + routeInfo.route_short_name + ")";
-            } else if (routeInfo.route_long_name != null){
-                route += " (" + routeInfo.route_long_name + ")";
+        String name = routeInfo.route_short_name;
+        String id = routeInfo.route_id;
+        // If we might actually use the name, check some fallbacks.
+        if (nameOrId != ID_ONLY) {
+            if (name == null) {
+                name = routeInfo.route_long_name;
+            }
+            if (name == null) {
+                name = routeInfo.route_id;
             }
         }
-        return route;
+        return switch (nameOrId) {
+            case NAME_ONLY -> name;
+            case ID_AND_NAME -> id + " (" + name + ")";
+            default -> id;
+        };
     }
 
     /**
      * For the given stop index, returns the GTFS stopId (stripped of R5's feedId prefix) and, if includeName is true,
      * stopName.
      */
-    public String stopString(int stopIndex, boolean includeName) {
-        // TODO use a compact feed index, instead of splitting to remove feedIds
-        String stop = stopIdForIndex.get(stopIndex) == null ? "[new]" : stopIdForIndex.get(stopIndex).split(":")[1];
-        if (includeName) stop += " (" + stopNames.get(stopIndex) + ")";
-        return stop;
+    public String stopString(int stopIndex, EntityRepresentation nameOrId) {
+        String stopId = stopIdForIndex.get(stopIndex);
+        String stopName = stopNames.get(stopIndex);
+        // I'd trust the JVM JIT to optimize out these assignments on different code paths, but not the split call.
+        if (nameOrId != NAME_ONLY) {
+            if (stopId == null) {
+                stopId = "[new]";
+            } else {
+                // TODO use a compact feed ID instead of splitting to remove feedIds (or put feedId into another CSV field)
+                stopId = stopId.split(":")[1];
+            }
+        }
+        if (nameOrId != ID_ONLY) {
+            if (stopName == null) {
+                stopName = "[new]";
+            }
+        }
+        return switch (nameOrId) {
+            case NAME_ONLY -> stopName;
+            case ID_AND_NAME -> stopId + " (" + stopName + ")";
+            default -> stopId;
+        };
     }
 }

--- a/src/main/java/com/conveyal/r5/transit/path/RouteSequence.java
+++ b/src/main/java/com/conveyal/r5/transit/path/RouteSequence.java
@@ -28,15 +28,15 @@ public class RouteSequence {
     }
 
     /** Returns details summarizing this route sequence, using GTFS ids stored in the supplied transitLayer. */
-    public String[] detailsWithGtfsIds(TransitLayer transitLayer){
+    public String[] detailsWithGtfsIds(TransitLayer transitLayer, boolean includeNames){
         StringJoiner routeIds = new StringJoiner("|");
         StringJoiner boardStopIds = new StringJoiner("|");
         StringJoiner alightStopIds = new StringJoiner("|");
         StringJoiner rideTimes = new StringJoiner("|");
         for (int i = 0; i < routes.size(); i++) {
-            routeIds.add(transitLayer.routeString(routes.get(i), false));
-            boardStopIds.add(transitLayer.stopString(stopSequence.boardStops.get(i), false));
-            alightStopIds.add(transitLayer.stopString(stopSequence.alightStops.get(i), false));
+            routeIds.add(transitLayer.routeString(routes.get(i), includeNames));
+            boardStopIds.add(transitLayer.stopString(stopSequence.boardStops.get(i), includeNames));
+            alightStopIds.add(transitLayer.stopString(stopSequence.alightStops.get(i), includeNames));
             rideTimes.add(String.format("%.1f", stopSequence.rideTimesSeconds.get(i) / 60f));
         }
         String accessTime = stopSequence.access == null ? null : String.format("%.1f", stopSequence.access.time / 60f);

--- a/src/main/java/com/conveyal/r5/transit/path/RouteSequence.java
+++ b/src/main/java/com/conveyal/r5/transit/path/RouteSequence.java
@@ -1,5 +1,6 @@
 package com.conveyal.r5.transit.path;
 
+import com.conveyal.analysis.models.CsvResultOptions;
 import com.conveyal.r5.transit.TransitLayer;
 import com.conveyal.r5.transit.TransitLayer.EntityRepresentation;
 import gnu.trove.list.TIntList;
@@ -10,7 +11,7 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.StringJoiner;
 
-import static com.conveyal.r5.transit.TransitLayer.EntityRepresentation.ID_AND_NAME;
+import static com.conveyal.r5.transit.TransitLayer.EntityRepresentation.NAME_AND_ID;
 
 /** A door-to-door path that includes the routes ridden between stops */
 public class RouteSequence {
@@ -31,15 +32,15 @@ public class RouteSequence {
     }
 
     /** Returns details summarizing this route sequence, using GTFS ids stored in the supplied transitLayer. */
-    public String[] detailsWithGtfsIds (TransitLayer transitLayer, EntityRepresentation nameOrId){
+    public String[] detailsWithGtfsIds (TransitLayer transitLayer, CsvResultOptions csvOptions){
         StringJoiner routeIds = new StringJoiner("|");
         StringJoiner boardStopIds = new StringJoiner("|");
         StringJoiner alightStopIds = new StringJoiner("|");
         StringJoiner rideTimes = new StringJoiner("|");
         for (int i = 0; i < routes.size(); i++) {
-            routeIds.add(transitLayer.routeString(routes.get(i), nameOrId));
-            boardStopIds.add(transitLayer.stopString(stopSequence.boardStops.get(i), nameOrId));
-            alightStopIds.add(transitLayer.stopString(stopSequence.alightStops.get(i), nameOrId));
+            routeIds.add(transitLayer.routeString(routes.get(i), csvOptions.routeRepresentation));
+            boardStopIds.add(transitLayer.stopString(stopSequence.boardStops.get(i), csvOptions.stopRepresentation));
+            alightStopIds.add(transitLayer.stopString(stopSequence.alightStops.get(i), csvOptions.stopRepresentation));
             rideTimes.add(String.format("%.1f", stopSequence.rideTimesSeconds.get(i) / 60f));
         }
         String accessTime = stopSequence.access == null ? null : String.format("%.1f", stopSequence.access.time / 60f);
@@ -58,9 +59,9 @@ public class RouteSequence {
     public Collection<TransitLeg> transitLegs(TransitLayer transitLayer) {
         Collection<TransitLeg> transitLegs = new ArrayList<>();
         for (int i = 0; i < routes.size(); i++) {
-            String routeString = transitLayer.routeString(routes.get(i), ID_AND_NAME);
-            String boardStop = transitLayer.stopString(stopSequence.boardStops.get(i), ID_AND_NAME);
-            String alightStop = transitLayer.stopString(stopSequence.alightStops.get(i), ID_AND_NAME);
+            String routeString = transitLayer.routeString(routes.get(i), NAME_AND_ID);
+            String boardStop = transitLayer.stopString(stopSequence.boardStops.get(i), NAME_AND_ID);
+            String alightStop = transitLayer.stopString(stopSequence.alightStops.get(i), NAME_AND_ID);
             transitLegs.add(new TransitLeg(routeString, stopSequence.rideTimesSeconds.get(i), boardStop, alightStop));
         }
         return transitLegs;

--- a/src/main/java/com/conveyal/r5/transit/path/RouteSequence.java
+++ b/src/main/java/com/conveyal/r5/transit/path/RouteSequence.java
@@ -1,6 +1,7 @@
 package com.conveyal.r5.transit.path;
 
 import com.conveyal.r5.transit.TransitLayer;
+import com.conveyal.r5.transit.TransitLayer.EntityRepresentation;
 import gnu.trove.list.TIntList;
 import gnu.trove.list.array.TIntArrayList;
 
@@ -8,6 +9,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.StringJoiner;
+
+import static com.conveyal.r5.transit.TransitLayer.EntityRepresentation.ID_AND_NAME;
 
 /** A door-to-door path that includes the routes ridden between stops */
 public class RouteSequence {
@@ -28,15 +31,15 @@ public class RouteSequence {
     }
 
     /** Returns details summarizing this route sequence, using GTFS ids stored in the supplied transitLayer. */
-    public String[] detailsWithGtfsIds(TransitLayer transitLayer, boolean includeNames){
+    public String[] detailsWithGtfsIds (TransitLayer transitLayer, EntityRepresentation nameOrId){
         StringJoiner routeIds = new StringJoiner("|");
         StringJoiner boardStopIds = new StringJoiner("|");
         StringJoiner alightStopIds = new StringJoiner("|");
         StringJoiner rideTimes = new StringJoiner("|");
         for (int i = 0; i < routes.size(); i++) {
-            routeIds.add(transitLayer.routeString(routes.get(i), includeNames));
-            boardStopIds.add(transitLayer.stopString(stopSequence.boardStops.get(i), includeNames));
-            alightStopIds.add(transitLayer.stopString(stopSequence.alightStops.get(i), includeNames));
+            routeIds.add(transitLayer.routeString(routes.get(i), nameOrId));
+            boardStopIds.add(transitLayer.stopString(stopSequence.boardStops.get(i), nameOrId));
+            alightStopIds.add(transitLayer.stopString(stopSequence.alightStops.get(i), nameOrId));
             rideTimes.add(String.format("%.1f", stopSequence.rideTimesSeconds.get(i) / 60f));
         }
         String accessTime = stopSequence.access == null ? null : String.format("%.1f", stopSequence.access.time / 60f);
@@ -55,9 +58,9 @@ public class RouteSequence {
     public Collection<TransitLeg> transitLegs(TransitLayer transitLayer) {
         Collection<TransitLeg> transitLegs = new ArrayList<>();
         for (int i = 0; i < routes.size(); i++) {
-            String routeString = transitLayer.routeString(routes.get(i), true);
-            String boardStop = transitLayer.stopString(stopSequence.boardStops.get(i), true);
-            String alightStop = transitLayer.stopString(stopSequence.alightStops.get(i), true);
+            String routeString = transitLayer.routeString(routes.get(i), ID_AND_NAME);
+            String boardStop = transitLayer.stopString(stopSequence.boardStops.get(i), ID_AND_NAME);
+            String alightStop = transitLayer.stopString(stopSequence.alightStops.get(i), ID_AND_NAME);
             transitLegs.add(new TransitLeg(routeString, stopSequence.rideTimesSeconds.get(i), boardStop, alightStop));
         }
         return transitLegs;


### PR DESCRIPTION
This makes it possible to represent stops and routes in CSV output using their names in addition to (or instead of) their IDs. Users have commented that they greatly prefer to work with the names, and often only with the names. Though they're not guaranteed to be unique, in some data sets names are clear enough to work well.

Showing route names has the additional major benefit of showing which modification created a route (instead of a meaningless UUID) in routes that did not come from GTFS.

As recently discussed, this also introduced a freeform `Set<String>` flags field in requests for enabling experimental, undocumented, or arcane behavior in backend or workers. When making a JSON request this will look like `"flags": ["csv_names", "csv_no_ids"]`. This should progressively replace all previous special behavior flags that were embedded inside analysis names etc.

I have tested this locally and it seems to work for all three entity representations.

Now that it's implemented, a few questions emerge. One is whether it's really worth it to define an enum for `EntityRepresentation { ID_ONLY, NAME_ONLY, ID_AND_NAME }` or it should just be two boolean parameters. Another is whether this would be better represented by actually adding a real enum-typed parameter to the requests. It would require less conversions and make it easier to toggle stop and route representations separately for example.

I think the flags facility should still be retained for other purposes even if we stop using it for this purpose.