### PR TITLE
Do not tolerate exceptions while storing the serialized network

### DIFF
--- a/src/main/java/com/conveyal/r5/transit/TransportNetworkCache.java
+++ b/src/main/java/com/conveyal/r5/transit/TransportNetworkCache.java
@@ -198,7 +198,7 @@ public class TransportNetworkCache implements Component {
      * If we did not find a cached network, build one from the input files. Should throw an exception rather than
      * returning null if for any reason it can't finish building one.
      */
-    private @Nonnull TransportNetwork buildNetwork (String networkId) {
+    private @Nonnull TransportNetwork buildNetwork(String networkId) throws IOException {
         TransportNetwork network;
         TransportNetworkConfig networkConfig = loadNetworkConfig(networkId);
         if (networkConfig == null) {
@@ -226,14 +226,10 @@ public class TransportNetworkCache implements Component {
         network.rebuildLinkedGridPointSet(buildGridsForModes);
 
         // Cache the serialized network on the local filesystem and mirror it to any remote storage.
-        try {
-            File cacheLocation = FileUtils.createScratchFile();
-            KryoNetworkSerializer.write(network, cacheLocation);
-            fileStorage.moveIntoStorage(getR5NetworkFileStorageKey(networkId), cacheLocation);
-        } catch (Exception e) {
-            // Tolerate exceptions here as we do have a network to return, we just failed to cache it.
-            LOG.error("Error saving cached network, returning the object anyway.", e);
-        }
+        File cacheLocation = FileUtils.createScratchFile();
+        KryoNetworkSerializer.write(network, cacheLocation);
+        fileStorage.moveIntoStorage(getR5NetworkFileStorageKey(networkId), cacheLocation);
+
         return network;
     }
 


### PR DESCRIPTION
`fileStorage.moveIntoStorage()` failed recently and the reason for failure was hidden until we logged into the server and checked the logs.

This PR removes the try/catch block in order to allow exceptions here to bubble up to the user during network building and saving. 

