### PR TITLE
Add flag to crop regional analysis destinations to origin extents

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/cluster/RegionalTask.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/RegionalTask.java
@@ -74,8 +74,11 @@ public class RegionalTask extends AnalysisWorkerTask implements Cloneable {
      */
     @Override
     public WebMercatorExtents getWebMercatorExtents() {
-        return WebMercatorExtents.forTask(this);
-        // TODO Use previous conditional logic with custom flag (request.flags.CROP_DESTINATIONS)
+        if (makeTauiSite || this.hasFlag("CROP_DESTINATIONS")) {
+            return WebMercatorExtents.forTask(this);
+        } else {
+            return WebMercatorExtents.forPointsets(this.destinationPointSets);
+        }
     }
 
     /**
@@ -107,6 +110,10 @@ public class RegionalTask extends AnalysisWorkerTask implements Cloneable {
         } else {
             return destinationPointSets[0].featureCount();
         }
+    }
+
+    public boolean hasFlag (String flag) {
+        return this.flags != null && this.flags.contains(flag);
     }
 
 }

--- a/src/main/java/com/conveyal/r5/analyst/cluster/RegionalTask.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/RegionalTask.java
@@ -74,11 +74,8 @@ public class RegionalTask extends AnalysisWorkerTask implements Cloneable {
      */
     @Override
     public WebMercatorExtents getWebMercatorExtents() {
-        if (makeTauiSite) {
-            return WebMercatorExtents.forTask(this);
-        } else {
-            return WebMercatorExtents.forPointsets(this.destinationPointSets);
-        }
+        return WebMercatorExtents.forTask(this);
+        // TODO Use previous conditional logic with custom flag (request.flags.CROP_DESTINATIONS)
     }
 
     /**


### PR DESCRIPTION
This PR adds a `flag` (`CROP_DESTINATIONS`) to crop destination grids to the web mercator extents used for origins. This setting can be useful for reducing computation, especially for auto analyses in large regions.