### PR TITLE
Use walking speed from request when linking origin and destination points to network

### DIFF
--- a/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
+++ b/src/main/java/com/conveyal/r5/streets/LinkedPointSet.java
@@ -449,11 +449,11 @@ public class LinkedPointSet implements Serializable {
             if (origin != null && origin.edge == edges[i]) {
                 // The target point lies along the same edge as the origin
                 int onStreetDistance_mm = Math.abs(origin.distance0_mm - distances0_mm[i]);
-                travelTimes[i] = // origin.distanceToEdge_mm / offStreetSpeed + TODO origin to origin split point
+                travelTimes[i] = origin.distanceToEdge_mm / offStreetSpeed +
                                 onStreetDistance_mm / onStreetSpeed + // along street
                                 distancesToEdge_mm[i] / offStreetSpeed; // from destination split point to destination
             } else {
-                travelTimes[i] = timeToPoint(timeToVertex, edge, i, onStreetSpeed);
+                travelTimes[i] = timeToPoint(timeToVertex, edge, i, onStreetSpeed, offStreetSpeed);
             }
         }
         return new PointSetTimes(pointSet, travelTimes);
@@ -526,7 +526,7 @@ public class LinkedPointSet implements Serializable {
                 // The routing variable is seconds only if we're doing a car search, so look up the car speed on the
                 // linked edge.
                 int onStreetSpeed = (int) (edge.getCarSpeedMetersPerSecond() * 1000);
-                cost = timeToPoint(costToVertex, edge, p, onStreetSpeed);
+                cost = timeToPoint(costToVertex, edge, p, onStreetSpeed, OFF_STREET_SPEED_MILLIMETERS_PER_SECOND);
             }
 
             if (cost != Integer.MAX_VALUE) {
@@ -607,13 +607,14 @@ public class LinkedPointSet implements Serializable {
      * @param onStreetSpeed speed at which the destination edge (to which the target is linked) is traversed
      * @return minimum time needed to reach point, or Integer.MAX_VALUE if point is not reachable.
      */
-    private int timeToPoint(CostToVertexFunction costToVertex, Edge edge, int pointIndex, int onStreetSpeed) {
+    private int timeToPoint(CostToVertexFunction costToVertex, Edge edge, int pointIndex, int onStreetSpeed,
+                            int offStreetSpeed) {
         int time0 = costToVertex.getCost(edge.getFromVertex());
         int time1 = costToVertex.getCost(edge.getToVertex());
         if (time0 == Integer.MAX_VALUE && time1 == Integer.MAX_VALUE) {
             return Integer.MAX_VALUE;
         } else {
-            int offStreetTime = distancesToEdge_mm[pointIndex] / OFF_STREET_SPEED_MILLIMETERS_PER_SECOND;
+            int offStreetTime = distancesToEdge_mm[pointIndex] / offStreetSpeed;
             time0 += distances0_mm[pointIndex] / onStreetSpeed + offStreetTime;
             time1 += distances1_mm[pointIndex] / onStreetSpeed + offStreetTime;
             return Math.min(handleOverflow(time0), handleOverflow(time1));

--- a/src/main/java/com/conveyal/r5/streets/StreetRouter.java
+++ b/src/main/java/com/conveyal/r5/streets/StreetRouter.java
@@ -337,7 +337,7 @@ public class StreetRouter {
         State startState0 = new State(split.vertex0, split.edge + 1, streetMode);
         State startState1 = new State(split.vertex1, split.edge, streetMode);
         EdgeStore.Edge  edge = streetLayer.edgeStore.getCursor(split.edge);
-        int offStreetTime = split.distanceToEdge_mm / OFF_STREET_SPEED_MILLIMETERS_PER_SECOND;
+        int offStreetTime = split.distanceToEdge_mm / (int) (profileRequest.walkSpeed * 1000);
 
         // Uses weight based on distance from end vertices, and speed on edge which depends on transport mode
         float speedMetersPerSecond = edge.calculateSpeed(profileRequest, streetMode);


### PR DESCRIPTION
R5 uses a walking speed when setting an origin point for street routing, and when linking (destination) points to the street network. Previously, we mixed use of a fixed constant (`OFF_STREET_SPEED_MILLIMETERS_PER_SECOND`) and the user-requested walk speed from analysis requests. This PR uses the user-requested walk speed more consistently. 

On the origin end, the walk speed is readily accessible in the `profileRequest` field of `StreetRouter`, so the change seems straightforward.

On the destination end, Egress Cost Tables store distances (in millimeters) for walking and biking linkages, and speeds are applied at analysis time when the user-requested walk speed is readily accessible. For car, on the other hand, times (in seconds) are stored; dividing distance by speed happens when creating the Egress Cost Tables, so it is simpler to maintain the use of the constant `OFF_STREET_SPEED_MILLIMETERS_PER_SECOND` (and we don't have known cases of users wanting to tweak the walking times between the street network and origins/destination points when the street mode is car).

More background is at https://github.com/conveyal/r5/issues/934#issuecomment-2090835628