### PR TITLE
(fix) elevation costs when copying a street network

### DIFF
--- a/src/main/java/com/conveyal/r5/rastercost/CostField.java
+++ b/src/main/java/com/conveyal/r5/rastercost/CostField.java
@@ -44,6 +44,14 @@ public interface CostField {
      */
     double getDisplayValue (int edgeIndex);
 
+    /**
+     * Return a copy of this CostField when duplicating for scenarios.
+     * If field won't be mutated in scenario, may return this.
+     */
+    default CostField extendOnlyCopy (EdgeStore copiedEdgeStore) {
+        return this;
+    }
+
     /** Interface for classes that create a CostField for a given StreetLayer, usually by overlaying a raster file. */
     interface Loader<T extends CostField> {
         void setNorthShiftMeters (double northShiftMeters);

--- a/src/main/java/com/conveyal/r5/streets/EdgeStore.java
+++ b/src/main/java/com/conveyal/r5/streets/EdgeStore.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.function.IntConsumer;
+import java.util.stream.Collectors;
 
 import static com.conveyal.r5.streets.EdgeStore.EdgeFlag.*;
 
@@ -1299,6 +1300,12 @@ public class EdgeStore implements Serializable {
         copy.turnRestrictionsReverse = turnRestrictionsReverse;
         if (edgeTraversalTimes != null) {
             copy.edgeTraversalTimes = edgeTraversalTimes.extendOnlyCopy(copy);
+        }
+        // We don't expect to add/change elevation
+        if (costFields != null) {
+            copy.costFields = costFields.stream()
+                    .map(costField -> costField.extendOnlyCopy(copy))
+                    .collect(Collectors.toList());
         }
         return copy;
     }


### PR DESCRIPTION
Currently when using `scenarioCopy` in TransportNetwork the elevation costs are dropped during the "deep copy" if the scenario announces that it will mutate the street layer. 

I added a small fix to copy over the raster costs to the new network. This is not a deep copy similarly to how some of the other fields are copied over, as at least in R5R we do not expect to change elevation in a scenario. However I don't think making a deep copy would be difficult I just didn't want to miss something. 

Elevation is now properly preserved in R5R when we make copies, not sure how to test from your guys' end.