### PR TITLE
Consider additional worker startup regularly during regional analysis jobs

### DIFF
--- a/src/main/java/com/conveyal/analysis/components/broker/Broker.java
+++ b/src/main/java/com/conveyal/analysis/components/broker/Broker.java
@@ -135,7 +135,13 @@ public class Broker implements Component {
      * results are received for a given workerCategory. Do so after receiving results for an
      * arbitrary task toward the beginning of the job
      */
-    public static final int AUTO_START_SPOT_INSTANCES_AT_TASK = 42;
+    public static final int START_INSTANCES_TASK = 42;
+
+    /**
+     * We also want to consider starting instances occasionally as a regional analysis is running, in case previously
+     * created instances have been terminated.
+     */
+    public static final int RESTART_INSTANCES_TASKS = 4000;
 
     /** The maximum number of spot instances allowable in an automatic request */
     public static final int MAX_WORKERS_PER_CATEGORY = 250;
@@ -535,7 +541,7 @@ public class Broker implements Component {
         }
         // When non-error results are received for several tasks we assume the regional analysis is running smoothly.
         // Consider accelerating the job by starting an appropriate number of EC2 spot instances.
-        if (workResult.taskId == AUTO_START_SPOT_INSTANCES_AT_TASK) {
+        if (workResult.taskId == START_INSTANCES_TASK || (workResult.taskId + 1) % RESTART_INSTANCES_TASKS == 0) {
             requestExtraWorkersIfAppropriate(job);
         }
     }

--- a/src/main/java/com/conveyal/analysis/components/broker/Broker.java
+++ b/src/main/java/com/conveyal/analysis/components/broker/Broker.java
@@ -546,42 +546,42 @@ public class Broker implements Component {
     // At certain task numbers, check various conditions about the worker pool then start spot or on-demand instances
     private void requestExtraWorkersIfAppropriate(Job job, int taskId) {
         if (taskId == START_INSTANCES_TASK || (taskId + 1) % RESTART_INSTANCES_TASKS == 0) {
-        WorkerCategory workerCategory = job.workerCategory;
-        int categoryWorkersAlreadyRunning = workerCatalog.countWorkersInCategory(workerCategory);
-        if (categoryWorkersAlreadyRunning < MAX_WORKERS_PER_CATEGORY) {
-            // TODO more refined determination of number of workers to start (e.g. using observed tasks per minute
-            //  for recently completed tasks -- but what about when initial origins are in a desert/ocean?)
-            int targetWorkerTotal;
-            if (job.templateTask.hasTransit()) {
-                // Total computation for a task with transit depends on the number of stops and whether the
-                // network has frequency-based routes. The total computation for the job depends on these
-                // factors as well as the number of tasks (origins). Zoom levels add a complication: the number of
-                // origins becomes an even poorer proxy for the number of stops. We use a scale factor to compensate
-                // -- all else equal, high zoom levels imply fewer stops per origin (task) and a lower ideal target
-                // for number of workers. TODO reduce scale factor further when there are no frequency routes. But is
-                //  this worth adding a field to Job or RegionalTask?
-                float transitScaleFactor = (9f / job.templateTask.zoom);
-                targetWorkerTotal = (int) ((job.nTasksTotal / TARGET_TASKS_PER_WORKER_TRANSIT) * transitScaleFactor);
-            } else {
-                // Tasks without transit are simpler. They complete relatively quickly, and the total computation for
-                // the job increases roughly with linearly with the number of origins.
-                targetWorkerTotal = job.nTasksTotal / TARGET_TASKS_PER_WORKER_NONTRANSIT;
-            }
+            WorkerCategory workerCategory = job.workerCategory;
+            int categoryWorkersAlreadyRunning = workerCatalog.countWorkersInCategory(workerCategory);
+            if (categoryWorkersAlreadyRunning < MAX_WORKERS_PER_CATEGORY) {
+                // TODO more refined determination of number of workers to start (e.g. using observed tasks per minute
+                //  for recently completed tasks -- but what about when initial origins are in a desert/ocean?)
+                int targetWorkerTotal;
+                if (job.templateTask.hasTransit()) {
+                    // Total computation for a task with transit depends on the number of stops and whether the
+                    // network has frequency-based routes. The total computation for the job depends on these
+                    // factors as well as the number of tasks (origins). Zoom levels add a complication: the number of
+                    // origins becomes an even poorer proxy for the number of stops. We use a scale factor to compensate
+                    // -- all else equal, high zoom levels imply fewer stops per origin (task) and a lower ideal target
+                    // for number of workers. TODO reduce scale factor further when there are no frequency routes. But is
+                    //  this worth adding a field to Job or RegionalTask?
+                    float transitScaleFactor = (9f / job.templateTask.zoom);
+                    targetWorkerTotal = (int) ((job.nTasksTotal / TARGET_TASKS_PER_WORKER_TRANSIT) * transitScaleFactor);
+                } else {
+                    // Tasks without transit are simpler. They complete relatively quickly, and the total computation for
+                    // the job increases roughly with linearly with the number of origins.
+                    targetWorkerTotal = job.nTasksTotal / TARGET_TASKS_PER_WORKER_NONTRANSIT;
+                }
 
-            // Do not exceed the limit on workers per category TODO add similar limit per accessGroup or user
-            targetWorkerTotal = Math.min(targetWorkerTotal, MAX_WORKERS_PER_CATEGORY);
-            // Guardrails until freeform pointsets are tested more thoroughly
-            if (job.templateTask.originPointSet != null) targetWorkerTotal = Math.min(targetWorkerTotal, 80);
-            if (job.templateTask.includePathResults) targetWorkerTotal = Math.min(targetWorkerTotal, 20);
-            int nWorkers = targetWorkerTotal - categoryWorkersAlreadyRunning;
-            if (taskId == START_INSTANCES_TASK) {
-                // After a few tasks are completed successfully, try to start spot instances
-                createWorkersInCategory(job.workerCategory, job.workerTags, 0, nWorkers);
-            } else {
-                // If the number of workers is below the target later in a job, it is likely that spot instances were
-                // terminated due to capacity limits. So request on-demand instances instead.
-                createWorkersInCategory(job.workerCategory, job.workerTags, nWorkers, 0);
-            }
+                // Do not exceed the limit on workers per category TODO add similar limit per accessGroup or user
+                targetWorkerTotal = Math.min(targetWorkerTotal, MAX_WORKERS_PER_CATEGORY);
+                // Guardrails until freeform pointsets are tested more thoroughly
+                if (job.templateTask.originPointSet != null) targetWorkerTotal = Math.min(targetWorkerTotal, 80);
+                if (job.templateTask.includePathResults) targetWorkerTotal = Math.min(targetWorkerTotal, 20);
+                int nWorkers = targetWorkerTotal - categoryWorkersAlreadyRunning;
+                if (taskId == START_INSTANCES_TASK) {
+                    // After a few tasks are completed successfully, try to start spot instances
+                    createWorkersInCategory(job.workerCategory, job.workerTags, 0, nWorkers);
+                } else {
+                    // If the number of workers is below the target later in a job, it is likely that spot instances were
+                    // terminated due to capacity limits. So request on-demand instances instead.
+                    createWorkersInCategory(job.workerCategory, job.workerTags, nWorkers, 0);
+                }
             }
         }
     }

--- a/src/main/java/com/conveyal/analysis/components/broker/Broker.java
+++ b/src/main/java/com/conveyal/analysis/components/broker/Broker.java
@@ -545,43 +545,42 @@ public class Broker implements Component {
 
     // At certain task numbers, check various conditions about the worker pool then start spot or on-demand instances
     private void requestExtraWorkersIfAppropriate(Job job, int taskId) {
-        if (taskId == START_INSTANCES_TASK || (taskId + 1) % RESTART_INSTANCES_TASKS == 0) {
-            WorkerCategory workerCategory = job.workerCategory;
-            int categoryWorkersAlreadyRunning = workerCatalog.countWorkersInCategory(workerCategory);
-            if (categoryWorkersAlreadyRunning < MAX_WORKERS_PER_CATEGORY) {
-                // TODO more refined determination of number of workers to start (e.g. using observed tasks per minute
-                //  for recently completed tasks -- but what about when initial origins are in a desert/ocean?)
-                int targetWorkerTotal;
-                if (job.templateTask.hasTransit()) {
-                    // Total computation for a task with transit depends on the number of stops and whether the
-                    // network has frequency-based routes. The total computation for the job depends on these
-                    // factors as well as the number of tasks (origins). Zoom levels add a complication: the number of
-                    // origins becomes an even poorer proxy for the number of stops. We use a scale factor to compensate
-                    // -- all else equal, high zoom levels imply fewer stops per origin (task) and a lower ideal target
-                    // for number of workers. TODO reduce scale factor further when there are no frequency routes. But is
-                    //  this worth adding a field to Job or RegionalTask?
-                    float transitScaleFactor = (9f / job.templateTask.zoom);
-                    targetWorkerTotal = (int) ((job.nTasksTotal / TARGET_TASKS_PER_WORKER_TRANSIT) * transitScaleFactor);
-                } else {
-                    // Tasks without transit are simpler. They complete relatively quickly, and the total computation for
-                    // the job increases roughly with linearly with the number of origins.
-                    targetWorkerTotal = job.nTasksTotal / TARGET_TASKS_PER_WORKER_NONTRANSIT;
-                }
+        if (!(taskId == START_INSTANCES_TASK || (taskId + 1) % RESTART_INSTANCES_TASKS == 0)) return;
+        WorkerCategory workerCategory = job.workerCategory;
+        int categoryWorkersAlreadyRunning = workerCatalog.countWorkersInCategory(workerCategory);
+        if (categoryWorkersAlreadyRunning < MAX_WORKERS_PER_CATEGORY) {
+            // TODO more refined determination of number of workers to start (e.g. using observed tasks per minute
+            //  for recently completed tasks -- but what about when initial origins are in a desert/ocean?)
+            int targetWorkerTotal;
+            if (job.templateTask.hasTransit()) {
+                // Total computation for a task with transit depends on the number of stops and whether the
+                // network has frequency-based routes. The total computation for the job depends on these
+                // factors as well as the number of tasks (origins). Zoom levels add a complication: the number of
+                // origins becomes an even poorer proxy for the number of stops. We use a scale factor to compensate
+                // -- all else equal, high zoom levels imply fewer stops per origin (task) and a lower ideal target
+                // for number of workers. TODO reduce scale factor further when there are no frequency routes. But is
+                //  this worth adding a field to Job or RegionalTask?
+                float transitScaleFactor = (9f / job.templateTask.zoom);
+                targetWorkerTotal = (int) ((job.nTasksTotal / TARGET_TASKS_PER_WORKER_TRANSIT) * transitScaleFactor);
+            } else {
+                // Tasks without transit are simpler. They complete relatively quickly, and the total computation for
+                // the job increases roughly with linearly with the number of origins.
+                targetWorkerTotal = job.nTasksTotal / TARGET_TASKS_PER_WORKER_NONTRANSIT;
+            }
 
-                // Do not exceed the limit on workers per category TODO add similar limit per accessGroup or user
-                targetWorkerTotal = Math.min(targetWorkerTotal, MAX_WORKERS_PER_CATEGORY);
-                // Guardrails until freeform pointsets are tested more thoroughly
-                if (job.templateTask.originPointSet != null) targetWorkerTotal = Math.min(targetWorkerTotal, 80);
-                if (job.templateTask.includePathResults) targetWorkerTotal = Math.min(targetWorkerTotal, 20);
-                int nWorkers = targetWorkerTotal - categoryWorkersAlreadyRunning;
-                if (taskId == START_INSTANCES_TASK) {
-                    // After a few tasks are completed successfully, try to start spot instances
-                    createWorkersInCategory(job.workerCategory, job.workerTags, 0, nWorkers);
-                } else {
-                    // If the number of workers is below the target later in a job, it is likely that spot instances were
-                    // terminated due to capacity limits. So request on-demand instances instead.
-                    createWorkersInCategory(job.workerCategory, job.workerTags, nWorkers, 0);
-                }
+            // Do not exceed the limit on workers per category TODO add similar limit per accessGroup or user
+            targetWorkerTotal = Math.min(targetWorkerTotal, MAX_WORKERS_PER_CATEGORY);
+            // Guardrails until freeform pointsets are tested more thoroughly
+            if (job.templateTask.originPointSet != null) targetWorkerTotal = Math.min(targetWorkerTotal, 80);
+            if (job.templateTask.includePathResults) targetWorkerTotal = Math.min(targetWorkerTotal, 20);
+            int nWorkers = targetWorkerTotal - categoryWorkersAlreadyRunning;
+            if (taskId == START_INSTANCES_TASK) {
+                // After a few tasks are completed successfully, try to start spot instances
+                createWorkersInCategory(job.workerCategory, job.workerTags, 0, nWorkers);
+            } else {
+                // If the number of workers is below the target later in a job, it is likely that spot instances were
+                // terminated due to capacity limits. So request on-demand instances instead.
+                createWorkersInCategory(job.workerCategory, job.workerTags, nWorkers, 0);
             }
         }
     }

--- a/src/main/java/com/conveyal/analysis/components/broker/Broker.java
+++ b/src/main/java/com/conveyal/analysis/components/broker/Broker.java
@@ -539,14 +539,13 @@ public class Broker implements Component {
             eventBus.send(new ErrorEvent(t));
             return;
         }
-        // When non-error results are received for several tasks we assume the regional analysis is running smoothly.
         // Consider accelerating the job by starting an appropriate number of EC2 spot instances.
-        if (workResult.taskId == START_INSTANCES_TASK || (workResult.taskId + 1) % RESTART_INSTANCES_TASKS == 0) {
-            requestExtraWorkersIfAppropriate(job);
-        }
+        requestExtraWorkersIfAppropriate(job, workResult.taskId);
     }
 
-    private void requestExtraWorkersIfAppropriate(Job job) {
+    // At certain task numbers, check various conditions about the worker pool then start spot or on-demand instances
+    private void requestExtraWorkersIfAppropriate(Job job, int taskId) {
+        if (taskId == START_INSTANCES_TASK || (taskId + 1) % RESTART_INSTANCES_TASKS == 0) {
         WorkerCategory workerCategory = job.workerCategory;
         int categoryWorkersAlreadyRunning = workerCatalog.countWorkersInCategory(workerCategory);
         if (categoryWorkersAlreadyRunning < MAX_WORKERS_PER_CATEGORY) {
@@ -574,8 +573,16 @@ public class Broker implements Component {
             // Guardrails until freeform pointsets are tested more thoroughly
             if (job.templateTask.originPointSet != null) targetWorkerTotal = Math.min(targetWorkerTotal, 80);
             if (job.templateTask.includePathResults) targetWorkerTotal = Math.min(targetWorkerTotal, 20);
-            int nSpot =  targetWorkerTotal - categoryWorkersAlreadyRunning;
-            createWorkersInCategory(job.workerCategory, job.workerTags, 0, nSpot);
+            int nWorkers = targetWorkerTotal - categoryWorkersAlreadyRunning;
+            if (taskId == START_INSTANCES_TASK) {
+                // After a few tasks are completed successfully, try to start spot instances
+                createWorkersInCategory(job.workerCategory, job.workerTags, 0, nWorkers);
+            } else {
+                // If the number of workers is below the target later in a job, it is likely that spot instances were
+                // terminated due to capacity limits. So request on-demand instances instead.
+                createWorkersInCategory(job.workerCategory, job.workerTags, nWorkers, 0);
+            }
+            }
         }
     }
 


### PR DESCRIPTION
This PR has a couple options to address #995 and make regional analysis progress smoother for users.

The first commit (9771a0d610c81a8590ec05e17d317d39346faddc) checks whether the number of running workers matches the target number every 4000 tasks in a regional job, then requests spot instances to make up any difference.

The second commit (b501a55fcf28edf32fd3424c1db8dc5c6fc1d07b) makes these subsequent requests for on-demand workers instead of spot workers, because if workers are missing in a regional job, it may be because AWS capacity issues have led to termination of our spot instances.

The third commit (a305d2164b9f81fe63d04ca24dff50311470ebef) is purely an indentation change, separated for more readable diffs.

Other approaches would be welcome, but I wanted to propose some initial minimal changes to address the tighter spot markets we've been seeing lately.