### PR TITLE
Set Status.PRESENT after synchronous preload

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/NetworkPreloader.java
+++ b/src/main/java/com/conveyal/r5/analyst/NetworkPreloader.java
@@ -97,7 +97,10 @@ public class NetworkPreloader extends AsyncLoader<NetworkPreloader.Key, Transpor
      * data is prepared. 
      */
     public TransportNetwork synchronousPreload (AnalysisWorkerTask task) {
-        return buildValue(Key.forTask(task));
+        Key key = Key.forTask(task);
+        TransportNetwork scenarioNetwork = buildValue(key);
+        setComplete(key, scenarioNetwork);
+        return scenarioNetwork;
     }
 
     @Override
@@ -140,7 +143,7 @@ public class NetworkPreloader extends AsyncLoader<NetworkPreloader.Key, Transpor
                 linkedPointSet.getEgressCostTable(progressListener);
             }
         }
-        // Finished building all needed inputs for analysis, return the completed network to the AsyncLoader code.
+        // Finished building all needed inputs for analysis, return the completed network
         return scenarioNetwork;
     }
 

--- a/src/main/java/com/conveyal/r5/analyst/NetworkPreloader.java
+++ b/src/main/java/com/conveyal/r5/analyst/NetworkPreloader.java
@@ -79,7 +79,7 @@ public class NetworkPreloader extends AsyncLoader<NetworkPreloader.Key, Transpor
         this.transportNetworkCache = transportNetworkCache;
     }
 
-    public LoaderState<TransportNetwork> preloadData (AnalysisWorkerTask task) {
+    public LoaderState<TransportNetwork> preload (AnalysisWorkerTask task) {
         if (task.scenario != null) {
             transportNetworkCache.rememberScenario(task.scenario);
         }
@@ -96,11 +96,8 @@ public class NetworkPreloader extends AsyncLoader<NetworkPreloader.Key, Transpor
      * This is provided specifically for regional tasks, to ensure that they remain in preloading mode while all this
      * data is prepared. 
      */
-    public TransportNetwork synchronousPreload (AnalysisWorkerTask task) {
-        Key key = Key.forTask(task);
-        TransportNetwork scenarioNetwork = buildValue(key);
-        setComplete(key, scenarioNetwork);
-        return scenarioNetwork;
+    public TransportNetwork preloadBlocking (AnalysisWorkerTask task) {
+        return getBlocking(Key.forTask(task));
     }
 
     @Override

--- a/src/main/java/com/conveyal/r5/analyst/NetworkPreloader.java
+++ b/src/main/java/com/conveyal/r5/analyst/NetworkPreloader.java
@@ -94,7 +94,8 @@ public class NetworkPreloader extends AsyncLoader<NetworkPreloader.Key, Transpor
      * similar tasks will make interleaved calls to setProgress (with superficial map synchronization). Other than
      * causing a value to briefly revert from PRESENT to BUILDING this doesn't seem deeply problematic.
      * This is provided specifically for regional tasks, to ensure that they remain in preloading mode while all this
-     * data is prepared. 
+     * data is prepared.
+     * Any exceptions that occur while building the network will escape this method, leaving the status as BUILDING.
      */
     public TransportNetwork preloadBlocking (AnalysisWorkerTask task) {
         return getBlocking(Key.forTask(task));

--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalysisWorker.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalysisWorker.java
@@ -314,7 +314,7 @@ public class AnalysisWorker implements Component {
     protected byte[] handleAndSerializeOneSinglePointTask (TravelTimeSurfaceTask task) throws IOException {
         LOG.debug("Handling single-point task {}", task.toString());
         // Get all the data needed to run one analysis task, or at least begin preparing it.
-        final AsyncLoader.LoaderState<TransportNetwork> networkLoaderState = networkPreloader.preloadData(task);
+        final AsyncLoader.LoaderState<TransportNetwork> networkLoaderState = networkPreloader.preload(task);
 
         // If loading is not complete, bail out of this function.
         // Ideally we'd stall briefly using something like Future.get(timeout) in case loading finishes quickly.
@@ -462,7 +462,7 @@ public class AnalysisWorker implements Component {
         // Note we're completely bypassing the async loader here and relying on the older nested LoadingCaches.
         // If those are ever removed, the async loader will need a synchronous mode with per-path blocking (kind of
         // reinventing the wheel of LoadingCache) or we'll need to make preparation for regional tasks async.
-        TransportNetwork transportNetwork = networkPreloader.synchronousPreload(task);
+        TransportNetwork transportNetwork = networkPreloader.preloadBlocking(task);
 
         // If we are generating a static site, there must be a single metadata file for an entire batch of results.
         // Arbitrarily we create this metadata as part of the first task in the job.

--- a/src/main/java/com/conveyal/r5/util/AsyncLoader.java
+++ b/src/main/java/com/conveyal/r5/util/AsyncLoader.java
@@ -97,7 +97,10 @@ public abstract class AsyncLoader<K,V> {
         }
     }
 
-    /** This has been factored out of the executor runnables so subclasses can force a blocking (non-async) load. */
+    /**
+     * This has been factored out of the executor runnables so subclasses can force a blocking (non-async) load.
+     * Any exceptions that occur while building the value will escape this method, leaving the status as BUILDING.
+     */
     protected V getBlocking (K key) {
         setProgress(key, 0, "Starting...");
         V value = buildValue(key);
@@ -111,6 +114,7 @@ public abstract class AsyncLoader<K,V> {
      * Attempt to fetch the value for the supplied key.
      * If the value is not yet present, and not yet being computed / fetched, enqueue a task to do so.
      * Return a response that reports status, and may or may not contain the value.
+     * Any exception that occurs while building the value is caught and associated with the key with a status of ERROR.
      */
     public LoaderState<V> get (K key) {
         LoaderState<V> state = null;

--- a/src/main/java/com/conveyal/r5/util/AsyncLoader.java
+++ b/src/main/java/com/conveyal/r5/util/AsyncLoader.java
@@ -102,7 +102,6 @@ public abstract class AsyncLoader<K,V> {
      * Any exceptions that occur while building the value will escape this method, leaving the status as BUILDING.
      */
     protected V getBlocking (K key) {
-        setProgress(key, 0, "Starting...");
         V value = buildValue(key);
         synchronized (map) {
             map.put(key, new LoaderState(Status.PRESENT, "Loaded", 100, value));
@@ -135,6 +134,7 @@ public abstract class AsyncLoader<K,V> {
         if (enqueueLoadTask) {
             executor.execute(() -> {
                 try {
+                    setProgress(key, 0, "Starting...");
                     getBlocking(key);
                 } catch (Throwable t) {
                     // It's essential to trap Throwable rather than just Exception. Otherwise the executor


### PR DESCRIPTION
This PR fixes #949, a longstanding issue (possibly since #746).

We have two pathways for loading transport network data on a worker: `preloadData` (asynchronously, for single-point tasks) and `synchronousPreload` (for regional tasks). Once data are loaded in an AsyncLoader, they should be marked with `Status.PRESENT`. The async pathway was doing this correctly. But once a worker switched to a regional task, it would switch the status to `LOADING` and never switch it back to `PRESENT`.

This PR factors out a `setComplete` method and calls it in both pathways.
