### PR TITLE
Store and retrieve user-specified network config, addresses #644

### DIFF
--- a/src/main/java/com/conveyal/analysis/controllers/BundleController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/BundleController.java
@@ -21,7 +21,6 @@ import com.conveyal.osmlib.OSM;
 import com.conveyal.r5.analyst.progress.ProgressInputStream;
 import com.conveyal.r5.analyst.cluster.TransportNetworkConfig;
 import com.conveyal.r5.analyst.progress.Task;
-import com.conveyal.r5.common.JsonUtilities;
 import com.conveyal.r5.streets.OSMCache;
 import com.conveyal.r5.util.ExceptionUtils;
 import com.mongodb.QueryBuilder;
@@ -137,9 +136,8 @@ public class BundleController implements HttpController {
             if (files.get("config") != null) {
                 // For validation, rather than reading as freeform JSON, deserialize into a model class instance.
                 // However, only the instance fields specifying things other than OSM and GTFS IDs will be retained.
-                // Use strict object mapper (from the strict/lenient pair) to fail on misspelled field names.
                 String configString = files.get("config").get(0).getString();
-                bundle.config = JsonUtilities.objectMapper.readValue(configString, TransportNetworkConfig.class);
+                bundle.config = JsonUtil.objectMapper.readValue(configString, TransportNetworkConfig.class);
             }
             UserPermissions userPermissions = UserPermissions.from(req);
             bundle.accessGroup = userPermissions.accessGroup;

--- a/src/main/java/com/conveyal/analysis/controllers/BundleController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/BundleController.java
@@ -21,6 +21,7 @@ import com.conveyal.osmlib.OSM;
 import com.conveyal.r5.analyst.progress.ProgressInputStream;
 import com.conveyal.r5.analyst.cluster.TransportNetworkConfig;
 import com.conveyal.r5.analyst.progress.Task;
+import com.conveyal.r5.common.JsonUtilities;
 import com.conveyal.r5.streets.OSMCache;
 import com.conveyal.r5.util.ExceptionUtils;
 import com.mongodb.QueryBuilder;
@@ -136,8 +137,9 @@ public class BundleController implements HttpController {
             if (files.get("config") != null) {
                 // For validation, rather than reading as freeform JSON, deserialize into a model class instance.
                 // However, only the instance fields specifying things other than OSM and GTFS IDs will be retained.
+                // Use strict object mapper (from the strict/lenient pair) to fail on misspelled field names.
                 String configString = files.get("config").get(0).getString();
-                bundle.config = JsonUtil.objectMapper.readValue(configString, TransportNetworkConfig.class);
+                bundle.config = JsonUtilities.objectMapper.readValue(configString, TransportNetworkConfig.class);
             }
             UserPermissions userPermissions = UserPermissions.from(req);
             bundle.accessGroup = userPermissions.accessGroup;

--- a/src/main/java/com/conveyal/analysis/controllers/BundleController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/BundleController.java
@@ -134,8 +134,9 @@ public class BundleController implements HttpController {
                 bundle.totalFeeds = bundleWithFeed.totalFeeds;
             }
             if (files.get("config") != null) {
-                // For validation, rather than reading as freeform JSON, deserialize into a model class instance.
-                // However, only the instance fields specifying things other than OSM and GTFS IDs will be retained.
+                // Validation by deserializing into a model class instance. Unknown fields are ignored to
+                // allow sending config to custom or experimental workers with features unknown to the backend.
+                // The fields specifying OSM and GTFS IDs are not expected here. They will be ignored and overwritten.
                 String configString = files.get("config").get(0).getString();
                 bundle.config = JsonUtil.objectMapper.readValue(configString, TransportNetworkConfig.class);
             }

--- a/src/main/java/com/conveyal/analysis/models/Bundle.java
+++ b/src/main/java/com/conveyal/analysis/models/Bundle.java
@@ -5,6 +5,7 @@ import com.conveyal.gtfs.GTFSFeed;
 import com.conveyal.gtfs.error.GTFSError;
 import com.conveyal.gtfs.model.FeedInfo;
 import com.conveyal.gtfs.validator.model.Priority;
+import com.conveyal.r5.analyst.cluster.TransportNetworkConfig;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.time.LocalDate;
@@ -46,6 +47,11 @@ public class Bundle extends Model implements Cloneable {
 
     public int feedsComplete;
     public int totalFeeds;
+
+    // The definitive TransportNetworkConfig is a JSON file stored alonside the feeds in file storage. It is
+    // duplicated here to record any additional user-specified options that were supplied when the bundle was created.
+    // It may contain redundant copies of information stored in the outer level Bundle such as OSM and GTFS feed IDs.
+    public TransportNetworkConfig config;
 
     public static String bundleScopeFeedId (String feedId, String feedGroupId) {
         return String.format("%s_%s", feedId, feedGroupId);

--- a/src/main/java/com/conveyal/analysis/models/Bundle.java
+++ b/src/main/java/com/conveyal/analysis/models/Bundle.java
@@ -48,7 +48,7 @@ public class Bundle extends Model implements Cloneable {
     public int feedsComplete;
     public int totalFeeds;
 
-    // The definitive TransportNetworkConfig is a JSON file stored alonside the feeds in file storage. It is
+    // The definitive TransportNetworkConfig is a JSON file stored alongside the feeds in file storage. It is
     // duplicated here to record any additional user-specified options that were supplied when the bundle was created.
     // It may contain redundant copies of information stored in the outer level Bundle such as OSM and GTFS feed IDs.
     public TransportNetworkConfig config;

--- a/src/main/java/com/conveyal/r5/transit/TransportNetworkCache.java
+++ b/src/main/java/com/conveyal/r5/transit/TransportNetworkCache.java
@@ -168,6 +168,8 @@ public class TransportNetworkCache implements Component {
         File configFile = fileStorage.getFile(configFileKey);
         try {
             // Use lenient mapper to mimic behavior in objectFromRequestBody.
+            // A single network configuration file might be used across several worker versions. Unknown field names
+            // may be present for other worker versions unknown to this one. So we can't strictly validate field names.
             return JsonUtilities.lenientObjectMapper.readValue(configFile, TransportNetworkConfig.class);
         } catch (IOException e) {
             throw new RuntimeException("Error reading TransportNetworkConfig. Does it contain new unrecognized fields?", e);


### PR DESCRIPTION
This is a draft implementation of the server side of the functionality described in #644, as a basis for discussion on integration with the UI.

At bundle creation, the POST request body can now include a "config" item containing JSON that is deserialized to a `com.conveyal.r5.analyst.cluster.TransportNetworkConfig`. This deserialization step provides some free validation and fail-fast behavior if the user makes mistakes in crafting the network configuration. For backward compatibility, the OSM and GTFS ID fields of that `TransportNetworkConfig` object are ignored and overwritten with the ones specified in the enclosing POST form's other fields.

The completed network config is then included in the database entry for the bundle, as well as the JSON file in file storage that is visible to the workers. That file is considered the definitive source of truth for the network config, as it has been around a lot longer and is present for all bundles created in the past.

The contents of that definitive config file are visible at a new endpoint at `/api/bundle/[id]/config`. But for any newly created bundles, the API response is expected to be identical to the config field of the bundle object in the database.

This has been tested using CURL for a simple case specifying `"buildGridsForModes":["BICYCLE"]`. Configuration was retained in the database and JSON file, and was available via both the database and single-purpose API endpoints.