### PR TITLE
Relax GTFS transfer validation and error logging

### DIFF
--- a/src/main/java/com/conveyal/gtfs/model/Transfer.java
+++ b/src/main/java/com/conveyal/gtfs/model/Transfer.java
@@ -34,7 +34,7 @@ public class Transfer extends Entity {
             tr.sourceFileLine    = row;
             tr.from_stop_id      = getStringField("from_stop_id", true);
             tr.to_stop_id        = getStringField("to_stop_id", true);
-            tr.transfer_type     = getIntField("transfer_type", true, 0, 3);
+            tr.transfer_type     = getIntField("transfer_type", true, 0, 5);
             tr.min_transfer_time = getIntField("min_transfer_time", false, 0, Integer.MAX_VALUE);
             tr.from_route_id     = getStringField("from_route_id", false);
             tr.to_route_id       = getStringField("to_route_id", false);
@@ -43,10 +43,12 @@ public class Transfer extends Entity {
 
             getRefField("from_stop_id", true, feed.stops);
             getRefField("to_stop_id", true, feed.stops);
-            getRefField("from_route_id", false, feed.routes);
-            getRefField("to_route_id", false, feed.routes);
-            getRefField("from_trip_id", false, feed.trips);
-            getRefField("to_trip_id", false, feed.trips);
+            // We do not validate referential integrity of these fields because they are not
+            // consumed by R5, and some prominent feeds contain thousands of such errors.
+            // getRefField("from_route_id", false, feed.routes);
+            // getRefField("to_route_id", false, feed.routes);
+            // getRefField("from_trip_id", false, feed.trips);
+            // getRefField("to_trip_id", false, feed.trips);
 
             // row number used as an arbitrary unique string to give MapDB a key.
             feed.transfers.put(Long.toString(row), tr);

--- a/src/main/java/com/conveyal/r5/streets/StreetLayer.java
+++ b/src/main/java/com/conveyal/r5/streets/StreetLayer.java
@@ -1220,7 +1220,7 @@ public class StreetLayer implements Serializable, Cloneable {
             try {
                 edgeStore.edgeTraversalTimes.setEdgePair(newEdge.edgeIndex, way);
             } catch (Exception ex) {
-                LOG.error("Continuing to load but ignoring generalized costs due to exception: {}", ex.toString());
+                LOG.info("Continuing to load but ignoring generalized costs following exception: {}", ex.toString());
                 edgeStore.edgeTraversalTimes = null;
             }
         }


### PR DESCRIPTION
This is a minimal first step toward #983, consisting of cherry-picking a single commit from that PR branch. It updates GTFS loading to tolerate a wider range of transfer types in the input data, even if we're not going to use all those types in preparing the routable network. It also bypasses the referential integrity checking on transfer specificity fields that only occur on transfer rows we do not actually use, since some commonly used feeds apparently have invalid values in thousands of such rows.

I have tested this on the MBTA feed and am able to build a network and route on it.

This also demotes one log message from ERROR to INFO, since that message appears in normal operation on almost every valid input file.