### PR TITLE
Change regional zip-of-geotiff progress message

### DIFF
--- a/src/main/java/com/conveyal/analysis/controllers/RegionalAnalysisController.java
+++ b/src/main/java/com/conveyal/analysis/controllers/RegionalAnalysisController.java
@@ -294,7 +294,7 @@ public class RegionalAnalysisController implements HttpController {
         }
         // File did not exist. Create it in the background and ask caller to request it later.
         filesBeingPrepared.add(zippedResultsKey.path);
-        Task task = Task.create("Zip all geotiffs for regional analysis " + analysis.name)
+        Task task = Task.create("Preparing regional results archive (hit download again when complete)")
             .forUser(userPermissions)
             .withAction(progressListener -> {
                 int nSteps = analysis.destinationPointSetIds.length * analysis.cutoffsMinutes.length *


### PR DESCRIPTION
This should make the workflow a bit clearer to end users. Two-step workflow is not intended to be permanent, see #987.