### PR TITLE
Generate old regional analysis results

### DIFF
--- a/src/main/java/com/conveyal/analysis/BackendMain.java
+++ b/src/main/java/com/conveyal/analysis/BackendMain.java
@@ -21,7 +21,7 @@ public abstract class BackendMain {
 
     public static void main (String... args) {
         final BackendComponents components = new LocalBackendComponents();
-        startServer(components);
+        startServer(components, new GenerateRegionalAnalysisResults(components.fileStorage));
     }
 
     protected static void startServer (BackendComponents components, TaskAction... postStartupTasks) {

--- a/src/main/java/com/conveyal/analysis/GenerateRegionalAnalysisResults.java
+++ b/src/main/java/com/conveyal/analysis/GenerateRegionalAnalysisResults.java
@@ -64,15 +64,15 @@ public class GenerateRegionalAnalysisResults implements TaskAction {
                         }
                     }
                 }
-                LOG.info("Finished generating files for {} of {}. Migrating db entry now...", regionalAnalysis._id, regionalAnalysis.accessGroup);
+                /* LOG.info("Migrating db entry for {} of {} now...", regionalAnalysis._id, regionalAnalysis.accessGroup);
 
                 // Save as modern types
                 regionalAnalysis.cutoffsMinutes = cutoffs;
                 regionalAnalysis.travelTimePercentiles = percentiles;
                 regionalAnalysis.destinationPointSetIds = destinationPointSetIds;
-                Persistence.regionalAnalyses.put(regionalAnalysis);
+                Persistence.regionalAnalyses.put(regionalAnalysis); */
 
-                LOG.info("Finished processing {} of {}.", regionalAnalysis._id, regionalAnalysis.accessGroup);
+                LOG.info("Finished generating files for {} of {}.", regionalAnalysis._id, regionalAnalysis.accessGroup);
             }
         } catch (Exception e) {
             LOG.error(ExceptionUtils.shortAndLongString(e));

--- a/src/main/java/com/conveyal/analysis/GenerateRegionalAnalysisResults.java
+++ b/src/main/java/com/conveyal/analysis/GenerateRegionalAnalysisResults.java
@@ -1,7 +1,6 @@
 package com.conveyal.analysis;
 
 import com.conveyal.analysis.controllers.RegionalAnalysisController;
-import com.conveyal.analysis.models.OpportunityDataset;
 import com.conveyal.analysis.models.RegionalAnalysis;
 import com.conveyal.analysis.persistence.Persistence;
 import com.conveyal.file.FileStorage;
@@ -48,14 +47,13 @@ public class GenerateRegionalAnalysisResults implements TaskAction {
 
                 // Iterate through all values and generate all possible formats for them.
                 for (String destinationPointSetId : destinationPointSetIds) {
-                    OpportunityDataset destinations = Persistence.opportunityDatasets.get(destinationPointSetId);
                     for (int cutoffMinutes : cutoffs) {
                         for (int percentile : percentiles) {
                             for (FileStorageFormat format : validFormats) {
                                 RegionalAnalysisController.getSingleCutoffGrid(
                                         fileStorage,
                                         regionalAnalysis,
-                                        destinations,
+                                        destinationPointSetId,
                                         cutoffMinutes,
                                         percentile,
                                         format

--- a/src/main/java/com/conveyal/analysis/GenerateRegionalAnalysisResults.java
+++ b/src/main/java/com/conveyal/analysis/GenerateRegionalAnalysisResults.java
@@ -51,15 +51,20 @@ public class GenerateRegionalAnalysisResults implements TaskAction {
                     for (int cutoffMinutes : cutoffs) {
                         for (int percentile : percentiles) {
                             for (FileStorageFormat format : validFormats) {
-                                RegionalAnalysisController.getSingleCutoffGrid(
-                                        fileStorage,
-                                        regionalAnalysis,
-                                        destinationPointSetId,
-                                        cutoffMinutes,
-                                        percentile,
-                                        format
-                                );
-                                filesGenerated++;
+                                try {
+                                    RegionalAnalysisController.getSingleCutoffGrid(
+                                            fileStorage,
+                                            regionalAnalysis,
+                                            destinationPointSetId,
+                                            cutoffMinutes,
+                                            percentile,
+                                            format
+                                    );
+                                    filesGenerated++;
+                                } catch (Exception e) {
+                                    LOG.error("Error generating single cutoff grid for {}", regionalAnalysis._id);
+                                    LOG.error(ExceptionUtils.shortAndLongString(e));
+                                }
                             }
                         }
                     }
@@ -72,7 +77,7 @@ public class GenerateRegionalAnalysisResults implements TaskAction {
                 regionalAnalysis.destinationPointSetIds = destinationPointSetIds;
                 Persistence.regionalAnalyses.put(regionalAnalysis); */
 
-                LOG.info("Finished generating files for {} of {}.", regionalAnalysis._id, regionalAnalysis.accessGroup);
+                LOG.info("Finished processing regional analysis {} of {}.", regionalAnalysis._id, regionalAnalysis.accessGroup);
             }
         } catch (Exception e) {
             LOG.error(ExceptionUtils.shortAndLongString(e));

--- a/src/main/java/com/conveyal/analysis/GenerateRegionalAnalysisResults.java
+++ b/src/main/java/com/conveyal/analysis/GenerateRegionalAnalysisResults.java
@@ -10,6 +10,7 @@ import com.conveyal.r5.analyst.progress.TaskAction;
 import com.conveyal.r5.util.ExceptionUtils;
 import com.mongodb.DBObject;
 import com.mongodb.QueryBuilder;
+import org.mongojack.DBProjection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +38,7 @@ public class GenerateRegionalAnalysisResults implements TaskAction {
         ).get();
         int filesGenerated = 0;
         try {
-            List<RegionalAnalysis> analyses = Persistence.regionalAnalyses.find(query).toArray();
+            List<RegionalAnalysis> analyses = Persistence.regionalAnalyses.find(query, DBProjection.exclude("request.scenario.modifications")).toArray();
             LOG.info("Query found {} regional analyses to process.", analyses.size());
             for (RegionalAnalysis regionalAnalysis : analyses) {
                 LOG.info("Processing regional analysis {} of {}.", regionalAnalysis._id, regionalAnalysis.accessGroup);

--- a/src/main/java/com/conveyal/analysis/GenerateRegionalAnalysisResults.java
+++ b/src/main/java/com/conveyal/analysis/GenerateRegionalAnalysisResults.java
@@ -46,19 +46,12 @@ public class GenerateRegionalAnalysisResults implements TaskAction {
                 int[] cutoffs = Objects.requireNonNullElseGet(regionalAnalysis.cutoffsMinutes, () -> new int[]{regionalAnalysis.cutoffMinutes});
                 String[] destinationPointSetIds = Objects.requireNonNullElseGet(regionalAnalysis.destinationPointSetIds, () -> new String[]{regionalAnalysis.grid});
 
-                // Save as modern types
-                regionalAnalysis.cutoffsMinutes = cutoffs;
-                regionalAnalysis.travelTimePercentiles = percentiles;
-                regionalAnalysis.destinationPointSetIds = destinationPointSetIds;
-                Persistence.regionalAnalyses.put(regionalAnalysis);
-
                 // Iterate through all values and generate all possible formats for them.
                 for (String destinationPointSetId : destinationPointSetIds) {
                     OpportunityDataset destinations = Persistence.opportunityDatasets.get(destinationPointSetId);
                     for (int cutoffMinutes : cutoffs) {
                         for (int percentile : percentiles) {
                             for (FileStorageFormat format : validFormats) {
-                                filesGenerated++;
                                 RegionalAnalysisController.getSingleCutoffGrid(
                                         fileStorage,
                                         regionalAnalysis,
@@ -67,10 +60,17 @@ public class GenerateRegionalAnalysisResults implements TaskAction {
                                         percentile,
                                         format
                                 );
+                                filesGenerated++;
                             }
                         }
                     }
                 }
+
+                // Save as modern types
+                regionalAnalysis.cutoffsMinutes = cutoffs;
+                regionalAnalysis.travelTimePercentiles = percentiles;
+                regionalAnalysis.destinationPointSetIds = destinationPointSetIds;
+                Persistence.regionalAnalyses.put(regionalAnalysis);
 
                 LOG.info("Finished processing {} of {}.", regionalAnalysis._id, regionalAnalysis.accessGroup);
             }

--- a/src/main/java/com/conveyal/analysis/GenerateRegionalAnalysisResults.java
+++ b/src/main/java/com/conveyal/analysis/GenerateRegionalAnalysisResults.java
@@ -1,0 +1,64 @@
+package com.conveyal.analysis;
+
+import com.conveyal.analysis.controllers.RegionalAnalysisController;
+import com.conveyal.analysis.models.OpportunityDataset;
+import com.conveyal.analysis.models.RegionalAnalysis;
+import com.conveyal.analysis.persistence.Persistence;
+import com.conveyal.file.FileStorage;
+import com.conveyal.file.FileStorageFormat;
+import com.conveyal.r5.analyst.progress.ProgressListener;
+import com.conveyal.r5.analyst.progress.TaskAction;
+import com.mongodb.DBObject;
+import com.mongodb.QueryBuilder;
+import org.mongojack.DBCursor;
+
+import java.util.Objects;
+
+public class GenerateRegionalAnalysisResults implements TaskAction {
+    private final FileStorage fileStorage;
+    public GenerateRegionalAnalysisResults (FileStorage fileStorage) {
+        this.fileStorage = fileStorage;
+    }
+
+    @Override
+    public void action(ProgressListener progressListener) throws Exception {
+        DBObject query = QueryBuilder.start().or(
+                QueryBuilder.start("travleTimePercentiles").is(null).get(),
+                QueryBuilder.start("cutoffsMinutes").is(null).get(),
+                QueryBuilder.start("destinationPointSetIds").is(null).get()
+        ).get();
+        try (DBCursor<RegionalAnalysis> cursor = Persistence.regionalAnalyses.find(query)) {
+            while (cursor.hasNext()) {
+                RegionalAnalysis regionalAnalysis = cursor.next();
+                int[] percentiles = Objects.requireNonNullElseGet(regionalAnalysis.travelTimePercentiles, () -> new int[]{regionalAnalysis.travelTimePercentile});
+                int[] cutoffs = Objects.requireNonNullElseGet(regionalAnalysis.cutoffsMinutes, () -> new int[]{regionalAnalysis.cutoffMinutes});
+                String[] destinationPointSetIds = Objects.requireNonNullElseGet(regionalAnalysis.destinationPointSetIds, () -> new String[]{regionalAnalysis.grid});
+
+                // Save as modern types
+                regionalAnalysis.cutoffsMinutes = cutoffs;
+                regionalAnalysis.travelTimePercentiles = percentiles;
+                regionalAnalysis.destinationPointSetIds = destinationPointSetIds;
+                Persistence.regionalAnalyses.put(regionalAnalysis);
+
+                // Iterate through all values and generate all possible formats for them.
+                for (String destinationPointSetId : destinationPointSetIds) {
+                    OpportunityDataset destinations = Persistence.opportunityDatasets.get(destinationPointSetId);
+                    for (int cutoffMinutes : cutoffs) {
+                        for (int percentile : percentiles) {
+                            for (FileStorageFormat format : FileStorageFormat.values()) {
+                                RegionalAnalysisController.getSingleCutoffGrid(
+                                        fileStorage,
+                                        regionalAnalysis,
+                                        destinations,
+                                        cutoffMinutes,
+                                        percentile,
+                                        format
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/conveyal/analysis/GenerateRegionalAnalysisResults.java
+++ b/src/main/java/com/conveyal/analysis/GenerateRegionalAnalysisResults.java
@@ -16,6 +16,11 @@ import java.util.Objects;
 
 public class GenerateRegionalAnalysisResults implements TaskAction {
     private final FileStorage fileStorage;
+    private final FileStorageFormat[] validFormats = new FileStorageFormat[]{
+            FileStorageFormat.GRID,
+            FileStorageFormat.GEOTIFF,
+            FileStorageFormat.PNG
+    };
     public GenerateRegionalAnalysisResults (FileStorage fileStorage) {
         this.fileStorage = fileStorage;
     }
@@ -23,7 +28,7 @@ public class GenerateRegionalAnalysisResults implements TaskAction {
     @Override
     public void action(ProgressListener progressListener) throws Exception {
         DBObject query = QueryBuilder.start().or(
-                QueryBuilder.start("travleTimePercentiles").is(null).get(),
+                QueryBuilder.start("travelTimePercentiles").is(null).get(),
                 QueryBuilder.start("cutoffsMinutes").is(null).get(),
                 QueryBuilder.start("destinationPointSetIds").is(null).get()
         ).get();
@@ -45,7 +50,7 @@ public class GenerateRegionalAnalysisResults implements TaskAction {
                     OpportunityDataset destinations = Persistence.opportunityDatasets.get(destinationPointSetId);
                     for (int cutoffMinutes : cutoffs) {
                         for (int percentile : percentiles) {
-                            for (FileStorageFormat format : FileStorageFormat.values()) {
+                            for (FileStorageFormat format : validFormats) {
                                 RegionalAnalysisController.getSingleCutoffGrid(
                                         fileStorage,
                                         regionalAnalysis,

--- a/src/main/java/com/conveyal/analysis/controllers/RegionalAnalysisController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/RegionalAnalysisController.java
@@ -39,7 +39,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.net.URI;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
@@ -184,13 +183,24 @@ public class RegionalAnalysisController implements HttpController {
      */
     private record HumanKey(FileStorageKey storageKey, String humanName) { };
 
+    private HumanKey getSingleCutoffGrid(
+            RegionalAnalysis analysis,
+            OpportunityDataset destinations,
+            int cutoffMinutes,
+            int percentile,
+            FileStorageFormat fileFormat
+    ) throws IOException {
+        return getSingleCutoffGrid(fileStorage, analysis, destinations, cutoffMinutes, percentile, fileFormat);
+    }
+
     /**
      * Get a regional analysis results raster for a single (percentile, cutoff, destination) combination, in one of
      * several image file formats. This method was factored out for use from two different API endpoints, one for
      * fetching a single grid, and another for fetching grids for all combinations of parameters at once.
      * It returns the unique FileStorageKey for those results, associated with a non-unique human-readable name.
      */
-    private HumanKey getSingleCutoffGrid (
+    public static HumanKey getSingleCutoffGrid(
+            FileStorage fileStorage,
             RegionalAnalysis analysis,
             OpportunityDataset destinations,
             int cutoffMinutes,

--- a/src/main/java/com/conveyal/analysis/controllers/RegionalAnalysisController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/RegionalAnalysisController.java
@@ -248,14 +248,14 @@ public class RegionalAnalysisController implements HttpController {
                 multiCutoffKey = String.format("%s_P%d.access", regionalAnalysisId, percentile);
                 multiCutoffFileStorageKey = new FileStorageKey(RESULTS, multiCutoffKey);
                 if (fileStorage.exists(multiCutoffFileStorageKey)) {
-                    checkArgument(analysis.destinationPointSetIds.length == 1);
+                    checkArgument(analysis.destinationPointSetIds == null || analysis.destinationPointSetIds.length == 1);
                 } else {
                     // Fall back on oldest form of results, single-percentile, single-destination-grid.
                     multiCutoffKey = regionalAnalysisId + ".access";
                     multiCutoffFileStorageKey = new FileStorageKey(RESULTS, multiCutoffKey);
                     if (fileStorage.exists(multiCutoffFileStorageKey)) {
-                        checkArgument(analysis.travelTimePercentiles.length == 1);
-                        checkArgument(analysis.destinationPointSetIds.length == 1);
+                        checkArgument(analysis.travelTimePercentiles == null || analysis.travelTimePercentiles.length == 1);
+                        checkArgument(analysis.destinationPointSetIds == null || analysis.destinationPointSetIds.length == 1);
                     } else {
                         throw AnalysisServerException.notFound("Cannot find original source regional analysis output.");
                     }


### PR DESCRIPTION
Generate all final results for old regional analyses with a task so that we can eliminate old code which was required to handle them. See #956 for the R5 code that can be simplified.

Regional analysis results had two changes to how they were stored over the years. However, the last change was several years ago. We still handle the old style of results in multiple locations in code, but if we migrate the database entries and pre-generate all of the regional analysis results we would be able to eliminate those code paths. This will make future changes easier to make.

This should be run on staging and production before #956 is merged.