### PR TITLE
Make human-friendly names available and allow multi-grid downloads 

### DIFF
--- a/src/main/java/com/conveyal/analysis/controllers/AggregationAreaController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/AggregationAreaController.java
@@ -10,6 +10,7 @@ import com.conveyal.analysis.persistence.AnalysisCollection;
 import com.conveyal.analysis.persistence.AnalysisDB;
 import com.conveyal.analysis.util.JsonUtil;
 import com.conveyal.file.FileStorage;
+import com.conveyal.file.UrlWithHumanName;
 import com.conveyal.r5.analyst.progress.Task;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.bson.conversions.Bson;
@@ -27,6 +28,7 @@ import static com.conveyal.analysis.util.JsonUtil.toJson;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
+import static org.eclipse.jetty.http.MimeTypes.Type.APPLICATION_JSON;
 
 /**
  * Stores vector aggregationAreas (used to define the region of a weighted average accessibility metric).
@@ -98,10 +100,10 @@ public class AggregationAreaController implements HttpController {
     }
 
     /** Returns a JSON-wrapped URL for the mask grid of the aggregation area whose id matches the path parameter. */
-    private ObjectNode getAggregationAreaGridUrl (Request req, Response res) {
+    private UrlWithHumanName getAggregationAreaGridUrl (Request req, Response res) {
         AggregationArea aggregationArea = aggregationAreaCollection.findPermittedByRequestParamId(req);
-        String url = fileStorage.getURL(aggregationArea.getStorageKey());
-        return JsonUtil.objectNode().put("url", url);
+        res.type(APPLICATION_JSON.asString());
+        return fileStorage.getJsonUrl(aggregationArea.getStorageKey(), aggregationArea.name, "grid");
     }
 
     @Override

--- a/src/main/java/com/conveyal/analysis/controllers/LocalFilesController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/LocalFilesController.java
@@ -33,7 +33,9 @@ public class LocalFilesController implements HttpController {
         FileStorageKey key = new FileStorageKey(category, filename);
         File file = fileStorage.getFile(key);
         FileStorageFormat format = FileStorageFormat.fromFilename(filename);
-        res.type(format.mimeType);
+        if (format != null) {
+            res.type(format.mimeType);
+        }
 
         // If the content-encoding is set to gzip, Spark automatically gzips the response. This double-gzips anything
         // that was already gzipped. Some of our files are already gzipped, and we rely on the the client browser to

--- a/src/main/java/com/conveyal/analysis/results/BaseResultWriter.java
+++ b/src/main/java/com/conveyal/analysis/results/BaseResultWriter.java
@@ -61,6 +61,7 @@ public abstract class BaseResultWriter {
 
         // There's probably a more elegant way to do this with NIO and without closing the buffer.
         // That would be Files.copy(File.toPath(),X) or ByteStreams.copy.
+        // Perhaps better: we could wrap the output buffer in a gzip output stream and zip as we write out.
         InputStream is = new BufferedInputStream(new FileInputStream(bufferFile));
         OutputStream os = new GZIPOutputStream(new BufferedOutputStream(new FileOutputStream(gzippedResultFile)));
         ByteStreams.copy(is, os);

--- a/src/main/java/com/conveyal/file/FileStorage.java
+++ b/src/main/java/com/conveyal/file/FileStorage.java
@@ -94,4 +94,9 @@ public interface FileStorage extends Component {
         }
     }
 
+    default UrlWithHumanName getJsonUrl (FileStorageKey key, String rawHumanName, String humanExtension) {
+        String url = this.getURL(key);
+        return UrlWithHumanName.fromCleanedName(url, rawHumanName, humanExtension);
+    }
+
 }

--- a/src/main/java/com/conveyal/file/FileStorage.java
+++ b/src/main/java/com/conveyal/file/FileStorage.java
@@ -99,4 +99,10 @@ public interface FileStorage extends Component {
         return UrlWithHumanName.fromCleanedName(url, rawHumanName, humanExtension);
     }
 
+    /** This assumes the humanFileName is already a complete filename (cleaned and truncated with any extension). */
+    default UrlWithHumanName getJsonUrl (FileStorageKey key, String humanFileName) {
+        String url = this.getURL(key);
+        return new UrlWithHumanName(url, humanFileName);
+    }
+
 }

--- a/src/main/java/com/conveyal/file/FileStorageFormat.java
+++ b/src/main/java/com/conveyal/file/FileStorageFormat.java
@@ -1,5 +1,7 @@
 package com.conveyal.file;
 
+import java.util.Locale;
+
 /**
  * An enumeration of all the file types we handle as uploads, derived internal data, or work products.
  * Really this should be a union of several enumerated types (upload/internal/product) but Java does not allow this.
@@ -37,7 +39,12 @@ public enum FileStorageFormat {
     }
 
     public static FileStorageFormat fromFilename (String filename) {
-        String extension = filename.substring(filename.lastIndexOf(".") + 1);
-        return FileStorageFormat.valueOf(extension.toUpperCase());
+        String extension = filename.substring(filename.lastIndexOf(".") + 1).toLowerCase(Locale.ROOT);
+        for (FileStorageFormat format : FileStorageFormat.values()) {
+            if (format.extension.equals(extension)) {
+                return format;
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/com/conveyal/file/UrlWithHumanName.java
+++ b/src/main/java/com/conveyal/file/UrlWithHumanName.java
@@ -1,0 +1,39 @@
+package com.conveyal.file;
+
+/**
+ * Combines a url for downloading a file, which might include a globally unique but human-annoying UUID, with a
+ * suggested human-readable name for that file when saved by an end user. The humanName may not be globally unique,
+ * so is only appropriate for cases where it doesn't need to be machine discoverable using a UUID. The humanName can
+ * be used as the download attribute of an HTML link, or as the attachment name in a content-disposition header.
+ * Instances of this record are intended to be serialized to JSON as an HTTP API response.
+ * // TODO make this into a class with factory methods and move static cleanFilename method here.
+ */
+public class UrlWithHumanName {
+    public final String url;
+    public final String humanName;
+
+    public UrlWithHumanName (String url, String humanName) {
+        this.url = url;
+        this.humanName = humanName;
+    }
+
+    private static final int TRUNCATE_FILENAME_CHARS = 220;
+
+    /**
+     * Given an arbitrary string, make it safe for use as a friendly human-readable filename.
+     * This can yield non-unique strings and is intended for files downloaded by end users that do not need to be
+     * machine-discoverable by unique IDs.
+     */
+    public static String filenameCleanString (String original) {
+        String ret = original.replaceAll("\\W+", "_");
+        if (ret.length() > TRUNCATE_FILENAME_CHARS) {
+            ret = ret.substring(0, TRUNCATE_FILENAME_CHARS);
+        }
+        return ret;
+    }
+
+    public static UrlWithHumanName fromCleanedName (String url, String rawHumanName, String humanExtension) {
+        String humanName = UrlWithHumanName.filenameCleanString(rawHumanName) + "." + humanExtension;
+        return new UrlWithHumanName(url, humanName);
+    }
+}

--- a/src/main/java/com/conveyal/file/UrlWithHumanName.java
+++ b/src/main/java/com/conveyal/file/UrlWithHumanName.java
@@ -6,7 +6,6 @@ package com.conveyal.file;
  * so is only appropriate for cases where it doesn't need to be machine discoverable using a UUID. The humanName can
  * be used as the download attribute of an HTML link, or as the attachment name in a content-disposition header.
  * Instances of this record are intended to be serialized to JSON as an HTTP API response.
- * // TODO make this into a class with factory methods and move static cleanFilename method here.
  */
 public class UrlWithHumanName {
     public final String url;

--- a/src/main/java/com/conveyal/file/UrlWithHumanName.java
+++ b/src/main/java/com/conveyal/file/UrlWithHumanName.java
@@ -19,14 +19,19 @@ public class UrlWithHumanName {
     private static final int TRUNCATE_FILENAME_CHARS = 220;
 
     /**
-     * Given an arbitrary string, make it safe for use as a friendly human-readable filename.
-     * This can yield non-unique strings and is intended for files downloaded by end users that do not need to be
-     * machine-discoverable by unique IDs.
+     * Given an arbitrary string, make it safe for use in a friendly human-readable filename. This can yield non-unique
+     * strings and is intended for files downloaded by end users that do not need to be machine-discoverable by unique
+     * IDs. A length of up to 255 characters will work with most filesystems and within ZIP files. In all names we
+     * generate, the end of the name more uniquely identifies it (contains a fragment of a hex object ID or contains
+     * the distinguishing factors such as cutoff and percentile for files within a ZIP archive). Therefore, we truncate
+     * to a suffix rather than a prefix when the name is too long. We keep the length somewhat under 255 in case some
+     * other short suffix needs to be appended before use as a filename.
+     * Note that this will strip dot characters out of the string, so any dot and extension must be suffixed later.
      */
     public static String filenameCleanString (String original) {
         String ret = original.replaceAll("\\W+", "_");
         if (ret.length() > TRUNCATE_FILENAME_CHARS) {
-            ret = ret.substring(0, TRUNCATE_FILENAME_CHARS);
+            ret = ret.substring(ret.length() - TRUNCATE_FILENAME_CHARS, ret.length());
         }
         return ret;
     }


### PR DESCRIPTION
The backend returns download URLs as small JSON objects with a `url` property. In this PR, these JSON responses are extended to also have a humanName property, which is an alternate filename that is more human readable but not guaranteed to be unique. This enables #673 (as discussed in https://github.com/conveyal/r5/issues/673#issuecomment-1912000319) but should be backward compatible with existing UI as responses still have the same old `url` property. The new `humanName` property can be used in various ways such as the download attribute of an HTML link or as the attachment name in a content-disposition header.

Regional result CSV download links seem to be the odd one out: they return text/plain instead of a JSON wrapped URL. Switching them over to use JSON wrapped URLs like everything else would require an accompanying change on the UI side but would also enable the CSV downloads to use human readable names. The updated code to return the JSON wrapped URL with humanName is already present in RegionalAnalysisController.getCsvResults but commented out for the time being.

This PR also adds and endpoint at `/api/regional/:_id/all` that will generate all available GeoTIFF rasters for a given regional analysis and store them in a persistent ZIP file, returning one of these new-style JSON wrapped download links including a human-readable name. An attempt is also made to replace any UUIDs in the names of files inside this ZIP with relevant human-readable strings.

Many of the changes here are just small changes to return types, MIME types etc. There is one big block add/remove RegionalAnalysisController which is mostly factoring the action of extracting a single grid out of the HTTP controller, so it can be called once by the existing grid-retrieval HTTP controller, but multiple times in a loop by the new bulk-zip-creating HTTP controller. The smaller targeted changes there are somewhat camouflaged/exaggerated by the indentation and movement of that big block. 