### PR TITLE
Refactor: Remove deprecated / unused regional analysis fields

### DIFF
--- a/src/main/java/com/conveyal/analysis/controllers/RegionalAnalysisController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/RegionalAnalysisController.java
@@ -377,7 +377,7 @@ public class RegionalAnalysisController implements HttpController {
         RegionalAnalysis analysis = getAnalysis(regionalAnalysisId, userPermissions);
 
         // If a query parameter is supplied, range check it, otherwise use the middle value in the list.
-        int threshold = 0;
+        int threshold;
         if (analysis.request.includeTemporalDensity) {
             int nThresholds = analysis.request.dualAccessThresholds.length;
             int[] thresholds = analysis.request.dualAccessThresholds;
@@ -387,9 +387,10 @@ public class RegionalAnalysisController implements HttpController {
                     "Dual access thresholds for this regional analysis must be taken from this list: (%s)",
                     Ints.join(", ", thresholds)
             );
-        } else if (analysis.cutoffsMinutes != null) {
+        } else {
             // Handle newer regional analyses with multiple cutoffs in an array.
             // The cutoff variable holds the actual cutoff in minutes, not the position in the array of cutoffs.
+            checkState(analysis.cutoffsMinutes != null, "Regional analysis has no cutoffs.");
             int nCutoffs = analysis.cutoffsMinutes.length;
             checkState(nCutoffs > 0, "Regional analysis has no cutoffs.");
             threshold = getIntQueryParameter(req, "threshold", analysis.cutoffsMinutes[nCutoffs / 2]);

--- a/src/main/java/com/conveyal/analysis/models/RegionalAnalysis.java
+++ b/src/main/java/com/conveyal/analysis/models/RegionalAnalysis.java
@@ -18,8 +18,6 @@ public class RegionalAnalysis extends Model implements Cloneable {
     public String projectId;
     public String scenarioId;
 
-    public int variant;
-
     public String workerVersion;
 
     public int zoom;
@@ -38,31 +36,12 @@ public class RegionalAnalysis extends Model implements Cloneable {
     public RegionalTask request;
 
     /**
-     * Single percentile of travel time being used in this analysis. Older analyses could have only one percentile.
-     * If the analysis is pre-percentiles and is using Andrew Owen-style accessibility, value is -1.
-     * If the analysis has more than one percentile, value is -2.
-     */
-    @Deprecated
-    public int travelTimePercentile = -1;
-
-    /**
      * Newer regional analyses (since release X in February 2020) can have more than one percentile.
      * If this is non-null it completely supersedes travelTimePercentile, which should be ignored.
      */
     public int[] travelTimePercentiles;
 
-    /** Single destination pointset id (for older analyses that did not allow multiple sets of destinations). */
-    @Deprecated
-    public String grid;
-
     public String[] destinationPointSetIds;
-
-    /**
-     * Older analyses (up to about January 2020, before release X) had only one cutoff.
-     * New analyses with more than one cutoff will have this set to -2.
-     */
-    @Deprecated
-    public int cutoffMinutes;
 
     /**
      * The different travel time thresholds used in this analysis to include or exclude opportunities from an

--- a/src/main/java/com/conveyal/r5/analyst/cluster/RegionalTask.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/RegionalTask.java
@@ -10,23 +10,6 @@ import com.conveyal.r5.analyst.WebMercatorExtents;
 public class RegionalTask extends AnalysisWorkerTask implements Cloneable {
 
     /**
-     * The storage key for the pointset we will compute access to (e.g. regionId/datasetId.grid).
-     * This is named grid instead of destinationPointSetId for backward compatibility, namely the ability to start
-     * regional jobs on old worker versions that expect the property "grid".
-     *
-     * Overloaded to specify a set of destination points which may or may not have densities attached.
-     * In fact this ID is taken from a field called "opportunityDatasetId" in the request coming from the UI. So we've
-     * got several slightly conflicting names and concepts.
-     *
-     * TODO revise and improve the below explanation:
-     * If this is not blank, the default TravelTimeSurfaceTask will be overridden; returnInVehicleTimes,
-     * returnWaitTimes, and returnPaths will be set to false; and the returned results will be an accessibility value
-     * per origin, rather than a grid of travel times from that origin.
-     */
-    @Deprecated
-    public String grid;
-
-    /**
      * Key for pointset (e.g. regionId/datasetId.pointset) from which to calculate travel times or accessibility
      */
     public String originPointSetKey;


### PR DESCRIPTION
Remove old fields in regional analysis that haven't been used in many years. 

#957, which contains a MongoDB migration to clean up old regional analyses, should be merged and ideally run first.

We recently removed a similar worker version related flag from the UI here: https://github.com/conveyal/ui/pull/2064