### PR TITLE
Add custom walking traversal permissions via TransportNetworkConfig

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/cluster/TransportNetworkConfig.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/TransportNetworkConfig.java
@@ -2,12 +2,8 @@ package com.conveyal.r5.analyst.cluster;
 
 import com.conveyal.r5.analyst.fare.InRoutingFareCalculator;
 import com.conveyal.r5.analyst.scenario.Modification;
-import com.conveyal.r5.analyst.scenario.RasterCost;
-import com.conveyal.r5.analyst.scenario.ShapefileLts;
 import com.conveyal.r5.profile.StreetMode;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import java.util.List;
 import java.util.Set;

--- a/src/main/java/com/conveyal/r5/analyst/cluster/TransportNetworkConfig.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/TransportNetworkConfig.java
@@ -54,4 +54,11 @@ public class TransportNetworkConfig {
      */
     public Set<StreetMode> buildGridsForModes;
 
+    /**
+     * Specifies which "labeler" to use when setting traversal mode permissions from OSM tags. For now, only
+     * implemented with "sidewalk" to use the SidewalkTraversalPermissionLayer. This should eventually be cleaned up
+     * (specifying different labelers, using enums).
+     */
+    public String traversalPermissionLabeler;
+
 }

--- a/src/main/java/com/conveyal/r5/kryo/KryoNetworkSerializer.java
+++ b/src/main/java/com/conveyal/r5/kryo/KryoNetworkSerializer.java
@@ -53,7 +53,7 @@ public abstract class KryoNetworkSerializer {
      * When prototyping new features, use a unique identifier such as the branch or a commit ID, not sequential nvX ones.
      * This avoids conflicts when multiple changes are combined in a single production release, or some are abandoned.
      */
-    public static final String NETWORK_FORMAT_VERSION = "nv3";
+    public static final String NETWORK_FORMAT_VERSION = "1fe1c83e";
 
     public static final byte[] HEADER = "R5NETWORK".getBytes();
 

--- a/src/main/java/com/conveyal/r5/kryo/KryoNetworkSerializer.java
+++ b/src/main/java/com/conveyal/r5/kryo/KryoNetworkSerializer.java
@@ -53,7 +53,7 @@ public abstract class KryoNetworkSerializer {
      * When prototyping new features, use a unique identifier such as the branch or a commit ID, not sequential nvX ones.
      * This avoids conflicts when multiple changes are combined in a single production release, or some are abandoned.
      */
-    public static final String NETWORK_FORMAT_VERSION = "1fe1c83e";
+    public static final String NETWORK_FORMAT_VERSION = "nv3";
 
     public static final byte[] HEADER = "R5NETWORK".getBytes();
 

--- a/src/main/java/com/conveyal/r5/labeling/SidewalkTraversalPermissionLabeler.java
+++ b/src/main/java/com/conveyal/r5/labeling/SidewalkTraversalPermissionLabeler.java
@@ -1,5 +1,7 @@
 package com.conveyal.r5.labeling;
 
+import com.conveyal.osmlib.Way;
+import com.conveyal.r5.streets.EdgeStore;
 
 /**
  * Traversal permission labeler that restricts walking on most driving ways (useful for networks with complete
@@ -11,8 +13,23 @@ public class SidewalkTraversalPermissionLabeler extends TraversalPermissionLabel
         addPermissions("bridleway", "bicycle=yes;foot=yes"); //horse=yes but we don't support horse
         addPermissions("cycleway", "bicycle=yes;foot=yes");
         addPermissions("trunk|primary|secondary|tertiary|unclassified|residential|living_street|road|service|track",
-                "access=yes;foot=no"); // Note foot=no
+                "access=yes");
+    }
 
+    @Override
+    public RoadPermission getPermissions(Way way) {
+        RoadPermission rp = super.getPermissions(way);
+        if (rp.forward.contains(EdgeStore.EdgeFlag.ALLOWS_CAR) ||
+            rp.forward.contains(EdgeStore.EdgeFlag.NO_THRU_TRAFFIC_CAR) ||
+            rp.backward.contains(EdgeStore.EdgeFlag.ALLOWS_CAR) ||
+            rp.backward.contains(EdgeStore.EdgeFlag.NO_THRU_TRAFFIC_CAR)
+        ) {
+            rp.forward.remove(EdgeStore.EdgeFlag.ALLOWS_PEDESTRIAN);
+            rp.forward.remove(EdgeStore.EdgeFlag.NO_THRU_TRAFFIC_PEDESTRIAN);
+            rp.backward.remove(EdgeStore.EdgeFlag.ALLOWS_PEDESTRIAN);
+            rp.backward.remove(EdgeStore.EdgeFlag.NO_THRU_TRAFFIC_PEDESTRIAN);
+        }
+        return rp;
     }
 
 }

--- a/src/main/java/com/conveyal/r5/labeling/SidewalkTraversalPermissionLabeler.java
+++ b/src/main/java/com/conveyal/r5/labeling/SidewalkTraversalPermissionLabeler.java
@@ -1,0 +1,18 @@
+package com.conveyal.r5.labeling;
+
+
+/**
+ * Traversal permission labeler that restricts walking on most driving ways (useful for networks with complete
+ * sidewalks). Also includes permissions for the United States (see USTraversalPermissionLabeler).
+ */
+public class SidewalkTraversalPermissionLabeler extends TraversalPermissionLabeler {
+    static {
+        addPermissions("pedestrian", "bicycle=yes");
+        addPermissions("bridleway", "bicycle=yes;foot=yes"); //horse=yes but we don't support horse
+        addPermissions("cycleway", "bicycle=yes;foot=yes");
+        addPermissions("trunk|primary|secondary|tertiary|unclassified|residential|living_street|road|service|track",
+                "access=yes;foot=no"); // Note foot=no
+
+    }
+
+}

--- a/src/main/java/com/conveyal/r5/streets/StreetLayer.java
+++ b/src/main/java/com/conveyal/r5/streets/StreetLayer.java
@@ -6,12 +6,14 @@ import com.conveyal.osmlib.OSM;
 import com.conveyal.osmlib.OSMEntity;
 import com.conveyal.osmlib.Relation;
 import com.conveyal.osmlib.Way;
+import com.conveyal.r5.analyst.cluster.TransportNetworkConfig;
 import com.conveyal.r5.analyst.scenario.PickupWaitTimes;
 import com.conveyal.r5.api.util.BikeRentalStation;
 import com.conveyal.r5.api.util.ParkRideParking;
 import com.conveyal.r5.common.GeometryUtils;
 import com.conveyal.r5.labeling.LevelOfTrafficStressLabeler;
 import com.conveyal.r5.labeling.RoadPermission;
+import com.conveyal.r5.labeling.SidewalkTraversalPermissionLabeler;
 import com.conveyal.r5.labeling.SpeedLabeler;
 import com.conveyal.r5.labeling.StreetClass;
 import com.conveyal.r5.labeling.TraversalPermissionLabeler;
@@ -132,8 +134,8 @@ public class StreetLayer implements Serializable, Cloneable {
     public TIntObjectMap<ParkRideParking> parkRideLocationsMap;
 
     // TODO these are only needed when building the network, should we really be keeping them here in the layer?
-    //      We should instead have a network builder that holds references to this transient state.
-    // TODO don't hardwire to US
+    //      We should instead have a network builder that holds references to this transient state. Note initial
+    //      approach of specifying a TraversalPermissionLabeler in TransportNetworkConfig.
     private transient TraversalPermissionLabeler permissionLabeler = new USTraversalPermissionLabeler();
     private transient LevelOfTrafficStressLabeler stressLabeler = new LevelOfTrafficStressLabeler();
     private transient TypeOfEdgeLabeler typeOfEdgeLabeler = new TypeOfEdgeLabeler();
@@ -207,6 +209,16 @@ public class StreetLayer implements Serializable, Cloneable {
 
     public StreetLayer() {
         speedLabeler = new SpeedLabeler(SpeedConfig.defaultConfig());
+    }
+
+    public StreetLayer(TransportNetworkConfig config) {
+        this();
+        if (config != null && config.traversalPermissionLabeler != null) {
+            // TODO cleaner mapping
+            if ("sidewalk".equals(config.traversalPermissionLabeler)) {
+                permissionLabeler = new SidewalkTraversalPermissionLabeler();
+            }
+        }
     }
 
     /** Load street layer from an OSM-lib OSM DB */

--- a/src/main/java/com/conveyal/r5/streets/StreetLayer.java
+++ b/src/main/java/com/conveyal/r5/streets/StreetLayer.java
@@ -213,11 +213,11 @@ public class StreetLayer implements Serializable, Cloneable {
 
     public StreetLayer(TransportNetworkConfig config) {
         this();
-        if (config != null && config.traversalPermissionLabeler != null) {
-            // TODO cleaner mapping
-            if ("sidewalk".equals(config.traversalPermissionLabeler)) {
+        if (config != null) {
+            // FIXME hack to force use of SIdewalkTraversalPermissionLabeler in cluster use
+            // if ("sidewalk".equals(config.traversalPermissionLabeler)) {
                 permissionLabeler = new SidewalkTraversalPermissionLabeler();
-            }
+            // }
         }
     }
 

--- a/src/main/java/com/conveyal/r5/streets/StreetLayer.java
+++ b/src/main/java/com/conveyal/r5/streets/StreetLayer.java
@@ -136,7 +136,7 @@ public class StreetLayer implements Serializable, Cloneable {
     // TODO these are only needed when building the network, should we really be keeping them here in the layer?
     //      We should instead have a network builder that holds references to this transient state. Note initial
     //      approach of specifying a TraversalPermissionLabeler in TransportNetworkConfig.
-    private transient TraversalPermissionLabeler permissionLabeler = new USTraversalPermissionLabeler();
+    private transient TraversalPermissionLabeler permissionLabeler;
     private transient LevelOfTrafficStressLabeler stressLabeler = new LevelOfTrafficStressLabeler();
     private transient TypeOfEdgeLabeler typeOfEdgeLabeler = new TypeOfEdgeLabeler();
     private transient SpeedLabeler speedLabeler;
@@ -209,15 +209,21 @@ public class StreetLayer implements Serializable, Cloneable {
 
     public StreetLayer() {
         speedLabeler = new SpeedLabeler(SpeedConfig.defaultConfig());
+        permissionLabeler = new USTraversalPermissionLabeler();
     }
 
     public StreetLayer(TransportNetworkConfig config) {
         this();
-        if (config != null && config.traversalPermissionLabeler != null) {
-            // TODO cleaner mapping
-            if ("sidewalk".equals(config.traversalPermissionLabeler)) {
-                permissionLabeler = new SidewalkTraversalPermissionLabeler();
-            }
+        if (config != null) {
+            permissionLabeler = switch (config.traversalPermissionLabeler) {
+                case "sidewalk" -> new SidewalkTraversalPermissionLabeler();
+                case null -> new USTraversalPermissionLabeler();
+                default -> throw new IllegalArgumentException(
+                        "Unknown traversal permission labeler: " + config.traversalPermissionLabeler
+                );
+            };
+        } else {
+            permissionLabeler = new USTraversalPermissionLabeler();
         }
     }
 

--- a/src/main/java/com/conveyal/r5/streets/StreetLayer.java
+++ b/src/main/java/com/conveyal/r5/streets/StreetLayer.java
@@ -213,11 +213,11 @@ public class StreetLayer implements Serializable, Cloneable {
 
     public StreetLayer(TransportNetworkConfig config) {
         this();
-        if (config != null) {
-            // FIXME hack to force use of SIdewalkTraversalPermissionLabeler in cluster use
-            // if ("sidewalk".equals(config.traversalPermissionLabeler)) {
+        if (config != null && config.traversalPermissionLabeler != null) {
+            // TODO cleaner mapping
+            if ("sidewalk".equals(config.traversalPermissionLabeler)) {
                 permissionLabeler = new SidewalkTraversalPermissionLabeler();
-            // }
+            }
         }
     }
 

--- a/src/main/java/com/conveyal/r5/transit/TransportNetworkCache.java
+++ b/src/main/java/com/conveyal/r5/transit/TransportNetworkCache.java
@@ -25,17 +25,12 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
 
 import static com.conveyal.file.FileCategory.BUNDLES;
 import static com.conveyal.file.FileCategory.DATASOURCES;

--- a/src/main/java/com/conveyal/r5/transit/TransportNetworkCache.java
+++ b/src/main/java/com/conveyal/r5/transit/TransportNetworkCache.java
@@ -183,9 +183,8 @@ public class TransportNetworkCache implements Component {
         TransportNetworkConfig networkConfig = loadNetworkConfig(networkId);
         if (networkConfig == null) {
             // The switch to use JSON manifests instead of zips occurred in 32a1aebe in July 2016.
-            // Over six years have passed, buildNetworkFromBundleZip is deprecated and could probably be removed.
-            LOG.warn("No network config (aka manifest) found. Assuming old-format network inputs bundle stored as a single ZIP file.");
-            network = buildNetworkFromBundleZip(networkId);
+            // buildNetworkFromBundleZip was deprecated for years then removed in 2024.
+            throw new RuntimeException("No network config (aka manifest) found.");
         } else {
             network = buildNetworkFromConfig(networkConfig);
         }
@@ -218,66 +217,14 @@ public class TransportNetworkCache implements Component {
         return network;
     }
 
-    /** Build a transport network given a network ID, using a zip of all bundle files in S3. */
-    @Deprecated
-    private TransportNetwork buildNetworkFromBundleZip (String networkId) {
-        // The location of the inputs that will be used to build this graph
-        File dataDirectory = FileUtils.createScratchDirectory();
-        FileStorageKey zipKey = new FileStorageKey(BUNDLES, networkId + ".zip");
-        File zipFile = fileStorage.getFile(zipKey);
-
-        try {
-            ZipInputStream zis = new ZipInputStream(new FileInputStream(zipFile));
-            ZipEntry entry;
-            while ((entry = zis.getNextEntry()) != null) {
-                File entryDestination = new File(dataDirectory, entry.getName());
-                if (!entryDestination.toPath().normalize().startsWith(dataDirectory.toPath())) {
-                    throw new Exception("Bad zip entry");
-                }
-
-                // Are both these mkdirs calls necessary?
-                entryDestination.getParentFile().mkdirs();
-                if (entry.isDirectory())
-                    entryDestination.mkdirs();
-                else {
-                    OutputStream entryFileOut = new FileOutputStream(entryDestination);
-                    zis.transferTo(entryFileOut);
-                    entryFileOut.close();
-                }
-            }
-            zis.close();
-        } catch (Exception e) {
-            // TODO delete cache dir which is probably corrupted.
-            LOG.warn("Error retrieving transportation network input files", e);
-            return null;
-        }
-
-        // Now we have a local copy of these graph inputs. Make a graph out of them.
-        TransportNetwork network;
-        try {
-            network = TransportNetwork.fromDirectory(dataDirectory);
-        } catch (DuplicateFeedException e) {
-            LOG.error("Duplicate feeds in transport network {}", networkId, e);
-            throw new RuntimeException(e);
-        }
-
-        // Set the ID on the network and its layers to allow caching linkages and analysis results.
-        network.scenarioId = networkId;
-
-        return network;
-    }
-
     /**
      * Build a network from a JSON TransportNetworkConfig in file storage.
      * This describes the locations of files used to create a bundle, as well as options applied at network build time.
      * It contains the unique IDs of the GTFS feeds and OSM extract.
      */
     private TransportNetwork buildNetworkFromConfig (TransportNetworkConfig config) {
-        // FIXME duplicate code. All internal building logic should be encapsulated in a method like
-        //  TransportNetwork.build(osm, gtfs1, gtfs2...)
-        // We currently have multiple copies of it, in buildNetworkFromConfig and buildNetworkFromBundleZip so you've
-        // got to remember to do certain things like set the network ID of the network in multiple places in the code.
-        // Maybe we should just completely deprecate bundle ZIPs and remove those code paths.
+        // FIXME All internal building logic should be encapsulated in a method like TransportNetwork.build(osm,
+        //  gtfs1, gtfs2...) (see various methods in TransportNetwork).
 
         TransportNetwork network = new TransportNetwork();
 

--- a/src/main/java/com/conveyal/r5/transit/TransportNetworkCache.java
+++ b/src/main/java/com/conveyal/r5/transit/TransportNetworkCache.java
@@ -281,7 +281,8 @@ public class TransportNetworkCache implements Component {
 
         TransportNetwork network = new TransportNetwork();
 
-        network.streetLayer = new StreetLayer();
+        network.streetLayer = new StreetLayer(config);
+
         network.streetLayer.loadFromOsm(osmCache.get(config.osmId));
 
         network.streetLayer.parentNetwork = network;


### PR DESCRIPTION
Users want the ability to configure different traversal permission labeling approaches (e.g., disallowing walking on any links that allow driving, under the assumption complete and separate sidewalk networks are available, see https://github.com/conveyal/r5/issues/643) 

This PR should be considered together with #941. Together with those changes, this PR allows users to build networks using a new experimental `SidewalkTraversalPermissionLabeler` with stricter walking permissions that are likely to be appropriate as more complete sidewalk networks become available.

Based on discussions in a work session a couple months ago, this PR removes the `buildNetworkFromBundleZip` method that has been unsupported since 2016.

This PR partly addresses https://github.com/conveyal/r5/issues/751 by passing `TransportNetworkConfig` values in `PointToPointRouterServer` use. The remaining piece of that r5r-related issue is allowing users to specify whether to save detailed GTFS shapes (which will be useful for us in publishing Taui sites, see #644)

