### PR TITLE
Grid transform fix

### DIFF
--- a/src/main/java/com/conveyal/r5/analyst/WebMercatorExtents.java
+++ b/src/main/java/com/conveyal/r5/analyst/WebMercatorExtents.java
@@ -119,7 +119,7 @@ public class WebMercatorExtents implements Serializable {
         checkState(this.zoom == other.zoom, "All grids supplied must be at the same zoom level.");
         final int thisEast = this.west + this.width;
         final int otherEast = other.west + other.width;
-        final int thisSouth = this.north + other.height;
+        final int thisSouth = this.north + this.height;
         final int otherSouth = other.north + other.height;
         final int outWest = Math.min(other.west, this.west);
         final int outEast = Math.max(otherEast, thisEast);

--- a/src/test/java/com/conveyal/r5/analyst/GridTransformWrapperTest.java
+++ b/src/test/java/com/conveyal/r5/analyst/GridTransformWrapperTest.java
@@ -74,6 +74,48 @@ class GridTransformWrapperTest {
         assertThrows(IllegalArgumentException.class, () -> new GridTransformWrapper(webMercatorExtents, grid));
     }
 
+    /// Stack two grids of different heights as we do in regional analyses, wrapping them to match
+    /// the minimum bounding extents found with forPointsets. This detects a bug where
+    /// WebMercatorExtents.expandToInclude truncated the height of the grid, zeroing out
+    /// opportunities in the southern rows of taller grids.
+    @Test
+    void testUnequalHeights () {
+
+        // The vertically short grid is the same width as the tall grid,
+        // and overlaps the northeast part of the tall grid.
+        Grid tallGrid = new Grid(2000, 1000, 100, 300, 10);
+        Grid shortGrid = new Grid(2050, 1100, 100, 50, 10);
+
+        // Put one full-height column and one full-width row of opportunities in each grid.
+        // This should catch truncation of the combined grid in either dimension.
+        List<Grid.PixelWeight> tallWeights = new ArrayList<>();
+        for (int y = 0; y < 300; y++) {
+            tallWeights.add(new Grid.PixelWeight(50, y, 1));
+        }
+        for (int x = 0; x < 100; x++) {
+            tallWeights.add(new Grid.PixelWeight(x, 150, 1));
+        }
+        List<Grid.PixelWeight> shortWeights = new ArrayList<>();
+        for (int y = 0; y < 50; y++) {
+            shortWeights.add(new Grid.PixelWeight(50, y, 1));
+        }
+        for (int x = 0; x < 100; x++) {
+            shortWeights.add(new Grid.PixelWeight(x, 25, 1));
+        }
+        tallGrid.incrementFromPixelWeights(tallWeights, 1);
+        shortGrid.incrementFromPixelWeights(shortWeights, 1);
+
+        WebMercatorExtents unionExtents = WebMercatorExtents.forPointsets(new PointSet[] {tallGrid, shortGrid});
+        assertEquals(new WebMercatorExtents(2000, 1000, 150, 300, 10), unionExtents,
+                "Union extents should be the minimum bounding extents of the two grids.");
+
+        for (Grid grid : List.of(tallGrid, shortGrid)) {
+            GridTransformWrapper wrapper = new GridTransformWrapper(unionExtents, grid);
+            assertEquals(grid.sumTotalOpportunities(), wrapper.sumTotalOpportunities(),
+                    "Wrapping a grid to the union extents of a stack should preserve all its opportunities.");
+        }
+    }
+
     /*
      * TODO lat/lon based testing
      * Given a set of points at latitudes and longitudes, write the same points into overlapping grids of different

--- a/src/test/java/com/conveyal/r5/analyst/WebMercatorExtentsTest.java
+++ b/src/test/java/com/conveyal/r5/analyst/WebMercatorExtentsTest.java
@@ -44,6 +44,24 @@ class WebMercatorExtentsTest {
         }
     }
 
+    /// Check that expandToInclude produces the minimum bounding extents when the two extents have
+    /// different heights, in both operand orders.
+    @Test
+    void expandUnequalHeights () {
+        // The outer extents fully contain the inner ones, so union should equal the outer extents.
+        WebMercatorExtents outer = new WebMercatorExtents(100, 100, 20, 50, 10);
+        WebMercatorExtents inner = new WebMercatorExtents(105, 110, 10, 10, 10);
+        Assertions.assertEquals(outer, outer.expandToInclude(inner));
+        Assertions.assertEquals(outer, inner.expandToInclude(outer));
+
+        // Partially overlapping extents of different heights, with the union derived by hand.
+        WebMercatorExtents a = new WebMercatorExtents(100, 100, 20, 50, 10);
+        WebMercatorExtents b = new WebMercatorExtents(110, 130, 30, 40, 10);
+        WebMercatorExtents union = new WebMercatorExtents(100, 100, 40, 70, 10);
+        Assertions.assertEquals(union, a.expandToInclude(b));
+        Assertions.assertEquals(union, b.expandToInclude(a));
+    }
+
     /**
      * Check that a zero-size envelope (around a single point for example) will yield an extents object containing
      * one cell (rather than zero cells). Also check an envelope with a tiny nonzero envelope away from cell edges.


### PR DESCRIPTION
This fixes a single line that was truncating the bottom of stacked grids of different dimensions. This only applied to regional analyses, not single-point, and only in cases where grids had different dimensions. But in those cases it would affect visibility of opportunities near the bottom/south edge.

Includes a couple of tests to reproduce the problem.