### PR TITLE
Dual access for grid origins

### DIFF
--- a/src/main/java/com/conveyal/analysis/results/MultiOriginAssembler.java
+++ b/src/main/java/com/conveyal/analysis/results/MultiOriginAssembler.java
@@ -139,7 +139,8 @@ public class MultiOriginAssembler {
                     // We might want to record a grid of dual accessibility values, but this will require some serious
                     // refactoring of the GridResultWriter.
                     // if (job.templateTask.dualAccessibilityThreshold > 0) { ... }
-                    throw new IllegalArgumentException("Temporal density of opportunities cannot be recorded for gridded origin points.");
+                    // throw new IllegalArgumentException("Temporal density of opportunities cannot be recorded for " +
+                    //        "gridded origin points.");
                 } else {
                     // Freeform origins.
                     // Output includes temporal density of opportunities and optionally dual accessibility.

--- a/src/main/java/com/conveyal/r5/analyst/TemporalDensityResult.java
+++ b/src/main/java/com/conveyal/r5/analyst/TemporalDensityResult.java
@@ -90,6 +90,17 @@ public class TemporalDensityResult {
         return result;
     }
 
+    /**
+     * Writes dual access travel time values (in minutes) to our standard access grid format. The value returned (for
+     * an origin) is the number of minutes required to reach a threshold number of opportunities (specified by
+     * the cutoffs and task.dualAccessibilityThreshold) in the specified destination layer at a given percentile of
+     * travel time. If the threshold cannot be reached in less than 120 minutes, returns 0.
+     * This is a temporary experimental feature, (ab)using existing features in the UI and backend so that grid access
+     * results can be obtained without any changes to those other components of our system. It uses the supplied
+     * task.cutoffsMinutes, except for the last one, as dual access thresholds. In place of the last cutoffsMinutes
+     * value, it uses task.dualAccessibilityThreshold (which is initialized to 0, so this is safe even if a user does
+     * not supply it).
+     */
     public int[][][] fakeDualAccess (RegionalTask task) {
         int nPointSets = task.destinationPointSets.length;
         int nCutoffs = task.cutoffsMinutes.length;
@@ -104,17 +115,17 @@ public class TemporalDensityResult {
                         sum += opportunitiesPerMinute[d][p][m];
                         m += 1;
                     }
-                    dualAccess[d][p][c] = m == 0 ? 999 : m;
+                    dualAccess[d][p][c] = m;
                 }
-                // But hack above won't allow thresholds over 120; so use the dualAccessibilityThreshold instead of
-                // the last cutoff
+                // But the hack above won't allow thresholds over 120 (see validateCutoffsMinutes()); so use the
+                // dualAccessibilityThreshold instead of the last cutoff.
                 int m = 0;
                 double sum = 0;
                 while (sum < task.dualAccessibilityThreshold && m < 120) {
                     sum += opportunitiesPerMinute[d][p][m];
                     m += 1;
                 }
-                dualAccess[d][p][nCutoffs - 1] = m == 0 ? 999 : m;
+                dualAccess[d][p][nCutoffs - 1] = m;
             }
         }
         return dualAccess;

--- a/src/main/java/com/conveyal/r5/analyst/TravelTimeReducer.java
+++ b/src/main/java/com/conveyal/r5/analyst/TravelTimeReducer.java
@@ -145,7 +145,7 @@ public class TravelTimeReducer {
         if (task.includePathResults) {
             pathResult = new PathResult(task, network.transitLayer);
         }
-        if (task.includeTemporalDensity) {
+        if (task.includeTemporalDensity || task.flags.contains("gridDualAccess")) {
             temporalDensityResult = new TemporalDensityResult(task);
         }
 

--- a/src/main/java/com/conveyal/r5/analyst/TravelTimeReducer.java
+++ b/src/main/java/com/conveyal/r5/analyst/TravelTimeReducer.java
@@ -145,7 +145,7 @@ public class TravelTimeReducer {
         if (task.includePathResults) {
             pathResult = new PathResult(task, network.transitLayer);
         }
-        if (task.includeTemporalDensity || task.flags.contains("gridDualAccess")) {
+        if (task.includeTemporalDensity || task.hasFlag("gridDualAccess")) {
             temporalDensityResult = new TemporalDensityResult(task);
         }
 

--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalysisWorker.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalysisWorker.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -406,6 +407,10 @@ public class AnalysisWorker implements Component {
     protected void handleOneRegionalTask (RegionalTask task) throws Throwable {
 
         LOG.debug("Handling regional task {}", task.toString());
+
+        // Force dual access results for grid (remove once broker has been relaunched to support custom flags)
+        LOG.info("Forcing dual access results");
+        task.flags = Set.of("gridDualAccess");
 
         if (task.injectFault != null) {
             task.injectFault.considerShutdownOrException(task.taskId);

--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalysisWorkerTask.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalysisWorkerTask.java
@@ -323,4 +323,8 @@ public abstract class AnalysisWorkerTask extends ProfileRequest {
         }
     }
 
+    public boolean hasFlag (String flag) {
+        return this.flags != null && this.flags.contains(flag);
+    }
+
 }

--- a/src/main/java/com/conveyal/r5/analyst/cluster/RegionalWorkResult.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/RegionalWorkResult.java
@@ -65,7 +65,7 @@ public class RegionalWorkResult {
         this.travelTimeValues = result.travelTimes == null ? null : result.travelTimes.values;
         if (result.accessibility == null) {
             this.accessibilityValues = null;
-        } else if (task.flags.contains("gridDualAccess")) {
+        } else if (task.hasFlag("gridDualAccess")) {
             this.accessibilityValues = result.density.fakeDualAccess(task);
         } else {
             this.accessibilityValues = result.accessibility.getIntValues();

--- a/src/main/java/com/conveyal/r5/analyst/cluster/RegionalWorkResult.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/RegionalWorkResult.java
@@ -63,7 +63,7 @@ public class RegionalWorkResult {
         this.jobId = task.jobId;
         this.taskId = task.taskId;
         this.travelTimeValues = result.travelTimes == null ? null : result.travelTimes.values;
-        this.accessibilityValues = result.accessibility == null ? null : result.accessibility.getIntValues();
+        this.accessibilityValues = result.accessibility == null ? null : result.density.fakeDualAccess(task);
         this.pathResult = result.paths == null ? null : result.paths.summarizeIterations(PathResult.Stat.MINIMUM);
         this.opportunitiesPerMinute = result.density == null ? null : result.density.opportunitiesPerMinute;
         // TODO checkTravelTimeInvariants, checkAccessibilityInvariants to verify that values are monotonically increasing

--- a/src/main/java/com/conveyal/r5/analyst/cluster/RegionalWorkResult.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/RegionalWorkResult.java
@@ -63,7 +63,13 @@ public class RegionalWorkResult {
         this.jobId = task.jobId;
         this.taskId = task.taskId;
         this.travelTimeValues = result.travelTimes == null ? null : result.travelTimes.values;
-        this.accessibilityValues = result.accessibility == null ? null : result.density.fakeDualAccess(task);
+        if (result.accessibility == null) {
+            this.accessibilityValues = null;
+        } else if (task.flags.contains("gridDualAccess")) {
+            this.accessibilityValues = result.density.fakeDualAccess(task);
+        } else {
+            this.accessibilityValues = result.accessibility.getIntValues();
+        }
         this.pathResult = result.paths == null ? null : result.paths.summarizeIterations(PathResult.Stat.MINIMUM);
         this.opportunitiesPerMinute = result.density == null ? null : result.density.opportunitiesPerMinute;
         // TODO checkTravelTimeInvariants, checkAccessibilityInvariants to verify that values are monotonically increasing


### PR DESCRIPTION
This is a temporary experimental feature, (ab)using existing features in the UI and backend so that dual access results for grid origins can be obtained without any changes to those other components of our system.

~~To activate via the UI, add `flags: {"gridDualAccess"}` to the analysis request JSON~~. With https://github.com/conveyal/r5/pull/935/commits/10a51a836004af3a6d12a87b471c770d98424adb, regional analyses are hard-coded to produce dual access results. When configuring the regional analysis, enter the desired dual access thresholds in the cutoffs field. Also enter 120 as the maximum cutoff. If you add `dualAccessibilityThreshold` to the analysis request JSON, it will be used in place of 120.

For example, if you select hospitals, grocery stores, and jobs as destination layers; 5, 10, and 120 as cutoffs; and 10000 as `dualAccessibilityThreshold`, from the regional results page you will be able to view and download grids showing the travel time required to reach 5 hospitals, 10 grocery stores, and 10k jobs (as well as the other combinations). For now though, the UI selector on the regional analysis result page will be misleadingly labeled (with the "minutes" unit, and with 120 instead of 10000 as the third value).

Thresholds of 1 or 3 might be common, but the UI currently imposes a minimum of 5 minutes.