### PR TITLE
Validate dual access thresholds

### DIFF
--- a/src/main/java/com/conveyal/analysis/controllers/RegionalAnalysisController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/RegionalAnalysisController.java
@@ -571,25 +571,17 @@ public class RegionalAnalysisController implements HttpController {
             );
         }
         if (task.includeTemporalDensity) {
-            if (task.originPointSet == null) {
-                checkArgument(
-                    task.dualAccessThresholds != null && task.dualAccessThresholds.length > 0,
-                    "`dualAccessThresholds` must be specified when dual access grid results are requested."
-                );
+            task.validateDualAccessThresholds();
 
+            checkArgument(
+                    SemVer.gte(task.workerVersion, "v7.4"),
+                    "Dual access results require a minimum worker version of v7.4"
+            );
+            
+            if (task.originPointSet == null) {
                 checkArgument(
                         !task.recordAccessibility,
                         "Accessibility and dual access grids cannot be created simultaneously."
-                );
-
-                checkArgument(
-                        SemVer.gte(task.workerVersion, "v7.4"),
-                        "Dual access with gridded origins requires a minimum worker version of v7.4"
-                );
-            } else {
-                checkArgument(
-                        SemVer.gte(task.workerVersion, "v7.0"),
-                        "Dual access with freeform origins requires a minimum worker version of v7.0"
                 );
             }
         }

--- a/src/main/java/com/conveyal/r5/analyst/TemporalDensityResult.java
+++ b/src/main/java/com/conveyal/r5/analyst/TemporalDensityResult.java
@@ -44,14 +44,13 @@ public class TemporalDensityResult {
     public TemporalDensityResult(AnalysisWorkerTask task) {
         Preconditions.checkArgument(
             notNullOrEmpty(task.destinationPointSets),
-                "Dual access requires at least one destination pointset."
+                "Temporal density requires at least one destination pointset."
         );
-        // TODO check that thresholds are sorted
         this.destinationPointSets = task.destinationPointSets;
         this.dualAccessThresholds = task.dualAccessThresholds;
         this.nPercentiles = task.percentiles.length;
         this.nPointSets = this.destinationPointSets.length;
-        this.nThresholds = this.dualAccessThresholds.length;
+        this.nThresholds = this.dualAccessThresholds == null ? 0 : this.dualAccessThresholds.length;
         opportunitiesPerMinute = new double[this.nPointSets][this.nPercentiles][TIME_LIMIT];
     }
 

--- a/src/main/java/com/conveyal/r5/analyst/cluster/AnalysisWorkerTask.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/AnalysisWorkerTask.java
@@ -322,4 +322,15 @@ public abstract class AnalysisWorkerTask extends ProfileRequest {
         }
     }
 
+    public void validateDualAccessThresholds () {
+        checkNotNull(dualAccessThresholds);
+        final int nThresholds = dualAccessThresholds.length;
+        checkArgument(nThresholds >= 1, "At least one dual access threshold must be supplied.");
+        for (int t = 0; t < nThresholds; t++) {
+            checkArgument(dualAccessThresholds[t] >= 0, "Dual access thresholds must be non-negative integers.");
+            if (t > 0) {
+                checkArgument(dualAccessThresholds[t] >= dualAccessThresholds[t - 1], "Dual access thresholds must be in ascending order.");
+            }
+        }
+    }
 }

--- a/src/main/java/com/conveyal/r5/analyst/cluster/RegionalWorkResult.java
+++ b/src/main/java/com/conveyal/r5/analyst/cluster/RegionalWorkResult.java
@@ -67,7 +67,7 @@ public class RegionalWorkResult {
         this.pathResult = result.paths == null ? null : result.paths.summarizeIterations(PathResult.Stat.MINIMUM);
         if (result.density != null) {
             this.opportunitiesPerMinute = result.density.opportunitiesPerMinute;
-            if (task.originPointSet == null) {
+            if (task.originPointSet == null && task.dualAccessThresholds != null) {
                 this.accessibilityValues = result.density.calculateDualAccessGrid();
             }
         }


### PR DESCRIPTION
Add a dual access threshold validation check similar to cutoffs and percentiles when `includeTemporalDensity` is enabled while creating a regional analysis. 

After the changes in https://github.com/conveyal/r5/pull/955, we now require `dualAccessThresholds` to be set for both CSV and gridded results. Previously we used a `int dualAccessibilityThreshold` value for CSV results, but now the UI will send an array of thresholds for either CSV or gridded results to be used as the threshold. This PR also moves up the `SemVer` check to enforce users to use v7.4 and up if they want any kind of temporal density result. Otherwise, we would need to handle backwards compatibility with the old parameter on R5 versions >= v7 and < v7.4.

Generating temporal density results does not require a threshold to be set, so this change also updates `TemporalDensityResult` to work with a task that has a null or empty `dualAccessThresholds` array.