### PR TITLE
Accelerate GeoTiff extraction (experiments)

### DIFF
--- a/src/main/java/com/conveyal/analysis/SelectingGridReducer.java
+++ b/src/main/java/com/conveyal/analysis/SelectingGridReducer.java
@@ -2,6 +2,7 @@ package com.conveyal.analysis;
 
 import com.conveyal.r5.analyst.Grid;
 
+import java.io.BufferedInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,7 +39,8 @@ public class SelectingGridReducer {
     }
 
     public Grid compute (InputStream rawInput) {
-        try (DataInputStream input = new DataInputStream(new GZIPInputStream(rawInput))) {
+        final int BUFSIZE = 64*1024;
+        try (DataInputStream input = new DataInputStream(new BufferedInputStream(new GZIPInputStream(rawInput, BUFSIZE), BUFSIZE))) {
             // Ideally, this access grid reading logic should not be embedded in this reduce operation.
             char[] header = new char[8];
             for (int i = 0; i < 8; i++) {

--- a/src/main/java/com/conveyal/analysis/SelectingGridReducer.java
+++ b/src/main/java/com/conveyal/analysis/SelectingGridReducer.java
@@ -1,10 +1,12 @@
 package com.conveyal.analysis;
 
 import com.conveyal.r5.analyst.Grid;
-import com.google.common.io.LittleEndianDataInputStream;
 
+import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.zip.GZIPInputStream;
 
 /**
@@ -26,60 +28,67 @@ public class SelectingGridReducer {
     /** Version of the access grid format we read */
     private static final int ACCESS_GRID_VERSION = 0;
 
-    public final int index;
+    private final int index;
+
+    private final ByteBuffer swapBuffer = ByteBuffer.allocate(8);
 
     /** Initialize with the index to extract */
     public SelectingGridReducer(int index) {
         this.index = index;
     }
 
-    public Grid compute (InputStream rawInput) throws IOException {
-        LittleEndianDataInputStream input = new LittleEndianDataInputStream(new GZIPInputStream(rawInput));
-
-        char[] header = new char[8];
-        for (int i = 0; i < 8; i++) {
-            header[i] = (char) input.readByte();
-        }
-
-        if (!"ACCESSGR".equals(new String(header))) {
-            throw new IllegalArgumentException("Input not in access grid format!");
-        }
-
-        int version = input.readInt();
-
-        // FIXME access grid reading logic should not be embedded in this reduce operation
-        if (version != ACCESS_GRID_VERSION) {
-            throw new IllegalArgumentException(String.format("Version mismatch of access grids, expected %s, found %s", ACCESS_GRID_VERSION, version));
-        }
-
-        int zoom = input.readInt();
-        int west = input.readInt();
-        int north = input.readInt();
-        int width = input.readInt();
-        int height = input.readInt();
-
-        // The number of samples stored at each origin; these could be instantaneous accessibility values for each
-        // Monte Carlo draw, or they could be bootstrap replications of a sampling distribution of accessibility given
-        // median travel time.
-        int nSamples = input.readInt();
-
-        Grid outputGrid = new Grid(west, north, width, height, zoom);
-
-        int[] valuesThisOrigin = new int[nSamples];
-
-        for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
-                // input values are delta-coded per origin, so use val to keep track of current value
-                for (int iteration = 0, val = 0; iteration < nSamples; iteration++) {
-                    val += input.readInt();
-                    valuesThisOrigin[iteration] = val;
-                }
-                // compute percentiles
-                outputGrid.grid[x][y] = valuesThisOrigin[index];
+    public Grid compute (InputStream rawInput) {
+        try (DataInputStream input = new DataInputStream(new GZIPInputStream(rawInput))) {
+            // Ideally, this access grid reading logic should not be embedded in this reduce operation.
+            char[] header = new char[8];
+            for (int i = 0; i < 8; i++) {
+                header[i] = (char) input.readByte();
             }
+            if (!"ACCESSGR".equals(new String(header))) {
+                throw new IllegalArgumentException("Input not in access grid format!");
+            }
+            int version = readIntSwap(input);
+            if (version != ACCESS_GRID_VERSION) {
+                throw new IllegalArgumentException(String.format("Version mismatch of access grids, expected %s, found %s", ACCESS_GRID_VERSION, version));
+            }
+            int zoom = readIntSwap(input);
+            int west = readIntSwap(input);
+            int north = readIntSwap(input);
+            int width = readIntSwap(input);
+            int height = readIntSwap(input);
+
+            // The number of samples stored at each origin; these could be instantaneous accessibility values for each
+            // Monte Carlo draw, or they could be bootstrap replications of a sampling distribution of accessibility given
+            // median travel time.
+            int nSamples = readIntSwap(input);
+            Grid outputGrid = new Grid(west, north, width, height, zoom);
+            int[] valuesThisOrigin = new int[nSamples];
+            for (int y = 0; y < height; y++) {
+                for (int x = 0; x < width; x++) {
+                    // input values are delta-coded per origin, so use val to keep track of current value
+                    for (int iteration = 0, val = 0; iteration < nSamples; iteration++) {
+                        val += readIntSwap(input);
+                        valuesThisOrigin[iteration] = val;
+                    }
+                    // compute percentiles
+                    outputGrid.grid[x][y] = valuesThisOrigin[index];
+                }
+            }
+            input.close();
+            return outputGrid;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
-        input.close();
-        return outputGrid;
     }
 
+    /// NOT THREAD SAFE, reuses per-instance byte buffer
+    private int swap (int x) {
+        swapBuffer.order(ByteOrder.nativeOrder()).putInt(0, x);
+        return swapBuffer.order(ByteOrder.BIG_ENDIAN).getInt(0);
+    }
+
+    private int readIntSwap (DataInputStream dis) throws IOException {
+        int swapped = dis.readInt();
+        return swap(swapped);
+    }
 }

--- a/src/main/java/com/conveyal/analysis/controllers/RegionalAnalysisController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/RegionalAnalysisController.java
@@ -37,6 +37,8 @@ import spark.Request;
 import spark.Response;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -247,11 +249,9 @@ public class RegionalAnalysisController implements HttpController {
             File multiCutoffFile = fileStorage.getFile(multiCutoffFileStorageKey);
             File tempOutFile = FileUtils.createScratchFile(fileFormat.toString());
             try (
-                  FileChannel multiCutoffChannel = FileChannel.open(multiCutoffFile.toPath(), StandardOpenOption.READ);
-                  FileChannel localOutputChannel = FileChannel.open(tempOutFile.toPath(), StandardOpenOption.WRITE)
+                InputStream multiCutoffStream = new FileInputStream(multiCutoffFile);
+                OutputStream tempOutStream = new FileOutputStream(tempOutFile);
             ) {
-                InputStream multiCutoffStream = Channels.newInputStream(multiCutoffChannel);
-                OutputStream tempOutStream = Channels.newOutputStream(localOutputChannel);
                 Grid grid = new SelectingGridReducer(thresholdIndex).compute(multiCutoffStream);
                 switch (fileFormat) {
                     case GRID:

--- a/src/main/java/com/conveyal/analysis/controllers/RegionalAnalysisController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/RegionalAnalysisController.java
@@ -41,11 +41,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -55,6 +59,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
 import static com.conveyal.analysis.util.JsonUtil.toJson;
@@ -239,27 +244,30 @@ public class RegionalAnalysisController implements HttpController {
             String multiCutoffKey = String.format("%s.%s", multiCutoffName, multiCutoffExtension);
             FileStorageKey multiCutoffFileStorageKey = new FileStorageKey(RESULTS, multiCutoffKey);
             LOG.debug("Single-cutoff grid {} not found on S3, deriving it from {}.", singleCutoffKey, multiCutoffKey);
-
-            InputStream multiCutoffInputStream = FileUtils.getInputStream(fileStorage.getFile(multiCutoffFileStorageKey));
-            Grid grid = new SelectingGridReducer(thresholdIndex).compute(multiCutoffInputStream);
-
-            File localFile = FileUtils.createScratchFile(fileFormat.toString());
-            OutputStream fos = FileUtils.getOutputStream(localFile);
-
-            switch (fileFormat) {
-                case GRID:
-                    grid.write(new GZIPOutputStream(fos));
-                    break;
-                case PNG:
-                    grid.writePng(fos);
-                    break;
-                case GEOTIFF:
-                    grid.writeGeotiff(fos);
-                    break;
+            File multiCutoffFile = fileStorage.getFile(multiCutoffFileStorageKey);
+            File tempOutFile = FileUtils.createScratchFile(fileFormat.toString());
+            try (
+                  FileChannel multiCutoffChannel = FileChannel.open(multiCutoffFile.toPath(), StandardOpenOption.READ);
+                  FileChannel localOutputChannel = FileChannel.open(tempOutFile.toPath(), StandardOpenOption.WRITE)
+            ) {
+                InputStream multiCutoffStream = Channels.newInputStream(multiCutoffChannel);
+                OutputStream tempOutStream = Channels.newOutputStream(localOutputChannel);
+                Grid grid = new SelectingGridReducer(thresholdIndex).compute(multiCutoffStream);
+                switch (fileFormat) {
+                    case GRID:
+                        grid.write(new GZIPOutputStream(tempOutStream));
+                        break;
+                    case PNG:
+                        grid.writePng(tempOutStream);
+                        break;
+                    case GEOTIFF:
+                        grid.writeGeotiff(tempOutStream);
+                        break;
+                }
+                LOG.debug("Finished deriving single-cutoff grid {}. Transferring to storage.", singleCutoffKey);
+                fileStorage.moveIntoStorage(singleCutoffFileStorageKey, tempOutFile);
+                LOG.debug("Finished transferring single-cutoff grid {} to storage.", singleCutoffKey);
             }
-            LOG.debug("Finished deriving single-cutoff grid {}. Transferring to storage.", singleCutoffKey);
-            fileStorage.moveIntoStorage(singleCutoffFileStorageKey, localFile);
-            LOG.debug("Finished transferring single-cutoff grid {} to storage.", singleCutoffKey);
         }
         String analysisHumanName = humanNameForEntity(analysis);
         String destinationHumanName = humanNameForEntity(destinations);


### PR DESCRIPTION
Extracting single channels out of an access file with the SelectingGridReducer is surprisingly slow. Past research shows this is not due to file transfer to cloud storage, but has something to do with the local file IO. The slowness is mostly tolerable when for example displaying single cutoffs of regional analysis results, but becomes a problem when working with very large data sets or extracting many channels at once, as when making a ZIP of GeoTiffs for every combination of parameters.

This branch contains some experiments to further narrow down the cause and test some alternative approaches.

Related past issues and comments:
- https://github.com/conveyal/r5/pull/932#issuecomment-2049435867 (some measurements and theories)
- https://github.com/conveyal/r5/pull/938 (current workaround, multi-channel extraction done as a background task)

Some ongoing UI changes would be much simpler if channel extraction was fast enough to be performed synchronously by the backend. We could then avoid exposing separate extract and download steps to the end user.