### PR TITLE
Accelerate geotiff extraction

### DIFF
--- a/src/main/java/com/conveyal/analysis/SelectingGridReducer.java
+++ b/src/main/java/com/conveyal/analysis/SelectingGridReducer.java
@@ -3,6 +3,7 @@ package com.conveyal.analysis;
 import com.conveyal.r5.analyst.Grid;
 import com.google.common.io.LittleEndianDataInputStream;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.zip.GZIPInputStream;
@@ -33,8 +34,10 @@ public class SelectingGridReducer {
         this.index = index;
     }
 
+    private static final int BUFSIZE = 32 * 1024;
+
     public Grid compute (InputStream rawInput) throws IOException {
-        LittleEndianDataInputStream input = new LittleEndianDataInputStream(new GZIPInputStream(rawInput));
+        LittleEndianDataInputStream input = new LittleEndianDataInputStream(new BufferedInputStream(new GZIPInputStream(rawInput, BUFSIZE), BUFSIZE));
 
         char[] header = new char[8];
         for (int i = 0; i < 8; i++) {


### PR DESCRIPTION
Extracting single channels out of an access file with the SelectingGridReducer is surprisingly slow. Past research shows this is not due to file transfer to cloud storage, but has something to do with the local file IO. The slowness is mostly tolerable when for example displaying single cutoffs of regional analysis results, but becomes a problem when working with very large data sets or extracting many channels at once, as when making a ZIP of GeoTiffs for every combination of parameters.

This branch contains some experiments to further narrow down the cause and test some alternative approaches.

Related past issues and comments:
- https://github.com/conveyal/r5/pull/932#issuecomment-2049435867 (some measurements and theories)
- https://github.com/conveyal/r5/pull/938 (current workaround, multi-channel extraction done as a background task)

After numerous experiments, the commit in this PR seems to be the most effective one. In testing on small regional results of 32k origins, GeoTiff generation is sped up by about 10x to 9 milliseconds.

The critical factor seems to be ensuring that `read` calls on the GZIPInputStream almost always operate on large numbers of bytes, not a single byte at a time or say 4 bytes of a single integer. It is common practice to manually specify buffering for streams in Java, but a) we assumed the GZIPInputStream's Inflater buffer was already having a read-combining effect and b) the buffering stream we explicitly included was _after_ the GZIPInputStream rather than before it.

Although the GZIPInputStream has its own internal buffer, both LittleEndianDataInputStream and DataInputStream tend to `read` one or four bytes at a time from it, and GZIPInputStream apparently passes these small read sizes through to its Inflater instance and perhaps all the way through to the wrapped source stream, rather than trying to read ahead in larger blocks. Wrapping GZIPInputStream in BufferedInputStream ensures large block read-ahead is passed through to the GZIPInputStream's Inflater, rather than the Inflater receiving tiny reads and passing those through to the buffer. 

To clarify: in existing dev branch we use FileUtils.getInputStream to create a buffered FileInputStream that is passed to the SelectingGridReducer, resulting in the chain:
`LittleEndianDataInputStream -> GZIPInputStream -> Inflater -> BufferedInputStream -> FileInputStream -> file`

Changing the order as follows has the most significant impact, as thousands of single-byte reads from LEDIS are coalesced immediately into block pre-reads by the BIS, cascading generally efficient larger reads down to the Inflater and file:
`LittleEndianDataInputStream -> BufferedInputStream -> GZIPInputStream -> Inflater -> FileInputStream -> file`

Additionally, the GZIP internal buffer is also very small by default at 512 bytes, and the BufferedInputStream buffer fairly small at 8k bytes so both have been enlarged to a value that showed good performance in testing.

Other experiments that did not yield appreciable improvements over the buffer order and size change:
- 1c56004 get streams from NIO FileChannels
- ba3da7e use ByteBuffer.order() to reverse int bytes instead of LittleEndianInputStream
