### PR TITLE
Update to latest mongodb legacy java driver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -164,7 +164,7 @@ dependencies {
     }
 
     // Database driver.
-    implementation 'org.mongodb:mongo-java-driver:3.11.0'
+    implementation 'org.mongodb:mongodb-driver-legacy:5.2.0'
 
     // Legacy system for storing Java objects, this functionality is now provided by the MongoDB driver itself.
     implementation 'org.mongojack:mongojack:2.10.1'


### PR DESCRIPTION
This is the newest driver, but with an older ("legacy") programming API that matches our code. It should be a drop-in replacement, and our Mongojack dependency also seems to cooperate with this as its transitive mongodb driver dependency.