### PR TITLE
Add better error message when trips in a pattern are not consistent

### DIFF
--- a/src/main/java/com/conveyal/r5/transit/FilteredPattern.java
+++ b/src/main/java/com/conveyal/r5/transit/FilteredPattern.java
@@ -56,6 +56,18 @@ public class FilteredPattern {
     }
 
     private static boolean overtakes (TripSchedule a, TripSchedule b) {
+        if (a.departures.length != b.departures.length) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "Trip %s and %s have %d and %d stops, respectively, but appear in the same pattern!",
+                    a.tripId,
+                    b.tripId,
+                    a.departures.length,
+                    b.departures.length
+                )
+            );
+        }
+        
         for (int s = 0; s < a.departures.length; s++) {
             if (a.departures[s] > b.departures[s]) return true;
         }


### PR DESCRIPTION
This does not _fix_ #978, but it does give a better error message when it comes up - currently you just get an array out of bounds exception, this at least points out an issue with patterns.